### PR TITLE
Use ansible_product_serial instead of board serial

### DIFF
--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -111,7 +111,7 @@ class ExtractorControllerDB():
                    main_hostmetric.deleted_counter,
                    main_hostmetric.last_deleted,
                    main_hostmetric.deleted,
-                   main_host.ansible_facts->>'ansible_board_serial'::TEXT AS ansible_board_serial,
+                   main_host.ansible_facts->>'ansible_product_serial'::TEXT AS ansible_product_serial,
                    main_host.ansible_facts->>'ansible_machine_id'::TEXT AS ansible_machine_id,
                    CASE
                        WHEN (metrics_utility_is_valid_json(main_host.variables))

--- a/metrics_utility/automation_controller_billing/report/renewal_guidance/dedup.py
+++ b/metrics_utility/automation_controller_billing/report/renewal_guidance/dedup.py
@@ -9,8 +9,8 @@ class Dedup:
         # Cleanup the null like values first
         self.dataframe['ansible_host_variable'] = self.dataframe['ansible_host_variable'].replace('', None)
 
-        self.dataframe['ansible_board_serial'] = self.dataframe['ansible_board_serial'].replace('NA', None)
-        self.dataframe['ansible_board_serial'] = self.dataframe['ansible_board_serial'].replace('', None)
+        self.dataframe['ansible_product_serial'] = self.dataframe['ansible_product_serial'].replace('NA', None)
+        self.dataframe['ansible_product_serial'] = self.dataframe['ansible_product_serial'].replace('', None)
 
         self.dataframe['ansible_machine_id'] = self.dataframe['ansible_machine_id'].replace('NA', None)
         self.dataframe['ansible_machine_id'] = self.dataframe['ansible_machine_id'].replace('', None)
@@ -37,7 +37,7 @@ class Dedup:
                 dupes = self.find_dupes(dupes, 'ansible_host_variable', dupes["ansible_host_variable"])
 
                 # Serial key dupes lookup
-                dupes = self.find_dupes(dupes, 'ansible_board_serial', dupes["ansible_board_serial"])
+                dupes = self.find_dupes(dupes, 'ansible_product_serial', dupes["ansible_product_serial"])
 
                 # ansible_machine_id key dupes lookup
                 dupes = self.find_dupes(dupes, 'ansible_machine_id', dupes["ansible_machine_id"])
@@ -46,9 +46,12 @@ class Dedup:
 
             deduped_list.append({
                 'hostname': row['hostname'],
+                'hostmetric_record_count': dupes['hostname'].nunique(),
+                'hostmetric_record_count_active': dupes[~dupes["deleted"]==True]['hostname'].nunique(),
+                'hostmetric_record_count_deleted': dupes[dupes["deleted"]==True]['hostname'].nunique(),
                 'hostnames': self.stringify(set(dupes['hostname'])),
                 'ansible_host_variables': self.stringify(set(dupes['ansible_host_variable'])),
-                'ansible_board_serials': self.stringify(set(dupes['ansible_board_serial'])),
+                'ansible_product_serials': self.stringify(set(dupes['ansible_product_serial'])),
                 'ansible_machine_ids': self.stringify(set(dupes['ansible_machine_id'])),
                 'deleted': min(dupes['deleted']), # if there was at least one false, it's not deleted
                 'first_automation':  min(dupes['first_automation']),

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -360,9 +360,12 @@ class ReportRenewalGuidance(Base):
                 'days_automated',
                 'deleted_counter',
                 'last_deleted',
+                'hostmetric_record_count',
+                'hostmetric_record_count_active',
+                'hostmetric_record_count_deleted',
                 'hostnames',
                 'ansible_host_variables',
-                'ansible_board_serials',
+                'ansible_product_serials',
                 'ansible_machine_ids',
             ]
         )
@@ -376,9 +379,12 @@ class ReportRenewalGuidance(Base):
                 'days_automated': "Number of days\nbetween first_automation\nand last_automation",
                 'deleted_counter': "Number of\nDeletions",
                 'last_deleted': "Last\ndeleted",
+                'hostmetric_record_count': "HostMetric\nrecord count",
+                'hostmetric_record_count_active': "HostMetric active\nrecord count",
+                'hostmetric_record_count_deleted': "HostMetric deleted\nrecord count",
                 'hostnames': "Host names",
                 'ansible_host_variables': "Variables ansible_host",
-                'ansible_board_serials': "Serial Numbers",
+                'ansible_product_serials': "Serial Numbers",
                 'ansible_machine_ids': "Machine UUIDs",
             }
         )

--- a/metrics_utility/test/renewal_guidance/test_candidate.py
+++ b/metrics_utility/test/renewal_guidance/test_candidate.py
@@ -3,7 +3,7 @@
 
 # HOST 1
 {
-    'ansible_board_serial': 'abc',
+    'ansible_product_serial': 'abc',
     'ansible_machine_id': '111',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -11,7 +11,7 @@
 
 # HOST 2 duplicate
 {
-    'ansible_board_serial': 'abc',
+    'ansible_product_serial': 'abc',
     'ansible_machine_id': '111',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -19,7 +19,7 @@
 
 # HOST 3 duplicate missing board_serial
 {
-    'ansible_board_serial': '',
+    'ansible_product_serial': '',
     'ansible_machine_id': '111',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -27,7 +27,7 @@
 
 # HOST 4 duplicate different machine id same hosts
 {
-    'ansible_board_serial': '',
+    'ansible_product_serial': '',
     'ansible_machine_id': '222',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -35,7 +35,7 @@
 
 # HOST 5 duplicate different board_serial same hosts
 {
-    'ansible_board_serial': 'def',
+    'ansible_product_serial': 'def',
     'ansible_machine_id': '',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -43,7 +43,7 @@
 
 # HOST 6 duplicate different machine_id
 {
-    'ansible_board_serial': 'abc',
+    'ansible_product_serial': 'abc',
     'ansible_machine_id': '1234',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_21'],
     'host_name': ['test_host_11', 'test_host_21']
@@ -51,7 +51,7 @@
 
 # HOST 7 duplicate different machine_id and hosts
 {
-    'ansible_board_serial': 'abc',
+    'ansible_product_serial': 'abc',
     'ansible_machine_id': '12345',
     'ansible_host_variable': ['test_real_host_51', 'test_real_host_61'],
     'host_name': ['test_host_51', 'test_host_61']
@@ -59,7 +59,7 @@
 
 # HOST 8 duplicate differernt machine_id and overlapping hosts
 {
-    'ansible_board_serial': 'abc',
+    'ansible_product_serial': 'abc',
     'ansible_machine_id': '12345',
     'ansible_host_variable': ['test_real_host_11', 'test_real_host_51'],
     'host_name': ['test_host_11', 'test_real_host_51']
@@ -67,7 +67,7 @@
 
 # HOST 9 duplicate matching host_variable
 {
-    'ansible_board_serial': '',
+    'ansible_product_serial': '',
     'ansible_machine_id': '',
     'ansible_host_variable': ['test_real_host_11'],
     'host_name': ['test_host_11']
@@ -75,7 +75,7 @@
 
 # HOST 10 duplicate matching host_name
 {
-    'ansible_board_serial': '',
+    'ansible_product_serial': '',
     'ansible_machine_id': '',
     'ansible_host_variable': [],
     'host_name': ['test_host_11']


### PR DESCRIPTION
product_serial is the chassis serial number that should be more reliable than motherboard serial number

and provide a counter of how many HostMetrics records are represented by each deduplicated row