### PR TITLE
Fix CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,12 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_GITHUB_ACTIONS: false
-          VALIDATE_ALL_CODEBASE: ${{ inputs.validate-all }}
+          VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: false
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_NATURAL_LANGUAGE: false
-          DEFAULT_BRANCH: "main"
+          DEFAULT_BRANCH: "devel"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   unit-test:


### PR DESCRIPTION
[AAP-XXXXX] TODO
Dont forget to link back issue to PR.

## Description
Fix red CI. Set the linter to run only against changed files.
- What is being changed?
Linter settings
- Why is this change needed?
To prevent linter errors from unchanged files to fail CI.
- How does this change address the issue?
Linter runs only against changed files.

## Testing
This can be tested as a GH workflow on GH.

### Expected Results

Linter GH action is green.

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed. (not needed)
- [x] Code includes relevant comments for complex sections. (not needed)
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.  (not needed)
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Red run to prove it catches lint errors in changed files when I had `metrics_utility/test/test_example.py` file

```
import pandas
import os
import gzip

def capital_case(x):
    return x.capitalize()

def test_capital_case():
    assert capital_case('semaphore') == 'Semaphore'
```
https://github.com/ansible/metrics-utility/actions/runs/12806718864/job/35705772345?pr=38


## Notes for the future

github/super-linter@v4 is two versions old and if we update to the latest it will run against the whole codebase no matter what according to https://github.com/super-linter/super-linter/issues/5541 so we'll need to fix the linter issues before that.