### PR TITLE
Fix failing report over data from 2024

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -54,8 +54,8 @@ class DataframeJobhostSummaryUsage(Base):
                     billing_data['job_created'] = pd.to_datetime(
                         billing_data['job_created']).dt.tz_localize(None)
                 else:
-                    billing_data['job_created'] = ''
-                    
+                    billing_data['job_created'] = pd.NaT
+
                 ################################
                 # Do the aggregation
                 ################################

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -50,9 +50,12 @@ class DataframeJobhostSummaryUsage(Base):
                 billing_data['created'] = pd.to_datetime(
                     billing_data['created']).dt.tz_localize(None)
 
-                billing_data['job_created'] = pd.to_datetime(
-                    billing_data['job_created']).dt.tz_localize(None)
-
+                if ('job_created' in billing_data):
+                    billing_data['job_created'] = pd.to_datetime(
+                        billing_data['job_created']).dt.tz_localize(None)
+                else:
+                    billing_data['job_created'] = ''
+                    
                 ################################
                 # Do the aggregation
                 ################################


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-38795
Dont forget to link back issue to PR.

## Description

Problem was that older data did not contained job_created column in job_host_summary.csv 

This is found in extracted data inside testing data folder, for example: /awx-dev/metrics-utility/metrics_utility/test/test_data/data/2024/02/28/

Extract the tarball and you will see the csv.

Now the code changes:

if job_created is missing then:
billing_data['job_created'] = pd.NaT

If billing data does not contains job_created, it fills empty data and algorithm does not seems to bother about it, because it can handle NaT values.

Reports were tested, they work, Ladas is thinking this may not introduce any problem. Reports on 2024 and 2025 works as expected.


## Testing



### Prerequisites

Having data of 2024,which are in the repo for everyone

### Steps to Test

run:
python manage.py build_report --month=2024-02 --force

gather data from 2025-01
Go to aap-ui in localhost:8030
run Template (menu templates, some Demo Template for example)

now call gather command:
python manage.py gather_automation_controller_billing_data --ship --until=100m

now you can build report from this month:
python manage.py build_report --month=2025-01 --force

### Expected Results

Report is generated and not broken. The generated report from 2024-02 should look like generated reports from 2025-01

Of course numbers will be different, but report should not be broken.


## Required Actions


## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

2024-02 report generated:
![image](https://github.com/user-attachments/assets/0d374884-60ef-4312-9152-6546c92af4c2)

2025-01 report generated (that one is the same as in devel branch, because job_created is not missing, so its not affected by PR change):
![image](https://github.com/user-attachments/assets/beadec94-4bb2-44b5-b5db-0fbb65ac0d7a)

