### PR TITLE
Add testing data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ metrics_utility/test/test_data/data/2024/**/*.csv
 
 # Reports
 /metrics_utility/test/test_data/reports/
+
+# Shipped data - for regular usage during developement
+/shipped_data

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@ testem.log
 
 # PyCharm
 .idea/*
+
+# Testing data
+metrics_utility/test/test_data/data/**
+!metrics_utility/test/test_data/data/2024/
+!metrics_utility/test/test_data/data/2024/**
+metrics_utility/test/test_data/data/2024/**/*.json
+metrics_utility/test/test_data/data/2024/**/*.csv
+
+# Reports
+/metrics_utility/test/test_data/reports/

--- a/.gitignore
+++ b/.gitignore
@@ -32,14 +32,13 @@ testem.log
 .idea/*
 
 # Testing data
-metrics_utility/test/test_data/data/**
-!metrics_utility/test/test_data/data/2024/
-!metrics_utility/test/test_data/data/2024/**
-metrics_utility/test/test_data/data/2024/**/*.json
-metrics_utility/test/test_data/data/2024/**/*.csv
+metrics_utility/test/test_data/data/**/*.csv
+metrics_utility/test/test_data/data/**/*.json
+!metrics_utility/test/test_data/data/**/*.tar.gz
+
 
 # Reports
 /metrics_utility/test/test_data/reports/
 
 # Shipped data - for regular usage during developement
-/shipped_data
+/shipped_data/


### PR DESCRIPTION
[AAP-38383]

## Description

Adds testing files to gitignore - all files inside test folder will be part of the repo, excluding csv and json files, because those are part of *tar.gz files - if you want to extract them and look whats inside for debug purposes, you now dont have to delete them, they will not be included in repo.

Also, uninclude generated reports.

Folder shipped_data is unincluded, that should be used only for runtime debugging - any data that should not be part of the repo should live there.
