### PR TITLE
Add missing developer documentation for the pre-commit hook setup [AAP-38768]

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,19 @@ You can inspect the data sent with --dry-run attribute and provide your own inte
 # This will collect whole day of 2023-12-21
 metrics-utility gather_automation_controller_billing_data --dry-run --since=2023-12-21 --until=2023-12-22
 ```
+
+## Developer Setup
+
+For developers contributing to this project, refer to the [Developer Setup Guide](./docs/developer_setup.md) for detailed instructions on setting up your local development environment, installing dependencies, and configuring pre-commit hooks.
+
+---
+
+## Available Documentation
+
+Additional documentation is available in the `/docs` directory. This includes:
+
+- **Developer Setup**: [docs/developer_setup.md](./docs/developer_setup.md)
+
+Please note that this is the upstream documentation for the metrics-utility project. Additional internal downstream documentation, accessible only to the Ansible organization, is maintained separately in the [Ansible Handbook](https://github.com/ansible/handbook/tree/main/The%20Ansible%20Engineering%20Handbook/docs/AAP/Services/Metrics).
+
+As the project grows, more guides and references will be added to the `/docs` folder.

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -1,0 +1,128 @@
+# Developer Setup for `metrics-utility`: `ruff` + `uv`
+
+This document helps new contributors set up their local development environment for the `metrics-utility` repository. It covers installing required tools, configuring `uv`, and enabling a pre-commit hook that uses `ruff` for linting and formatting.
+
+---
+
+## 1. Overview
+
+- **`uv`**: A Python virtual environment manager that simplifies dependency management.  
+- **`ruff`**: A fast Python linter and formatter. Ensures code adheres to style and best practices.
+
+The pre-commit hook leverages `ruff` (managed by `uv`) to automatically check and format your code whenever you run `git commit`. This helps maintain consistent code quality.
+
+---
+
+## 2. Prerequisites
+
+- **Python 3.11+** installed on your system.
+- **Git** installed for version control.
+- **`pip`** or other package managers (e.g., `pipx`) for installing Python tools.
+
+---
+
+## 3. Initial Setup
+
+1. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/ansible/metrics-utility.git
+   cd metrics-utility
+   ```
+
+2. **Install `uv` (if not installed)**:
+   ```bash
+   pip install uv
+   ```
+   > **Note**: You may need to use `pip3` or run under a virtual environment if you have multiple Python versions.
+
+3. **Synchronize Dependencies**:
+   ```bash
+   uv sync
+   ```
+   This command creates (or updates) the virtual environment defined by `pyproject.toml` and `uv.lock`. It installs all project dependencies, including `ruff`, `pytest`, `django-admin`, etc.
+
+4. **Verify Installations**:
+   ```bash
+   ruff --version
+   pytest --version
+   django-admin --version
+   pre-commit --version
+   ```
+   If any command fails, run `uv sync` again or check your `uv` installation.
+
+---
+
+## 4. Configuring Pre-commit Hooks
+
+1. **Install Pre-commit Hooks**:
+   ```bash
+   pre-commit install
+   ```
+   This registers the hooks defined in `.pre-commit-config.yaml` so that every `git commit` triggers a lint/format check using `ruff`.
+
+2. **Test the Hook**:
+   1. Create a test file with a simple linting error:
+      ```bash
+      echo "import os\n\nprint( 'Hello World' )" > test.py
+      ```
+   2. Stage and commit the file:
+      ```bash
+      git add test.py
+      git commit -m "Test pre-commit hook"
+      ```
+   3. The hook should **block** the commit, showing an error about the unused import or formatting issues.
+
+---
+
+## 5. Fixing Linting Issues
+
+Depending on the project’s configuration:
+
+- **Manual Fix**: Remove unused imports or fix spacing.  
+- **Auto-fix with Ruff**:  
+  ```bash
+  ruff format test.py
+  ```
+  or  
+  ```bash
+  ruff check test.py --fix
+  ```
+  (Both commands achieve a similar result in the latest versions of Ruff.)
+
+After fixing, re-stage and commit again:
+```bash
+git add test.py
+git commit -m "Fix linting issues"
+```
+This time, the commit should succeed if all issues are resolved.
+
+---
+
+## 6. Troubleshooting
+
+1. **`uv sync` Errors**  
+   - Ensure Python 3.8+ is installed.
+   - Confirm you have the correct permissions to install packages.
+
+2. **`ruff` or `pre-commit` Not Found**  
+   - Run `uv sync` again.
+   - Make sure your shell is set to use the environment from `uv`.
+
+3. **Hook Doesn’t Run**  
+   - Check that `.pre-commit-config.yaml` references `ruff`.
+   - Re-run `pre-commit install`.
+
+4. **Bypassing Hooks**  
+   - If you see developers bypassing hooks with `--no-verify`, note that the checks won’t run. For consistent code quality, discourage skipping hooks.
+
+---
+
+## 7. Additional Resources
+
+- [Ruff Documentation](https://beta.ruff.rs/docs/)
+- [Pre-commit Documentation](https://pre-commit.com/)
+- [uv - GitHub Repository](https://github.com/astral-sh/uv)
+
+---
+
+**That’s it!** You should now have a functioning development environment for `metrics-utility` with a pre-commit hook that catches lint and formatting issues via `ruff`.


### PR DESCRIPTION
[AAP-38768]
Original PR: [add pre-commit with ruff #42](https://github.com/ansible/metrics-utility/pull/42)

## Description

**What is being changed?**
- Added developer-focused documentation detailing how to install `uv` and `ruff` and configure the pre-commit hook.
- Expanded the `/docs` directory and updated the `README.md` to guide new contributors on setting up their local environments.

**Why is this change needed?**
- The pre-commit hook with `uv` and `ruff` has already been implemented, but there was insufficient documentation explaining how new developers should install and use these tools.
- Without clear setup instructions, contributors might struggle to replicate the required environment, leading to confusion and inconsistent code formatting.

**How does this change address the issue?**
- By providing a dedicated `/docs/developer_setup.md` file (and references in `README.md`), we ensure that new contributors can quickly and accurately configure their environment.
- This documentation closes the knowledge gap around `uv` and `ruff` usage, preventing onboarding challenges.

**Supporting Documentation:**
- [Ruff Documentation](https://docs.astral.sh/ruff/)
- [UV Documentation](https://docs.astral.sh/uv/)

---

## Testing

Since these changes are primarily documentation updates, there are no code changes to test directly. However, you can follow the new instructions to confirm they are accurate and comprehensive. First please check the PR https://github.com/ansible/metrics-utility/pull/42 introducing the changes for more clarity and then simply follow the same steps:

1. Clone the `metrics-utility` repository.
2. Install `uv` using `pip install uv`.
3. Run `uv sync` to install all dependencies.
4. Verify that `ruff`, `pytest`, `django-admin`, and `pre-commit` are installed.
5. Install the pre-commit hooks with `pre-commit install`.
6. Create a simple Python file with a linting error (e.g., an unused import) and attempt to commit. The pre-commit hook should block the commit.

**Expected Results:**
- New contributors should be able to follow the documentation to set up the environment and verify that the pre-commit hook blocks commits with linting issues.

---

## Required Actions

- [x] **Requires documentation updates**  
  - `/docs/developer_setup.md` created or updated  
  - `README.md` updated to reference developer documentation

- [ ] Requires downstream repository changes *(None)*
- [ ] Requires infrastructure/deployment changes *(None)*
- [ ] Requires coordination with other teams *(None)*

---

## Self-Review Checklist

- [x] Documentation is clear, accurate, and accessible.
- [x] No major workflow steps are missing.
- [x] All references and links are working.
- [ ] Any relevant diagrams or screenshots are included (N/A if none).
- [ ] Changes reviewed by at least one other team member.

---

## Notes for Reviewers

- These changes **do not** introduce new code or hook logic—the pre-commit hook was previously merged. (See the original PR https://github.com/ansible/metrics-utility/pull/42)
- This PR **adds and refines documentation** to fill the gap for new developers who need clear instructions on using `uv` and `ruff`.
- Future updates may migrate some of this content to the Ansible Handbook, but for now, it remains in the repo for immediate access.