### PR TITLE
run ruff on repo

### DIFF
--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -1,6 +1,6 @@
+import importlib.util
 import os
 import sys
-import importlib.util
 
 from metrics_utility.management_utility import ManagementUtility
 
@@ -18,8 +18,8 @@ def manage():
             sys.stderr.write(f"Automation Controller modules not found in {awx_path}\n")
             exit(1)
 
-    from awx import prepare_env
     import django
+    from awx import prepare_env
 
     prepare_env()
     django.setup()

--- a/metrics_utility/automation_controller_billing/base/s3_handler.py
+++ b/metrics_utility/automation_controller_billing/base/s3_handler.py
@@ -1,7 +1,9 @@
 import logging
+import os
+
 import boto3
 from botocore.exceptions import ClientError
-import os
+
 
 class S3Handler():
     def __init__(self, params):

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -1,20 +1,20 @@
 import contextlib
 import json
 import logging
-from django.conf import settings
-from django.db import connection
 
 import insights_analytics_collector as base
-
+from awx.main.utils import datetime_hook
+from awx.main.utils.pglock import advisory_lock
+from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db import connection
+
 # from awx.conf.license import get_license
 # from awx.main.models import Job
 # from awx.main.access import access_registry
 # from rest_framework.exceptions import PermissionDenied
-from metrics_utility.automation_controller_billing.package.factory import Factory as PackageFactory
-
-from awx.main.utils import datetime_hook
-from awx.main.utils.pglock import advisory_lock
+from metrics_utility.automation_controller_billing.package.factory import \
+    Factory as PackageFactory
 
 logger = logging.getLogger('metrics_utility.collector')
 
@@ -129,7 +129,7 @@ class Collector(base.Collector):
         if self.is_shipping_enabled():
             # We need to wait on analytics lock, to update the last collected timestamp settings
             # so we don't clash with analytics job collection.
-            with self._pg_advisory_lock("gather_analytics_lock", wait=True) as acquired:
+            with self._pg_advisory_lock("gather_analytics_lock", wait=True):
                 # We need to load fresh settings again as we're obtaning the lock, since
                 # Analytics job could have changed this on the background and we'd be resetting
                 # the Analytics values here.

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -2,18 +2,19 @@ import json
 import os
 import os.path
 import platform
-import distro
 
-from django.db import connection
+import distro
+from awx.conf.license import get_license
+from awx.main.utils import datetime_hook, get_awx_version
 from django.conf import settings
+from django.db import connection
 from django.utils.timezone import now, timedelta
 from django.utils.translation import gettext_lazy as _
-
-from awx.conf.license import get_license
-from awx.main.utils import get_awx_version, datetime_hook
 # TODO: enhance the CsvFIleSplitter base class and use that
-from insights_analytics_collector import register #, CsvFileSplitter
-from metrics_utility.automation_controller_billing.csv_file_splitter import CsvFileSplitter
+from insights_analytics_collector import register  # , CsvFileSplitter
+
+from metrics_utility.automation_controller_billing.csv_file_splitter import \
+    CsvFileSplitter
 
 """
 This module is used to define metrics collected by

--- a/metrics_utility/automation_controller_billing/csv_file_splitter.py
+++ b/metrics_utility/automation_controller_billing/csv_file_splitter.py
@@ -1,4 +1,3 @@
-import io
 import os
 
 from insights_analytics_collector import CsvFileSplitter as BaseCsvFileSplitter

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -1,5 +1,6 @@
-import logging
 import datetime
+import logging
+
 from dateutil.relativedelta import relativedelta
 
 logger = logging.getLogger(__name__)

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -1,11 +1,9 @@
 import logging
-import datetime
 import pandas as pd
 import re
-from dateutil.relativedelta import relativedelta
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base, list_dates, granularity_cast
+    import Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -1,9 +1,10 @@
 import logging
-import pandas as pd
 import re
 
-from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base
+import pandas as pd
+
+from metrics_utility.automation_controller_billing.dataframe_engine.base import \
+    Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -1,8 +1,9 @@
 import logging
+
 import pandas as pd
 
-from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base
+from metrics_utility.automation_controller_billing.dataframe_engine.base import \
+    Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -1,10 +1,8 @@
 import logging
-import datetime
 import pandas as pd
-from dateutil.relativedelta import relativedelta
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base, list_dates
+    import Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
@@ -1,11 +1,8 @@
 import logging
-import datetime
 import pandas as pd
-import re
-from dateutil.relativedelta import relativedelta
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base, list_dates, granularity_cast
+    import Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
@@ -1,8 +1,9 @@
 import logging
+
 import pandas as pd
 
-from metrics_utility.automation_controller_billing.dataframe_engine.base \
-    import Base
+from metrics_utility.automation_controller_billing.dataframe_engine.base import \
+    Base
 
 logger = logging.getLogger(__name__)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
@@ -1,12 +1,9 @@
-from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_jobhost_summary_usage \
-    import DataframeJobhostSummaryUsage
-
-from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage \
-    import DataframeContentUsage
-
-from metrics_utility.automation_controller_billing.dataframe_engine.db_dataframe_host_metric \
-    import DBDataframeHostMetric
-
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import \
+    DataframeContentUsage
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_jobhost_summary_usage import \
+    DataframeJobhostSummaryUsage
+from metrics_utility.automation_controller_billing.dataframe_engine.db_dataframe_host_metric import \
+    DBDataframeHostMetric
 from metrics_utility.exceptions import NotSupportedFactory
 
 

--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 
 import pandas as pd
-
 from django.db import connection
 
 

--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -109,7 +109,7 @@ class ExtractorDirectory():
             with open(file_path) as f:
                 config_data = json.loads(f.read())
             return config_data
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             self.logger.warn(f"{self.LOG_PREFIX} missing required file under path: {self.path} and date: {self.date}")
             # raise MissingRequiredFile(self.filename) from e
 
@@ -118,7 +118,7 @@ class ExtractorDirectory():
 
         try:
             paths = [os.path.join(prefix, f) for f in os.listdir(prefix) if os.path.isfile(os.path.join(prefix, f))]
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             paths = []
 
         return paths

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -1,4 +1,3 @@
-import io
 import json
 import logging
 import os
@@ -116,7 +115,7 @@ class ExtractorS3():
             with open(file_path) as f:
                 config_data = json.loads(f.read())
             return config_data
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             self.logger.warn(f"{self.LOG_PREFIX} missing required file under path: {self.path} and date: {self.date}")
             # raise MissingRequiredFile(self.filename) from e
 

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -6,7 +6,8 @@ import tempfile
 
 import pandas as pd
 
-from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler
+from metrics_utility.automation_controller_billing.base.s3_handler import \
+    S3Handler
 
 
 class ExtractorS3():

--- a/metrics_utility/automation_controller_billing/extract/factory.py
+++ b/metrics_utility/automation_controller_billing/extract/factory.py
@@ -1,7 +1,9 @@
-from metrics_utility.automation_controller_billing.extract.extractor_directory import ExtractorDirectory
-from metrics_utility.automation_controller_billing.extract.extractor_controller_db import ExtractorControllerDB
-from metrics_utility.automation_controller_billing.extract.extractor_s3 import ExtractorS3
-
+from metrics_utility.automation_controller_billing.extract.extractor_controller_db import \
+    ExtractorControllerDB
+from metrics_utility.automation_controller_billing.extract.extractor_directory import \
+    ExtractorDirectory
+from metrics_utility.automation_controller_billing.extract.extractor_s3 import \
+    ExtractorS3
 from metrics_utility.exceptions import NotSupportedFactory
 
 

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -1,7 +1,9 @@
 import datetime
+
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
+
 from metrics_utility.exceptions import UnparsableParameter
 
 

--- a/metrics_utility/automation_controller_billing/package/factory.py
+++ b/metrics_utility/automation_controller_billing/package/factory.py
@@ -1,6 +1,9 @@
-from metrics_utility.automation_controller_billing.package.package_crc import PackageCRC
-from metrics_utility.automation_controller_billing.package.package_directory import PackageDirectory
-from metrics_utility.automation_controller_billing.package.package_s3 import PackageS3
+from metrics_utility.automation_controller_billing.package.package_crc import \
+    PackageCRC
+from metrics_utility.automation_controller_billing.package.package_directory import \
+    PackageDirectory
+from metrics_utility.automation_controller_billing.package.package_s3 import \
+    PackageS3
 from metrics_utility.exceptions import NotSupportedFactory
 
 

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -1,13 +1,13 @@
-import os
-import requests
 import json
+import os
 
 import insights_analytics_collector as base
-
+import requests
 from awx.main.utils import get_awx_http_client_headers
+from django.conf import settings
+
 from metrics_utility.exceptions import FailedToUploadPayload
 
-from django.conf import settings
 
 class PackageCRC(base.Package):
     CERT_PATH = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -1,7 +1,6 @@
 import os
 import requests
 import json
-import logging
 
 import insights_analytics_collector as base
 

--- a/metrics_utility/automation_controller_billing/package/package_directory.py
+++ b/metrics_utility/automation_controller_billing/package/package_directory.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-import insights_analytics_collector as base
 
+import insights_analytics_collector as base
 from django.conf import settings
 
 

--- a/metrics_utility/automation_controller_billing/package/package_s3.py
+++ b/metrics_utility/automation_controller_billing/package/package_s3.py
@@ -1,7 +1,5 @@
 import os
-import shutil
 import insights_analytics_collector as base
-import tempfile
 
 from django.conf import settings
 from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler

--- a/metrics_utility/automation_controller_billing/package/package_s3.py
+++ b/metrics_utility/automation_controller_billing/package/package_s3.py
@@ -1,8 +1,10 @@
 import os
-import insights_analytics_collector as base
 
+import insights_analytics_collector as base
 from django.conf import settings
-from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler
+
+from metrics_utility.automation_controller_billing.base.s3_handler import \
+    S3Handler
 
 
 class PackageS3(base.Package):

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -1,13 +1,11 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
-from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Border, Side, Alignment
+from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 import os
-import pandas as pd
 
 
 class Base:

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -1,11 +1,11 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
+import os
+
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
-
-import os
 
 
 class Base:

--- a/metrics_utility/automation_controller_billing/report/factory.py
+++ b/metrics_utility/automation_controller_billing/report/factory.py
@@ -1,8 +1,11 @@
-from metrics_utility.automation_controller_billing.report.report_ccsp import ReportCCSP
-from metrics_utility.automation_controller_billing.report.report_ccsp_v2 import ReportCCSPv2
-from metrics_utility.automation_controller_billing.report.report_renewal_guidance import ReportRenewalGuidance
-from metrics_utility.automation_controller_billing.report.report_renewal_guidance_v2 import ReportRenewalGuidanceV2
-
+from metrics_utility.automation_controller_billing.report.report_ccsp import \
+    ReportCCSP
+from metrics_utility.automation_controller_billing.report.report_ccsp_v2 import \
+    ReportCCSPv2
+from metrics_utility.automation_controller_billing.report.report_renewal_guidance import \
+    ReportRenewalGuidance
+from metrics_utility.automation_controller_billing.report.report_renewal_guidance_v2 import \
+    ReportRenewalGuidanceV2
 
 
 class Factory:

--- a/metrics_utility/automation_controller_billing/report/renewal_guidance/dedup.py
+++ b/metrics_utility/automation_controller_billing/report/renewal_guidance/dedup.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+
 class Dedup:
     def __init__(self, dataframe, extra_params):
         self.dataframe = dataframe
@@ -51,8 +52,8 @@ class Dedup:
             deduped_list.append({
                 'hostname': latest_hostname,
                 'hostmetric_record_count': dupes['hostname'].nunique(),
-                'hostmetric_record_count_active': dupes[~dupes["deleted"]==True]['hostname'].nunique(),
-                'hostmetric_record_count_deleted': dupes[dupes["deleted"]==True]['hostname'].nunique(),
+                'hostmetric_record_count_active': dupes[~dupes["deleted"]]['hostname'].nunique(),
+                'hostmetric_record_count_deleted': dupes[dupes["deleted"]]['hostname'].nunique(),
                 'hostnames': self.stringify(set(dupes['hostname'])),
                 'ansible_host_variables': self.stringify(set(dupes['ansible_host_variable'])),
                 'ansible_product_serials': self.stringify(set(dupes['ansible_product_serial'])),
@@ -75,5 +76,3 @@ class Dedup:
         dupes = pd.concat([dupes,next_iteration_dupes]).drop_duplicates().reset_index(drop=True)
 
         return dupes
-
-

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -1,11 +1,13 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
-from metrics_utility.automation_controller_billing.report.base import Base
 from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Border, Side, Alignment
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
+
+from metrics_utility.automation_controller_billing.report.base import Base
+
 
 class ReportCCSP(Base):
     BLACK_COLOR_HEX = "00000000"

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -1,14 +1,16 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
-from metrics_utility.automation_controller_billing.report.base import Base
+import time
+
+import pandas as pd
 from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Border, Side, Alignment
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
-import pandas as pd
-import time
+from metrics_utility.automation_controller_billing.report.base import Base
+
 
 class ReportCCSPv2(Base):
     # BLACK_COLOR_HEX = "00000000"

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -1,17 +1,21 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
-from metrics_utility.automation_controller_billing.helpers import parse_number_of_days
-from metrics_utility.automation_controller_billing.report.base import Base
-from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup import Dedup
+import datetime
+import time
+
+import pandas as pd
 from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Border, Side, Alignment
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
-import datetime
-import pandas as pd
-import time
+from metrics_utility.automation_controller_billing.helpers import \
+    parse_number_of_days
+from metrics_utility.automation_controller_billing.report.base import Base
+from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup import \
+    Dedup
+
 
 class ReportRenewalGuidance(Base):
     def __init__(self, dataframe, report_period, extra_params):
@@ -160,11 +164,11 @@ class ReportRenewalGuidance(Base):
 
     def df_managed_nodes_query(self, dataframe, ephemeral=None, with_deleted=False):
         if ephemeral is None:
-            return dataframe[dataframe["deleted"]==False]
+            return dataframe[not dataframe["deleted"]]
         else:
             # Take only non deleted
             if not with_deleted:
-                dataframe = dataframe[dataframe["deleted"]==False]
+                dataframe = dataframe[not dataframe["deleted"]]
 
             # Filter ephemeral based on number of automated days
             ephemeral_days = parse_number_of_days(self.extra_params.get("opt_ephemeral"))
@@ -182,7 +186,7 @@ class ReportRenewalGuidance(Base):
                                  (dataframe["first_automation"] > ephemeral_threshold)]
 
     def df_deleted_managed_nodes_query(self, dataframe):
-        return dataframe[dataframe["deleted"]==True]
+        return dataframe[dataframe["deleted"]]
 
     def get_intervals(self, start_date, end_date, interval_size):
         intervals = []

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance_v2.py
@@ -1,14 +1,16 @@
 ######################################
 # Code for building the spreadsheet
 ######################################
-from metrics_utility.automation_controller_billing.report.base import Base
+import time
+
+import pandas as pd
 from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Border, Side, Alignment
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
-import pandas as pd
-import time
+from metrics_utility.automation_controller_billing.report.base import Base
+
 
 class ReportRenewalGuidanceV2(Base):
     def __init__(self, dataframe, report_period, extra_params):

--- a/metrics_utility/automation_controller_billing/report_saver/factory.py
+++ b/metrics_utility/automation_controller_billing/report_saver/factory.py
@@ -1,6 +1,7 @@
-from metrics_utility.automation_controller_billing.report_saver.report_saver_directory import ReportSaverDirectory
-from metrics_utility.automation_controller_billing.report_saver.report_saver_s3 import ReportSaverS3
-
+from metrics_utility.automation_controller_billing.report_saver.report_saver_directory import \
+    ReportSaverDirectory
+from metrics_utility.automation_controller_billing.report_saver.report_saver_s3 import \
+    ReportSaverS3
 from metrics_utility.exceptions import NotSupportedFactory
 
 

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 
-
 class ReportSaverDirectory():
     LOG_PREFIX = "[ExtractorDirectory]"
 

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
@@ -1,11 +1,6 @@
-import io
-import json
 import logging
 import os
-import tarfile
-import tempfile
 
-import pandas as pd
 
 
 class ReportSaverDirectory():

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
@@ -2,8 +2,8 @@ import logging
 import os
 import tempfile
 
-
-from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler
+from metrics_utility.automation_controller_billing.base.s3_handler import \
+    S3Handler
 
 
 class ReportSaverS3():

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
@@ -1,11 +1,7 @@
-import io
-import json
 import logging
 import os
-import tarfile
 import tempfile
 
-import pandas as pd
 
 from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -5,7 +5,6 @@ import datetime
 from dateutil.parser import parse as date_parse
 from dateutil.relativedelta import relativedelta
 from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar
-from metrics_utility.automation_controller_billing.collector import Collector
 from metrics_utility.automation_controller_billing.dataframe_engine.factory import Factory as DataframeEngineFactory
 from metrics_utility.automation_controller_billing.extract.factory import Factory as ExtractorFactory
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
@@ -13,7 +12,6 @@ from metrics_utility.automation_controller_billing.report_saver.factory import F
 from metrics_utility.automation_controller_billing.helpers import parse_date_param
 from metrics_utility.management.validation import handle_directory_ship_target, handle_s3_ship_target
 
-from dateutil import parser
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -1,19 +1,26 @@
+import datetime
 import logging
 import os
 
-import datetime
 from dateutil.parser import parse as date_parse
 from dateutil.relativedelta import relativedelta
-from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar
-from metrics_utility.automation_controller_billing.dataframe_engine.factory import Factory as DataframeEngineFactory
-from metrics_utility.automation_controller_billing.extract.factory import Factory as ExtractorFactory
-from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
-from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
-from metrics_utility.automation_controller_billing.helpers import parse_date_param
-from metrics_utility.management.validation import handle_directory_ship_target, handle_s3_ship_target
-
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+
+from metrics_utility.automation_controller_billing.dataframe_engine.factory import \
+    Factory as DataframeEngineFactory
+from metrics_utility.automation_controller_billing.extract.factory import \
+    Factory as ExtractorFactory
+from metrics_utility.automation_controller_billing.helpers import \
+    parse_date_param
+from metrics_utility.automation_controller_billing.report.factory import \
+    Factory as ReportFactory
+from metrics_utility.automation_controller_billing.report_saver.factory import \
+    Factory as ReportSaverFactory
+from metrics_utility.exceptions import (BadRequiredEnvVar, BadShipTarget,
+                                        MissingRequiredEnvVar)
+from metrics_utility.management.validation import (
+    handle_directory_ship_target, handle_s3_ship_target)
 
 
 class Command(BaseCommand):

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -1,16 +1,19 @@
+import datetime
 import logging
 import os
-
-import datetime
-from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar, FailedToUploadPayload,\
-    BadRequiredEnvVar, NoAnalyticsCollected
-from metrics_utility.automation_controller_billing.collector import Collector
-from metrics_utility.management.validation import handle_directory_ship_target, handle_s3_ship_target, \
-    handle_crc_ship_target
 
 from dateutil import parser
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+
+from metrics_utility.automation_controller_billing.collector import Collector
+from metrics_utility.exceptions import (BadRequiredEnvVar, BadShipTarget,
+                                        FailedToUploadPayload,
+                                        MissingRequiredEnvVar,
+                                        NoAnalyticsCollected)
+from metrics_utility.management.validation import (
+    handle_crc_ship_target, handle_directory_ship_target,
+    handle_s3_ship_target)
 
 
 class Command(BaseCommand):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,4 +1,5 @@
 import os
+
 from metrics_utility.exceptions import MissingRequiredEnvVar
 
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,5 +1,5 @@
 import os
-from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar
+from metrics_utility.exceptions import MissingRequiredEnvVar
 
 
 def handle_directory_ship_target(ship_target):

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -1,7 +1,8 @@
 import os
 import sys
-import django.core.management as management
 from importlib import import_module
+
+import django.core.management as management
 
 
 class ManagementUtility(management.ManagementUtility):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,7 @@ requires-python = ">=3.11"
 # Do not uncomment the line below. We need to be able to override the version via a file, and this
 # causes the "version" key in setup.cfg to be ignored.
 # [tool.setuptools_scm]
+
+[tool.ruff]
+# Allow longer lines than ruff's default 88.
+line-length = 150


### PR DESCRIPTION
[[39264](https://issues.redhat.com/browse/AAP-39264)]

In tandem with https://github.com/ansible/metrics-utility/pull/49, this pr is an effort to transition the CI linter to use uv+ruff.

## Testing

A clean run with `ruff check` on root dir /metrics-utility.


### Steps to Test

1. Run `ruff check` from the root dir.


### Expected Results

No errors should occur


- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
