### PR TITLE
WIP - [AAP-38819] - Setting up pytest + S3 (Minio) + example test

### DIFF
--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -18,32 +18,43 @@ services:
     image: minio/mc:latest
     depends_on:
       - minio
-    entrypoint: >
+    volumes:
+      - minio_config:/tmp
+    entrypoint: |
       sh -c '
       echo "Waiting for MinIO to be ready...";
       sleep 5;
-
       until /usr/bin/mc alias set local http://minio:9000 minioaccess miniosecret; do
         echo "MinIO is not ready yet... waiting...";
         sleep 2;
       done;
 
-      echo "MinIO is ready! Creating bucket...";
-      /usr/bin/mc mb --ignore-existing local/metricsutilitys3 || { echo "Error creating bucket"; exit 1; }
+      echo "MinIO is ready! Creating bucket and user...";
+      /usr/bin/mc mb --ignore-existing local/metricsutilitys3 || exit 1;
+      /usr/bin/mc admin user add local mynewuser mysecretpassword || exit 1;
+      /usr/bin/mc admin policy attach local readwrite --user=mynewuser || exit 1;
+      /usr/bin/mc admin user svcacct add local mynewuser > /tmp/minio_keys.txt;
+      
+      echo "Extracting credentials...";
+      ACCESS_KEY=""
+      SECRET_KEY=""
+      
+      while IFS= read -r line; do
+        case "$$line" in
+          "Access Key:"*) ACCESS_KEY="$${line#Access Key: }" ;;
+          "Secret Key:"*) SECRET_KEY="$${line#Secret Key: }" ;;
+        esac
+      done < /tmp/minio_keys.txt
 
-      echo "Creating new access key...";
-      /usr/bin/mc admin user add local mynewuser mysecretpassword || { echo "Error creating user"; exit 1; }
+      if [ -z "$${ACCESS_KEY}" ] || [ -z "$${SECRET_KEY}" ]; then
+        echo "ERROR: Failed to extract credentials!"
+        exit 1
+      fi
 
-      echo "Assigning policy to the new user...";
-      /usr/bin/mc admin policy attach local readwrite --user=mynewuser || { echo "Error assigning policy"; exit 1; }
-
-      echo "Generating service account for user (Access Key & Secret Key)...";
-      /usr/bin/mc admin user svcacct add local mynewuser > /tmp/minio_keys.txt
-
-      echo "User details:";
-      cat /tmp/minio_keys.txt;
-
-      echo "Setup complete!";
+      echo "ACCESS_KEY=$${ACCESS_KEY}" > /tmp/minio_env.sh
+      echo "SECRET_KEY=$${SECRET_KEY}" >> /tmp/minio_env.sh
+      chmod +x /tmp/minio_env.sh
+      echo "Setup complete.";
       '
 
   metrics-utility:
@@ -53,6 +64,7 @@ services:
       - minio-setup
     volumes:
       - .:/app
+      - minio_config:/tmp
     working_dir: /app
     environment:
       UV_VENV: /app/.venv
@@ -61,29 +73,39 @@ services:
       METRICS_UTILITY_BUCKET_NAME: metricsutilitys3
       METRICS_UTILITY_BUCKET_ENDPOINT: "http://minio:9000"
       METRICS_UTILITY_BUCKET_REGION: "us-east-1"
-      METRICS_UTILITY_BUCKET_ACCESS_KEY: "xxxxxx"
-      METRICS_UTILITY_BUCKET_SECRET_KEY: "xxxxxx"
       METRICS_UTILITY_REPORT_TYPE: CCSPv2
-      METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS: 'jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations'
-    entrypoint: >
-      bash -c "
-      echo 'Installing uv...';
+      METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS: "jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations"
+    entrypoint: |
+      bash -c '
+      echo "Waiting for MinIO credentials...";
+      while [ ! -s /tmp/minio_env.sh ]; do
+        sleep 2;
+      done;
+
+      source /tmp/minio_env.sh;
+      
+      if [ -z "$$ACCESS_KEY" ] || [ -z "$$SECRET_KEY" ]; then
+        echo "ERROR: Loaded credentials are empty!"
+        exit 1
+      fi
+
+      export METRICS_UTILITY_BUCKET_ACCESS_KEY=$$ACCESS_KEY;
+      export METRICS_UTILITY_BUCKET_SECRET_KEY=$$SECRET_KEY;
+
+      echo "Listing all environment variables:";
+      printenv | sort;
+
+      echo "Installing dependencies...";
       pip install uv || exit 1;
-
-      echo 'Creating virtual environment with uv...';
       uv venv || exit 1;
-
-      echo 'Installing dependencies using uv...';
       uv pip install . || exit 1;
-
-      echo 'Activating virtual environment...';
       . .venv/bin/activate || exit 1;
 
-      echo 'Running automation billing data collection...';
+      echo "Running automation billing data collection...";
       python manage.py gather_automation_controller_billing_data --ship --since=20d || exit 1;
-
-      echo 'Execution complete.';
-      "
+      echo "Execution complete.";
+      '
 
 volumes:
   minio_data:
+  minio_config:

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -1,0 +1,89 @@
+version: '3.8'
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioaccess
+      MINIO_ROOT_PASSWORD: miniosecret
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
+  minio-setup:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      sh -c '
+      echo "Waiting for MinIO to be ready...";
+      sleep 5;
+
+      until /usr/bin/mc alias set local http://minio:9000 minioaccess miniosecret; do
+        echo "MinIO is not ready yet... waiting...";
+        sleep 2;
+      done;
+
+      echo "MinIO is ready! Creating bucket...";
+      /usr/bin/mc mb --ignore-existing local/metricsutilitys3 || { echo "Error creating bucket"; exit 1; }
+
+      echo "Creating new access key...";
+      /usr/bin/mc admin user add local mynewuser mysecretpassword || { echo "Error creating user"; exit 1; }
+
+      echo "Assigning policy to the new user...";
+      /usr/bin/mc admin policy attach local readwrite --user=mynewuser || { echo "Error assigning policy"; exit 1; }
+
+      echo "Generating service account for user (Access Key & Secret Key)...";
+      /usr/bin/mc admin user svcacct add local mynewuser > /tmp/minio_keys.txt
+
+      echo "User details:";
+      cat /tmp/minio_keys.txt;
+
+      echo "Setup complete!";
+      '
+
+  metrics-utility:
+    image: python:3.11-slim
+    container_name: metrics-utility
+    depends_on:
+      - minio-setup
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      UV_VENV: /app/.venv
+      METRICS_UTILITY_SHIP_TARGET: s3
+      METRICS_UTILITY_SHIP_PATH: metrics-utility/shipped_data
+      METRICS_UTILITY_BUCKET_NAME: metricsutilitys3
+      METRICS_UTILITY_BUCKET_ENDPOINT: "http://minio:9000"
+      METRICS_UTILITY_BUCKET_REGION: "us-east-1"
+      METRICS_UTILITY_BUCKET_ACCESS_KEY: "xxxxxx"
+      METRICS_UTILITY_BUCKET_SECRET_KEY: "xxxxxx"
+      METRICS_UTILITY_REPORT_TYPE: CCSPv2
+      METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS: 'jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations'
+    entrypoint: >
+      bash -c "
+      echo 'Installing uv...';
+      pip install uv || exit 1;
+
+      echo 'Creating virtual environment with uv...';
+      uv venv || exit 1;
+
+      echo 'Installing dependencies using uv...';
+      uv pip install . || exit 1;
+
+      echo 'Activating virtual environment...';
+      . .venv/bin/activate || exit 1;
+
+      echo 'Running automation billing data collection...';
+      python manage.py gather_automation_controller_billing_data --ship --since=20d || exit 1;
+
+      echo 'Execution complete.';
+      "
+
+volumes:
+  minio_data:


### PR DESCRIPTION
# [AAP-38819] Setting up pytest + S3 (Minio) + example test  

[**AAP-38819**  ](https://issues.redhat.com/browse/AAP-38819)

## Description  

WIP

### What is being changed?  
- **Minio setup** for local and CI testing.  
- Addition of an **initial test scenario** to validate `CCSPv2` report generation with **S3 backend**.  
- Integration with **pytest** to run automated tests using Minio as a simulated backend.  

### Why is this change needed?  
- Enables testing of `metrics-utility` S3 storage functionality without relying on an external environment.  
- Facilitates **test automation** in the CI pipeline.  
- Ensures that **report generation** works correctly with the S3 backend before full implementation.  

### How does this change address the issue?  
- Uses **Minio** as a local S3 backend for testing.  
- Defines the necessary setup to run locally and in CI.  
- Implements an **initial test case** covering `CCSPv2` report generation.  

---

### Expected Results  

- ✅ The **Minio environment** starts successfully.  
- ✅ The **metrics-utility-test** bucket is created successfully.  
- ✅ **S3 report generation tests** run and pass without errors.  

