### PR TITLE
AAP-39699 - fixing ValueError(

### DIFF
--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -164,11 +164,11 @@ class ReportRenewalGuidance(Base):
 
     def df_managed_nodes_query(self, dataframe, ephemeral=None, with_deleted=False):
         if ephemeral is None:
-            return dataframe[not dataframe["deleted"]]
+            return dataframe[~dataframe["deleted"]]
         else:
             # Take only non deleted
             if not with_deleted:
-                dataframe = dataframe[not dataframe["deleted"]]
+                dataframe = dataframe[~dataframe["deleted"]]
 
             # Filter ephemeral based on number of automated days
             ephemeral_days = parse_number_of_days(self.extra_params.get("opt_ephemeral"))


### PR DESCRIPTION
Full stack of error:

```(awx) [root@ip-10-0-7-77 metrics-utility]# python manage.py build_report --since=12months --ephemeral=1month
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/ui_next/build' in the STATICFILES_DIRS setting does not exist.
Traceback (most recent call last):
  File "/root/metrics-utility/manage.py", line 6, in <module>
    manage()
  File "/root/metrics-utility/metrics_utility/__init__.py", line 28, in manage
    utility.execute()
  File "/root/metrics-utility/metrics_utility/management_utility.py", line 58, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/management/commands/build_report.py", line 134, in handle
    report_spreadsheet = report_engine.build_spreadsheet()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py", line 126, in build_spreadsheet
    current_row = self._build_data_section(current_row, ws, host_metric_dataframe, ephemeral_usage_dataframe)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py", line 275, in _build_data_section
    'quantity_consumed': self.df_managed_nodes_query(dataframe, ephemeral=False)["hostname"].nunique()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py", line 171, in df_managed_nodes_query
    dataframe = dataframe[not dataframe["deleted"]]
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pandas/core/generic.py", line 1576, in __nonzero__
    raise ValueError(
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().```