### PR TITLE
Sonarcloud integration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,25 @@
+name: SonarCloud Scan
+
+on:
+  pull_request:
+    branches:
+      - devel
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+
+
+  steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: SonarCloud Scan
+          uses: sonarsource/sonarcloud-github-action@v2
+          with:
+            args: >
+              -Dsonar.projectKey=ansible_metrics-utility
+              -Dsonar.organization=ansible
+              -Dsonar.host.url=https://sonarcloud.io
+            token: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,12 @@
+# Complete documentation with many more options at:
+# https://docs.sonarqube.org/latest/analysis/analysis-parameters/
+
 ## The unique project identifier. This is mandatory.
 # Do not duplicate or reuse!
 # Available characters: [a-zA-Z0-9_:\.\-]
 # Must have least one non-digit.
 # Recommended format: <group>:<project>
-sonar.projectKey=ansible_eda-server FIX
+sonar.projectKey=ansible_metrics-utility
 
 sonar.organization=ansible
 
@@ -11,7 +14,7 @@ sonar.organization=ansible
 sonar.sources=.
 
 # Verbose name of project displayed in WUI. Default is set to the projectKey. This field is optional.
-sonar.projectName=eda-server FIX
+sonar.projectName=metrics-utility
 
 # Version of project. This field is optional.
 #sonar.projectVersion=1.0
@@ -22,10 +25,10 @@ sonar.projectName=eda-server FIX
 sonar.issue.ignore.multicriteria=e1
 # Ignore "should be a variable"
 #sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/* FIX, should this be here?
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
 
 # Only scan with python3
-sonar.python.version=3.9,3.10,3.11,3.12
+sonar.python.version=3.11,3.12
 
 # Ignore code dupe for the migrations
-sonar.cpd.exclusions=**/migrations/*.py  FIX, should this be here?
+sonar.cpd.exclusions=**/migrations/*.py

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,31 @@
+## The unique project identifier. This is mandatory.
+# Do not duplicate or reuse!
+# Available characters: [a-zA-Z0-9_:\.\-]
+# Must have least one non-digit.
+# Recommended format: <group>:<project>
+sonar.projectKey=ansible_eda-server FIX
+
+sonar.organization=ansible
+
+# Customize what paths to scan. Default is .
+sonar.sources=.
+
+# Verbose name of project displayed in WUI. Default is set to the projectKey. This field is optional.
+sonar.projectName=eda-server FIX
+
+# Version of project. This field is optional.
+#sonar.projectVersion=1.0
+
+# Tell sonar scanner where coverage files exist
+#sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.issue.ignore.multicriteria=e1
+# Ignore "should be a variable"
+#sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/* FIX, should this be here?
+
+# Only scan with python3
+sonar.python.version=3.9,3.10,3.11,3.12
+
+# Ignore code dupe for the migrations
+sonar.cpd.exclusions=**/migrations/*.py  FIX, should this be here?


### PR DESCRIPTION
[AAP-39024]

## Description

Properly create and configure the `sonar-project.properties` file.

## Further explaination:

Sonarcloud is running a automatic analysis already, but we also require the dynamic analysis that makes calls to sonarcloud from inside a GH action in order to initiate scans. It's explained here in the [handbook](https://handbook.eng.ansible.com/docs/CICD/Services/sonar-config) and mirrors the eda [config](https://github.com/ansible/eda-server/blob/main/sonar-project.properties). As noted below though, the sonar-project.properties config is only the first step in getting this running; we also need to set up a gh actions workflow and the secret sonar token. But we are waiting on [AAP-39227](https://issues.redhat.com/browse/AAP-39227) and in turn [AAP-39220](https://issues.redhat.com/browse/AAP-39220) for that.

## Testing

See /metrics-utility/sonar-project.properties

### Prerequisites

None

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [x] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

This pr does _not_ include the following steps:
- GitHub Actions workflow includes steps for SonarCloud scanning and coverage reporting.
- The secret SONAR_TOKEN is configured in the repository.

Anything related to running tests will rely on [AAP-39227](https://issues.redhat.com/browse/AAP-39227) which in turn relies on [AAP-39220](https://issues.redhat.com/browse/AAP-39220). 
