### PR TITLE
[AAP-38577] Docs: Refactor README.md & Relocate Legacy Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,241 +1,100 @@
-# AAP metrics-utility
+# AAP Metrics-Utility
 
-The AAP metrics utility tool is a standalone CLI utility called `metrics-utility` which is intended to be installed to
-the system containing instance of the [Automation Controller](https://www.ansible.com/products/controller).
-It's an alternative command line tool for the Controller's CLI `awx-manage`.
+A standalone CLI utility for collecting and reporting metrics from [Ansible Automation Platform (AAP)](https://www.ansible.com/products/automation-platform) Controller instances. This tool allows users to:
 
-## Installation
+- Collect and analyze Controller usage data
+- Generate reports (CCSP, CCSPv2, RENEWAL_GUIDANCE)
+- Support multiple storage adapters for data persistence
+- Push metrics data to `console.redhat.com`
 
-### Run from source
+## Quick Start
 
-Run as awx user, to have the python virtual env available:
+### Prerequisites
 
-```shell
-cd ~
-git clone https://github.com/ansible/metrics-utility.git (or fetch the latest upstream commits)
-cd metrics-utility
+- **Python 3.11 or later**
+- **uv package manager** (Install with `pip install uv` if not already installed)
+- **Dependencies managed via `pyproject.toml`** (Ensure `uv.lock` is used for consistency)
 
-# Activate Automation Controller's Python virtual environment
-. /var/lib/awx/venv/awx/bin/activate
+### Installation
 
-# Install the dependecies
-pip install .
-
-# Set extra ENV VARs for report generation purposes
-export METRICS_UTILITY_SHIP_TARGET=controller_db
-export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
-# add path for the report to go in
-export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
-
-# Run some command, but rather instead of command using RPM like:
-# metrics-utility build_report ...
-# we run it as
-# python manage.py build_report ...
-python manage.py build_report --since=12months --ephemeral=1month
-```
-
-
-### From GitHub repository
-
-Install as a root user (running this on older Controller envs can result in package conflicts):
-
-```shell
-# Download to any folder
-cd ~
+```bash
+# Clone the repository
 git clone https://github.com/ansible/metrics-utility.git
-
-# Activate Automation Controller's Python virtual environment
-. /var/lib/awx/venv/awx/bin/activate
-
-# Install the utility
 cd metrics-utility
-pip install .
-# Successfully installed metrics-utility
 
-which metrics-utility
-# /var/lib/awx/venv/awx/bin/metrics-utility
-
-# Move to /usr/bin (like awx-manage)
-mv /var/lib/awx/venv/awx/bin/metrics-utility /usr/bin/
+# Install dependencies using uv
+uv pip install .
 ```
 
-## Available functionality
+For development setup, see the [Developer Setup Guide](./docs/developer_setup.md).
 
-### Available storage adapters
+### Basic Usage
 
-#### Local directory
+#### Standalone Mode (CCSPv2 Reports)
 
-Storing datasets under a local directory. With using PVC on OpenShift deployments.
+The utility can generate CCSPv2 reports using test data without requiring a Controller environment:
 
-```
-# Set needed ENV VARs for data gathering
-export METRICS_UTILITY_SHIP_TARGET=directory
-export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
-```
+```bash
+# Generate a test CCSPv2 report using the convenience script
+./run-ccsp2-build
 
-#### Object storage with S3 interface
-
-Object storage with S3 like interface
-
-```
-# Set needed ENV VARs for data gathering
-export METRICS_UTILITY_SHIP_TARGET=s3
-export METRICS_UTILITY_SHIP_PATH=metrics-utility/shipped_data
-
-# Define S3 config
-export METRICS_UTILITY_BUCKET_NAME=metrics-utility
-export METRICS_UTILITY_BUCKET_ENDPOINT=<endpoint to your S3>
-# For AWS S3, define also a region
-# export METRICS_UTILITY_BUCKET_REGION="us-east-1"
-
-# Define S3 credentials
-export METRICS_UTILITY_BUCKET_ACCESS_KEY=<access_key>
-export METRICS_UTILITY_BUCKET_SECRET_KEY=<secret_key>
-```
-
-
-### Local data gathering and CCSP report generation
-
-This set of commands will be periodically storing data and generating CCSP reports at the beginning of each month.
-Run this command as a cronjob.
-
-
-#### Example for CCSP type report
-
-Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
-
-```
-# Set extra ENV VARs for report generation purposes
-export METRICS_UTILITY_REPORT_TYPE=CCSP
-export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
-export METRICS_UTILITY_REPORT_SKU=MCT3752MO
-export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
-export METRICS_UTILITY_REPORT_H1_HEADING="CCSP Reporting <Company>: ANSIBLE Consumption"
-export METRICS_UTILITY_REPORT_COMPANY_NAME="Company Name"
-export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
-export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
-export METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER="BUSINESS LEADER"
-export METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER="PROCUREMENT LEADER"
-
-# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
-metrics-utility gather_automation_controller_billing_data --ship --until=10m
-
-# Build report for previous month unless it already exists. Report will be created under ./reports dir under SHIP_PATH dir.
-metrics-utility build_report
-```
-
-
-#### Example for CCSPv2 type report
-
-Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
-
-```
-# Set extra ENV VARs for report generation purposes
+# Or manually:
 export METRICS_UTILITY_REPORT_TYPE=CCSPv2
-export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
-export METRICS_UTILITY_REPORT_SKU=MCT3752MO
-export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
-export METRICS_UTILITY_REPORT_H1_HEADING="CCSP NA Direct Reporting Template"
-export METRICS_UTILITY_REPORT_COMPANY_NAME="Partner A"
-export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
-export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
-export METRICS_UTILITY_REPORT_PO_NUMBER="123"
-export METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME="Customer A"
-export METRICS_UTILITY_REPORT_END_USER_CITY="Springfield"
-export METRICS_UTILITY_REPORT_END_USER_STATE="TX"
-export METRICS_UTILITY_REPORT_END_USER_COUNTRY="US"
-
-# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
-python manage.py gather_automation_controller_billing_data --ship --until=10m
-# or metrics-utility gather_automation_controller_billing_data --ship --until=10m
-
-# Build report for previous month unless it already exists. Report will be created under ./reports dir under SHIP_PATH dir.
 python manage.py build_report
-# or metrics-utility build_report
-
-# Build report for a specific month
-python manage.py build_report --month=2024-06
-
-
 ```
 
-#### Example for CCSPv2 type report for jobs, organizations and managed nodes usage history
+Reports will be saved in `metrics_utility/test/test_data/reports/YYYY/MM/`.
 
-This example reuses CCSPv2 type, but just provides a usage report outside of CCSP domain
+#### Controller Environment Mode
 
-Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
+For data gathering and other report types, the utility needs to be run in a Controller environment. **If Automation Controller is not running, execution will fail with a missing module error.**
 
-```
-# Set report type
-export METRICS_UTILITY_REPORT_TYPE=CCSPv2
+Recent changes in AWX have decoupled some dependencies, meaning certain components must now be mocked when running outside of a full AWX environment. Ensure Automation Controller is running before executing commands.
 
-# Set subset of sheets to be built:
-export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS='jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations'
+1. Install the utility in your Controller environment:
 
-# Optionally add a semicolon separated list of organizations, to limit the report only for certain orgs
-# e.g. export METRICS_UTILITY_ORGANIZATION_FILTER="ACME;Test Org 1"
+   ```bash
+   cd metrics-utility
+   uv pip install .
+   ```
 
-# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
-python manage.py gather_automation_controller_billing_data --ship --until=10m
-# or metrics-utility gather_automation_controller_billing_data --ship --until=10m
+2. Configure storage location:
 
-# Build report defining a custom range, report on last 5 months will be
-python manage.py build_report --since=5months
+   ```bash
+   export METRICS_UTILITY_SHIP_TARGET=directory
+   export METRICS_UTILITY_SHIP_PATH=/path/to/store/data
+   ```
 
-# Build report defining a custom range with specific dates
-python manage.py build_report --since=2024-05-01 --until=2024-09-30
-```
+3. Collect and analyze data:
 
-### Example with Controller's database as a storage RENEWAL_GUIDANCE type
+   ```bash
+   # Collect metrics data
+   python manage.py gather_automation_controller_billing_data --ship --until=10m
+   ```
+   
+   If the Automation Controller environment is missing, you will see an error like:
+   
+   ```
+   Automation Controller modules not found in /awx_devel (AWX_PATH). Using mock and continuing.
+   ModuleNotFoundError: No module named 'awx.main.utils.pglock'
+   ```
+   
+   Ensure Automation Controller is correctly installed and running before proceeding.
 
-```
-# Set extra ENV VARs for report generation purposes
-export METRICS_UTILITY_SHIP_TARGET=controller_db
-export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
-export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+4. Generate renewal guidance report:
 
-# Builds report covering 365days back by default
-python manage.py build_report --since=12months --ephemeral=1month
-# or metrics-utility build_report --since=12months --ephemeral=1month
-```
+   ```bash
+   export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
+   python manage.py build_report --since=12months --ephemeral=1month
+   ```
 
-### Pushing data periodically into console.redhat.com
+## Documentation
 
-This command will push new data into console.redhat.com, it automatically stores the last collected interval and will collect
-up to 4 week long gap. The --until option collects the data until 10 minutes ago, to give time for fresh data to be inserted
-into the Controller's database. Run this command as a cronjob.
-```
-export METRICS_UTILITY_SHIP_TARGET=crc
-export METRICS_UTILITY_SERVICE_ACCOUNT_ID=<service account name>
-export METRICS_UTILITY_SERVICE_ACCOUNT_SECRET=<service account secret>
-export METRICS_UTILITY_OPTIONAL_COLLECTORS=""
+Documentation is available in the [`/docs` directory](./docs).
 
-# AWS specific params
-export METRICS_UTILITY_BILLING_PROVIDER=aws
-export METRICS_UTILITY_BILLING_ACCOUNT_ID="<AWS 12 digit customer id>"
-export METRICS_UTILITY_RED_HAT_ORG_ID="<Red Had org id tied to the AWS billing account>"
+> **Note:** The older README, which includes installation instructions, legacy AWX integration details, and additional information about available storage adapters and report types, has been moved to [`/docs/old-readme.md`](./docs/old-readme.md) for reference.
 
-metrics-utility gather_automation_controller_billing_data --ship --until=10m
-```
+## Contributing
 
-You can inspect the data sent with --dry-run attribute and provide your own interval with --since and --until:
-```
-# This will collect whole day of 2023-12-21
-metrics-utility gather_automation_controller_billing_data --dry-run --since=2023-12-21 --until=2023-12-22
-```
+Please follow our [Contributor's Guide](./docs/contributing/contributor_guide.md) for details on submitting changes and documentation standards.
 
-## Developer Setup
-
-For developers contributing to this project, refer to the [Developer Setup Guide](./docs/developer_setup.md) for detailed instructions on setting up your local development environment, installing dependencies, and configuring pre-commit hooks.
-
----
-
-## Available Documentation
-
-Additional documentation is available in the `/docs` directory. This includes:
-
-- **Developer Setup**: [docs/developer_setup.md](./docs/developer_setup.md)
-
-Please note that this is the upstream documentation for the metrics-utility project. Additional internal downstream documentation, accessible only to the Ansible organization, is maintained separately in the [Ansible Handbook](https://github.com/ansible/handbook/tree/main/The%20Ansible%20Engineering%20Handbook/docs/AAP/Services/Metrics).
-
-As the project grows, more guides and references will be added to the `/docs` folder.

--- a/docs/old-readme.md
+++ b/docs/old-readme.md
@@ -1,0 +1,241 @@
+# AAP metrics-utility
+
+The AAP metrics utility tool is a standalone CLI utility called `metrics-utility` which is intended to be installed to
+the system containing instance of the [Automation Controller](https://www.ansible.com/products/controller).
+It's an alternative command line tool for the Controller's CLI `awx-manage`.
+
+## Installation
+
+### Run from source
+
+Run as awx user, to have the python virtual env available:
+
+```shell
+cd ~
+git clone https://github.com/ansible/metrics-utility.git (or fetch the latest upstream commits)
+cd metrics-utility
+
+# Activate Automation Controller's Python virtual environment
+. /var/lib/awx/venv/awx/bin/activate
+
+# Install the dependecies
+pip install .
+
+# Set extra ENV VARs for report generation purposes
+export METRICS_UTILITY_SHIP_TARGET=controller_db
+export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
+# add path for the report to go in
+export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+
+# Run some command, but rather instead of command using RPM like:
+# metrics-utility build_report ...
+# we run it as
+# python manage.py build_report ...
+python manage.py build_report --since=12months --ephemeral=1month
+```
+
+
+### From GitHub repository
+
+Install as a root user (running this on older Controller envs can result in package conflicts):
+
+```shell
+# Download to any folder
+cd ~
+git clone https://github.com/ansible/metrics-utility.git
+
+# Activate Automation Controller's Python virtual environment
+. /var/lib/awx/venv/awx/bin/activate
+
+# Install the utility
+cd metrics-utility
+pip install .
+# Successfully installed metrics-utility
+
+which metrics-utility
+# /var/lib/awx/venv/awx/bin/metrics-utility
+
+# Move to /usr/bin (like awx-manage)
+mv /var/lib/awx/venv/awx/bin/metrics-utility /usr/bin/
+```
+
+## Available functionality
+
+### Available storage adapters
+
+#### Local directory
+
+Storing datasets under a local directory. With using PVC on OpenShift deployments.
+
+```
+# Set needed ENV VARs for data gathering
+export METRICS_UTILITY_SHIP_TARGET=directory
+export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+```
+
+#### Object storage with S3 interface
+
+Object storage with S3 like interface
+
+```
+# Set needed ENV VARs for data gathering
+export METRICS_UTILITY_SHIP_TARGET=s3
+export METRICS_UTILITY_SHIP_PATH=metrics-utility/shipped_data
+
+# Define S3 config
+export METRICS_UTILITY_BUCKET_NAME=metrics-utility
+export METRICS_UTILITY_BUCKET_ENDPOINT=<endpoint to your S3>
+# For AWS S3, define also a region
+# export METRICS_UTILITY_BUCKET_REGION="us-east-1"
+
+# Define S3 credentials
+export METRICS_UTILITY_BUCKET_ACCESS_KEY=<access_key>
+export METRICS_UTILITY_BUCKET_SECRET_KEY=<secret_key>
+```
+
+
+### Local data gathering and CCSP report generation
+
+This set of commands will be periodically storing data and generating CCSP reports at the beginning of each month.
+Run this command as a cronjob.
+
+
+#### Example for CCSP type report
+
+Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
+
+```
+# Set extra ENV VARs for report generation purposes
+export METRICS_UTILITY_REPORT_TYPE=CCSP
+export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
+export METRICS_UTILITY_REPORT_SKU=MCT3752MO
+export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
+export METRICS_UTILITY_REPORT_H1_HEADING="CCSP Reporting <Company>: ANSIBLE Consumption"
+export METRICS_UTILITY_REPORT_COMPANY_NAME="Company Name"
+export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
+export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
+export METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER="BUSINESS LEADER"
+export METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER="PROCUREMENT LEADER"
+
+# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
+metrics-utility gather_automation_controller_billing_data --ship --until=10m
+
+# Build report for previous month unless it already exists. Report will be created under ./reports dir under SHIP_PATH dir.
+metrics-utility build_report
+```
+
+
+#### Example for CCSPv2 type report
+
+Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
+
+```
+# Set extra ENV VARs for report generation purposes
+export METRICS_UTILITY_REPORT_TYPE=CCSPv2
+export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
+export METRICS_UTILITY_REPORT_SKU=MCT3752MO
+export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
+export METRICS_UTILITY_REPORT_H1_HEADING="CCSP NA Direct Reporting Template"
+export METRICS_UTILITY_REPORT_COMPANY_NAME="Partner A"
+export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
+export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
+export METRICS_UTILITY_REPORT_PO_NUMBER="123"
+export METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME="Customer A"
+export METRICS_UTILITY_REPORT_END_USER_CITY="Springfield"
+export METRICS_UTILITY_REPORT_END_USER_STATE="TX"
+export METRICS_UTILITY_REPORT_END_USER_COUNTRY="US"
+
+# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
+python manage.py gather_automation_controller_billing_data --ship --until=10m
+# or metrics-utility gather_automation_controller_billing_data --ship --until=10m
+
+# Build report for previous month unless it already exists. Report will be created under ./reports dir under SHIP_PATH dir.
+python manage.py build_report
+# or metrics-utility build_report
+
+# Build report for a specific month
+python manage.py build_report --month=2024-06
+
+
+```
+
+#### Example for CCSPv2 type report for jobs, organizations and managed nodes usage history
+
+This example reuses CCSPv2 type, but just provides a usage report outside of CCSP domain
+
+Set a storage adapter and path first, pick one from [Available storage adapters](#available-storage-adapters)
+
+```
+# Set report type
+export METRICS_UTILITY_REPORT_TYPE=CCSPv2
+
+# Set subset of sheets to be built:
+export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS='jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations'
+
+# Optionally add a semicolon separated list of organizations, to limit the report only for certain orgs
+# e.g. export METRICS_UTILITY_ORGANIZATION_FILTER="ACME;Test Org 1"
+
+# Gather and store the data in provided SHIP_PATH directory under ./report_data subdir
+python manage.py gather_automation_controller_billing_data --ship --until=10m
+# or metrics-utility gather_automation_controller_billing_data --ship --until=10m
+
+# Build report defining a custom range, report on last 5 months will be
+python manage.py build_report --since=5months
+
+# Build report defining a custom range with specific dates
+python manage.py build_report --since=2024-05-01 --until=2024-09-30
+```
+
+### Example with Controller's database as a storage RENEWAL_GUIDANCE type
+
+```
+# Set extra ENV VARs for report generation purposes
+export METRICS_UTILITY_SHIP_TARGET=controller_db
+export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
+export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+
+# Builds report covering 365days back by default
+python manage.py build_report --since=12months --ephemeral=1month
+# or metrics-utility build_report --since=12months --ephemeral=1month
+```
+
+### Pushing data periodically into console.redhat.com
+
+This command will push new data into console.redhat.com, it automatically stores the last collected interval and will collect
+up to 4 week long gap. The --until option collects the data until 10 minutes ago, to give time for fresh data to be inserted
+into the Controller's database. Run this command as a cronjob.
+```
+export METRICS_UTILITY_SHIP_TARGET=crc
+export METRICS_UTILITY_SERVICE_ACCOUNT_ID=<service account name>
+export METRICS_UTILITY_SERVICE_ACCOUNT_SECRET=<service account secret>
+export METRICS_UTILITY_OPTIONAL_COLLECTORS=""
+
+# AWS specific params
+export METRICS_UTILITY_BILLING_PROVIDER=aws
+export METRICS_UTILITY_BILLING_ACCOUNT_ID="<AWS 12 digit customer id>"
+export METRICS_UTILITY_RED_HAT_ORG_ID="<Red Had org id tied to the AWS billing account>"
+
+metrics-utility gather_automation_controller_billing_data --ship --until=10m
+```
+
+You can inspect the data sent with --dry-run attribute and provide your own interval with --since and --until:
+```
+# This will collect whole day of 2023-12-21
+metrics-utility gather_automation_controller_billing_data --dry-run --since=2023-12-21 --until=2023-12-22
+```
+
+## Developer Setup
+
+For developers contributing to this project, refer to the [Developer Setup Guide](developer_setup.md) for detailed instructions on setting up your local development environment, installing dependencies, and configuring pre-commit hooks.
+
+---
+
+## Available Documentation
+
+Additional documentation is available in the `/docs` directory. This includes:
+
+- **Developer Setup**: [docs/developer_setup.md](developer_setup.md)
+
+Please note that this is the upstream documentation for the metrics-utility project. Additional internal downstream documentation, accessible only to the Ansible organization, is maintained separately in the [Ansible Handbook](https://github.com/ansible/handbook/tree/main/The%20Ansible%20Engineering%20Handbook/docs/AAP/Services/Metrics).
+
+As the project grows, more guides and references will be added to the `/docs` folder.


### PR DESCRIPTION
## **Description**  

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->  

- **What is being changed?**  
  - The existing `README.md` has been updated.  
  - The previous `README.md` has been moved to `/docs/old-readme.md` for reference.  
  - A few updates in installation instructions.  

- **Why is this change needed?**  
  - The outcome of the [Spike: Research and Define Documentation Structure & Storage](https://issues.redhat.com/browse/AAP-38577)
  - Recent AWX decoupling work has impacted the installation process, requiring adjustments to the setup documentation.  
  - The current documentation strategy mandates separating detailed setup guides into structured files under `/docs`.  
  - The `old-readme.md` still contains useful information and will serve as a reference for further documentation improvements by the developers contributing the changes.  

- **How does this change address the issue?**  
  - The new `README.md` includes relevant, working instructions and is more concise and easier to read.
  - The `/docs` directory will house additional in-depth guides, which will be created based on information from `old-readme.md`.  
  - Upcoming documentation additions *might* include:  
    - **Installation Guide**  
    - **Configuration Guide**  
    - **Storage Adapters Guide**  
    - **Report Types Guide**  

---

## **Testing**  

<!-- Optional for test-only changes. Mandatory for all other changes -->  

### **Steps to Test**  
- Running the Installation Steps in the provided documentation, ensuring the expected outcome.

### **Expected Results**  
- `uv pip install .` should complete successfully.  
- CCSPv2 report should be generated without errors.  
- Controller environment commands should function correctly.  

---

## **Required Actions**  

- [x] Requires documentation updates  
  - The old `README.md` is now `/docs/old-readme.md` and will be refined further.  
  - The following guides should be created based on `old-readme.md`:  
    - Installation Guide  
    - Configuration Guide  
    - Storage Adapters Guide  
    - Report Types Guide  
- [ ] Requires downstream repository changes - mentioning in the Ansible Handbook: https://github.com/ansible/handbook/pull/308

---

## **Self-Review Checklist**  

### **Code Quality**  

- [x] Documentation follows the agreed-upon structure.  
- [ ] All setup instructions are tested and verified.  
- [ ] Changes are reviewed and approved by at least two team members.  

---

## **Notes for Reviewers**  

- The separation of `old-readme.md` ensures we don’t lose valuable information while keeping the main `README.md` clean and structured.  
- Future documentation expansion will cross-reference details from the `old-readme.md`.  
- Let me know if additional refinements are required before merging.  
- I didn't have a chance to run the `Controller Environment Mode`. The problem is that after AWX decoupling most of the original (old-readme.md) instructions became obsolete. If you have knowledeg on how to test it in the Controller Environment, please do so and share your findings.
- The Contributor's Guide is going to be accessible after merging #62 