### PR TITLE
Fix bug in standalone mode - datetime utc and logger

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
-
-
 if __name__ == '__main__':
     from metrics_utility import manage
     manage()

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
+
+
 if __name__ == '__main__':
     from metrics_utility import manage
     manage()

--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -15,6 +15,7 @@ def manage():
         sys.path.append(awx_path)
         spec = importlib.util.find_spec('awx')
         if spec is None:
+            os.environ['STANDALONE_MODE'] = '1'
             sys.stderr.write(f"Automation Controller modules not found in {awx_path} (AWX_PATH). Using mock and continuing.\n")
             sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'mock_awx')))
 

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -2,7 +2,7 @@ import datetime
 
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
-from django.utils import timezone
+from datetime import timezone
 
 from metrics_utility.exceptions import UnparsableParameter
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -68,8 +68,7 @@ class Command(BaseCommand):
                 handler.setFormatter(logging.Formatter('%(message)s'))
                 self.logger.addHandler(handler)
                 self.logger.propagate = False
-
-        if os.getenv('STANDALONE_MODE') is not None:
+        else:
             self.logger.setLevel(logging.DEBUG)  # Ensure the logger captures all messages
             if not self.logger.handlers:  # If no handlers exist, add one
                 standalone_handler = logging.StreamHandler()

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
                 standalone_handler.setLevel(logging.DEBUG)
                 standalone_handler.setFormatter(logging.Formatter('%(message)s'))
                 self.logger.addHandler(standalone_handler)
-            
+
             self.logger.propagate = False  # Ensure logs do not propagate to other handlers
 
     def handle(self, *args, **options):

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -5,7 +5,7 @@ import os
 from dateutil.parser import parse as date_parse
 from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
-from django.utils import timezone
+from datetime import timezone
 
 from metrics_utility.automation_controller_billing.dataframe_engine.factory import \
     Factory as DataframeEngineFactory

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -58,11 +58,26 @@ class Command(BaseCommand):
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
-        handler.setFormatter(logging.Formatter('%(message)s'))
-        self.logger.addHandler(handler)
-        self.logger.propagate = False
+
+        if os.getenv('STANDALONE_MODE') is None:
+            # Prevent duplicate handlers
+            if not self.logger.handlers:
+                self.logger = logging.getLogger('awx.main.analytics')
+                handler = logging.StreamHandler()
+                handler.setLevel(logging.DEBUG)
+                handler.setFormatter(logging.Formatter('%(message)s'))
+                self.logger.addHandler(handler)
+                self.logger.propagate = False
+
+        if os.getenv('STANDALONE_MODE') is not None:
+            self.logger.setLevel(logging.DEBUG)  # Ensure the logger captures all messages
+            if not self.logger.handlers:  # If no handlers exist, add one
+                standalone_handler = logging.StreamHandler()
+                standalone_handler.setLevel(logging.DEBUG)
+                standalone_handler.setFormatter(logging.Formatter('%(message)s'))
+                self.logger.addHandler(standalone_handler)
+            
+            self.logger.propagate = False  # Ensure logs do not propagate to other handlers
 
     def handle(self, *args, **options):
         self.init_logging()


### PR DESCRIPTION
[AAP-40143]

## Description

Two changes:

1) used standard datetime timezones instead of django ones. This fix error:

Traceback (most recent call last):
  File "/home/milan/ansible_galaxy/awx/awx-dev/metrics-utility/manage.py", line 6, in <module>
    manage()
  File "/home/milan/ansible_galaxy/awx/awx-dev/metrics-utility/metrics_utility/__init__.py", line 28, in manage
    utility.execute()
  File "/home/milan/ansible_galaxy/awx/awx-dev/metrics-utility/metrics_utility/management_utility.py", line 58, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/milan/.local/lib/python3.11/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/milan/.local/lib/python3.11/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/milan/ansible_galaxy/awx/awx-dev/metrics-utility/metrics_utility/management/commands/build_report.py", line 79, in handle
    opt_since = parse_date_param(opt_since)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/milan/ansible_galaxy/awx/awx-dev/metrics-utility/metrics_utility/automation_controller_billing/helpers.py", line 31, in parse_date_param
    parsed_date = parsed_date.replace(tzinfo=timezone.utc)
                                             ^^^^^^^^^^^^
AttributeError: module 'django.utils.timezone' has no attribute 'utc'


2) Repaired logger - PR introduces new env variable "STANDALONE_MODE", this is set when awx is not found. Then if this env var is set, logger is set differently. Previous logger is set to work inside awx, but this setting did not worked in standalone.

Also handlers are added only when dont exist, this prevents duplicating handers, which can happen when __init__ is loaded multiple times, this can happen in tests.

## Testing
Described in issue.

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

