### PR TITLE
Adding an example of 'date' in the README as it is required. Otherwise, it will fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,14 @@ Recent changes in AWX have decoupled some dependencies, meaning certain componen
 4. Generate renewal guidance report:
 
    ```bash
-   export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
-   python manage.py build_report --since=12months --ephemeral=1month
+      # Set extra ENV VARs for report generation purposes
+      export METRICS_UTILITY_SHIP_TARGET=controller_db
+      export METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE
+      export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+
+      # Builds report covering 365days back by default
+      python manage.py build_report --since=12months --ephemeral=1month
+      # or metrics-utility build_report --since=12months --ephemeral=1month
    ```
 
 ## Documentation


### PR DESCRIPTION
If we don't add a date, we will end up the following error. 

`Traceback (most recent call last):
  File "/root/metrics-utility/manage.py", line 6, in <module>
    manage()
  File "/root/metrics-utility/metrics_utility/__init__.py", line 28, in manage
    utility.execute()
  File "/root/metrics-utility/metrics_utility/management_utility.py", line 58, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/management/commands/build_report.py", line 124, in handle
    extra_params=extra_params).create()
                               ^^^^^^^^
  File "/root/metrics-utility/metrics_utility/automation_controller_billing/dataframe_engine/factory.py", line 26, in create
    return (self._get_db_dataframe_host_metric_usage().build_dataframe(),)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/metrics-utility/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py", line 24, in build_dataframe
    for data in self.extractor.iter_batches():
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ExtractorDirectory.iter_batches() missing 1 required positional argument: 'date'`

So I have added this in the readme as an example so that people can run it without these problems