### PR TITLE
Pytest enable

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,4 +76,4 @@ jobs:
           METRICS_UTILITY_BUCKET_REGION: "us-east-1"
           METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
         run: |
-          env # pytest -s -v
+          uv run pytest -s -v

--- a/README.md
+++ b/README.md
@@ -98,3 +98,6 @@ Documentation is available in the [`/docs` directory](./docs).
 
 Please follow our [Contributor's Guide](./docs/contributing/CONTRIBUTING.md) for details on submitting changes and documentation standards.
 
+## Tests
+
+Run tests using `pytest -s -v`. Some tests depend on a running postgres & minio instance - run `docker compose -f tools/docker/docker-compose.yaml up` to get one.

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Please follow our [Contributor's Guide](./docs/contributing/CONTRIBUTING.md) for
 
 ## Tests
 
-Run tests using `pytest -s -v`. Some tests depend on a running postgres & minio instance - run `docker compose -f tools/docker/docker-compose.yaml up` to get one.
+Run tests using `pytest -s -v`. Some tests depend on a running postgres & minio instance - run `docker compose -f tools/docker/docker-compose.yaml up` to get one. You may need to `docker login quay.io` first.

--- a/metrics_utility/test/ccspv_reports/test_CCSP.py
+++ b/metrics_utility/test/ccspv_reports/test_CCSP.py
@@ -9,7 +9,7 @@ import pytest
 env_vars = {
     "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
     "METRICS_UTILITY_REPORT_RHN_LOGIN": "test_login",
-    "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+    "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
     "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",
     "METRICS_UTILITY_REPORT_H1_HEADING": "CCSP NA Direct Reporting Template",
     "METRICS_UTILITY_REPORT_PO_NUMBER": "123",
@@ -21,7 +21,7 @@ env_vars = {
     "AWX_LOGGING_MODE": "stdout",
 }
 
-file_path = "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data/reports/2024/02/CCSP-2024-02.xlsx"
+file_path = "./metrics_utility/test/test_data/reports/2024/02/CCSP-2024-02.xlsx"
 
 
 date_today = datetime.now().strftime("%b %d, %Y")

--- a/metrics_utility/test/ccspv_reports/test_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_CCSPv2.py
@@ -8,7 +8,7 @@ import pytest
 env_vars = {
     "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
     "METRICS_UTILITY_REPORT_RHN_LOGIN": "test_login",
-    "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+    "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
     "METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME": "Customer A",
     "METRICS_UTILITY_REPORT_END_USER_STATE": "TX",
     "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",
@@ -24,7 +24,7 @@ env_vars = {
     "AWX_LOGGING_MODE": "stdout",
 }
 
-file_path = "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data/reports/2024/02/CCSPv2-2024-02.xlsx"
+file_path = "./metrics_utility/test/test_data/reports/2024/02/CCSPv2-2024-02.xlsx"
 
 
 date_today = datetime.now().strftime("%b %d, %Y")

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
@@ -9,7 +9,7 @@ import pytest
 env_vars = {
     "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
     "METRICS_UTILITY_REPORT_RHN_LOGIN": "test_login",
-    "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+    "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
     "METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME": "Customer A",
     "METRICS_UTILITY_REPORT_END_USER_STATE": "TX",
     "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",
@@ -25,7 +25,7 @@ env_vars = {
     "AWX_LOGGING_MODE": "stdout",
 }
 
-file_path = "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx"
+file_path = "./metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx"
 
 date_today = datetime.now().strftime("%b %d, %Y")
 

--- a/metrics_utility/test/snapshot_tests/CCSP/CCSP_snapshot_generator.py
+++ b/metrics_utility/test/snapshot_tests/CCSP/CCSP_snapshot_generator.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import copy
 
 # You can run this script by using:
-# python -m metrics_utility.test.snapshot_tests.CCSP.CCSP_snapshot_generator
+# uv run python -m metrics_utility.test.snapshot_tests.CCSP.CCSP_snapshot_generator
 
 def select_env_vars(dictionary, position):
     values = {}
@@ -35,7 +35,7 @@ def get_data():
     # Base dictionary
     base_dict = {
         'METRICS_UTILITY_SHIP_TARGET': ['directory'],
-        'METRICS_UTILITY_SHIP_PATH': ['/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data'],
+        'METRICS_UTILITY_SHIP_PATH': ['./metrics_utility/test/test_data'],
         'METRICS_UTILITY_PRICE_PER_NODE': ['11.55', '15.01', '9.99'],
         'METRICS_UTILITY_REPORT_SKU': ['MCT3752MO', 'CSP8794CE', 'RHT1234PL'],
         'METRICS_UTILITY_REPORT_SKU_DESCRIPTION': [

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-01--2024-02-29.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-01--2024-02-29.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-05--2024-04-30.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-05--2024-04-30.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-15--2024-03-22.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02-15--2024-03-22.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-02.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-01--2024-03-31.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-01--2024-03-31.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-02--2024-04-20.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-02--2024-04-20.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-05--2024-03-15.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03-05--2024-03-15.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-03.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-04.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSP/snapshot_def_2024-04.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "9.99",
         "METRICS_UTILITY_REPORT_SKU": "RHT1234PL",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Satellite, Standard Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-01--2024-02-29.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-01--2024-02-29.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-05--2024-04-30.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-05--2024-04-30.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-15--2024-03-22.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02-15--2024-03-22.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-02.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-01--2024-03-31.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-01--2024-03-31.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-02--2024-04-20.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-02--2024-04-20.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-05--2024-03-15.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03-05--2024-03-15.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "15.01",
         "METRICS_UTILITY_REPORT_SKU": "CSP8794CE",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat OpenShift Container Platform, Premium Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-03.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "11.55",
         "METRICS_UTILITY_REPORT_SKU": "MCT3752MO",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)",

--- a/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-04.json
+++ b/metrics_utility/test/snapshot_tests/CCSP/data/CCSPv2/snapshot_def_2024-04.json
@@ -1,7 +1,7 @@
 {
     "env_vars": {
         "METRICS_UTILITY_SHIP_TARGET": "directory",
-        "METRICS_UTILITY_SHIP_PATH": "/awx_devel/awx-dev/metrics-utility/metrics_utility/test/test_data",
+        "METRICS_UTILITY_SHIP_PATH": "./metrics_utility/test/test_data",
         "METRICS_UTILITY_PRICE_PER_NODE": "9.99",
         "METRICS_UTILITY_REPORT_SKU": "RHT1234PL",
         "METRICS_UTILITY_REPORT_SKU_DESCRIPTION": "EX: Red Hat Satellite, Standard Support (1 Node, Monthly)",

--- a/metrics_utility/test/snapshot_tests/snapshot_utils.py
+++ b/metrics_utility/test/snapshot_tests/snapshot_utils.py
@@ -189,7 +189,7 @@ def run_snapshot_definition(data: DataShape) -> str:
         return generated_file
 
     # Regular expression to capture the file path if get_file_name was not able to compute it
-    pattern = r'Report generated into directory:\s*([\w\-/]+)\.xlsx'
+    pattern = r'Report generated into directory:\s*(.+)\.xlsx'
 
     match = re.search(pattern, text)
     if match:

--- a/metrics_utility/test/snapshot_tests/snapshot_utils.py
+++ b/metrics_utility/test/snapshot_tests/snapshot_utils.py
@@ -189,11 +189,11 @@ def run_snapshot_definition(data: DataShape) -> str:
         return generated_file
 
     # Regular expression to capture the file path if get_file_name was not able to compute it
-    pattern = r'Report generated into directory:\s*(.+)\.xlsx'
+    pattern = r'Report generated into directory: (.*\.xlsx)'
 
     match = re.search(pattern, text)
     if match:
-        return match.group(1) + '.xlsx'
+        return match.group(1)
 
     return ''
 


### PR DESCRIPTION
Issue: [AAP-39227](https://issues.redhat.com/browse/AAP-39227)
Follows #72

This enables pytest,
updates test paths to be relative to metrics utility root,
and updates snapshots to match these paths.
Also allows more characters in paths for the snapshot util - such as `./`
And renames complex_test_... to test_complex_... to make pytest find it.
And mentions how to run the tests in the README.

After this, tests can run the same way on CI & locally with docker compose.
Both `.github/workflows/pytest.yml` and `tools/docker/docker-compose.yaml` do similar setup for postgres & minio,
the github version doesn't need quay login (and uses github caches), the compose version does (`docker login quay.io`). 