### PR TITLE
Tweak sonar duplication checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,5 +30,5 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
 # Only scan with python3
 sonar.python.version=3.11,3.12
 
-# Ignore code dupe for the migrations
-sonar.cpd.exclusions=**/migrations/*.py
+# Ignore code dupe for the migrations, tests and xlsx report definitions
+sonar.cpd.exclusions=**/migrations/*.py,**/test/**/*.py,**/report/*.py


### PR DESCRIPTION
/test dir should be ignored, since tests are supposer to be duplicated since tests are not supposed to follow DRY principle

/report dir will be ignored now, since DSL for creating sheets has duplicate code
