### PR TITLE
s3 test: make sure upload succeeds

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,5 +81,6 @@ jobs:
           METRICS_UTILITY_BUCKET_NAME: "metricsutilitys3"
           METRICS_UTILITY_BUCKET_REGION: "us-east-1"
           METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
+          METRICS_UTILITY_DB_HOST: "localhost"
         run: |
           uv run pytest -s -v

--- a/metrics_utility/test/gather/test_s3_gather.py
+++ b/metrics_utility/test/gather/test_s3_gather.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+import subprocess
+import sys
+
+env_vars = {
+    'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'myuseraccesskey',
+    'METRICS_UTILITY_BUCKET_ENDPOINT': os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', 'http://localhost:9000'),  # or http://minio:9000
+    'METRICS_UTILITY_BUCKET_NAME': 'metricsutilitys3',
+    'METRICS_UTILITY_BUCKET_REGION': 'us-east-1',
+    'METRICS_UTILITY_BUCKET_SECRET_KEY': 'myusersecretkey',
+    'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
+    'METRICS_UTILITY_SHIP_PATH': 'metrics-utility/shipped_data',
+    'METRICS_UTILITY_SHIP_TARGET': 's3',
+    'AWX_LOGGING_MODE': 'stdout',
+}
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_command():
+    """Build xlsx report using build command and test its contents."""
+
+    python_executable = sys.executable
+    result = subprocess.run(
+        [python_executable, 'manage.py', 'gather_automation_controller_billing_data', '--ship', '--until=10m', '--force'],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env_vars,
+    )
+
+    assert result.returncode == 0
+
+    # mc ls -r local/metricsutilitys3/metrics-utility/shipped_data/data/

--- a/mock_awx/settings/__init__.py
+++ b/mock_awx/settings/__init__.py
@@ -1,10 +1,12 @@
+import os
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'awx',
         'USER': 'myuser',
         'PASSWORD': 'mypassword',
-        'HOST': 'localhost',
+        'HOST': os.getenv('METRICS_UTILITY_DB_HOST', 'localhost'),
         'PORT': '5432',
     }
 }

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -113,10 +113,6 @@ services:
       METRICS_UTILITY_BUCKET_NAME: "metricsutilitys3"
       METRICS_UTILITY_BUCKET_REGION: "us-east-1"
       METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
-      METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS: "jobs,managed_nodes,usage_by_organizations,managed_nodes_by_organizations"
-      METRICS_UTILITY_REPORT_TYPE: "CCSPv2"
-      METRICS_UTILITY_SHIP_PATH: "metrics-utility/shipped_data"
-      METRICS_UTILITY_SHIP_TARGET: "s3"
     entrypoint: |
       sh -c '
         set -e

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -77,6 +77,7 @@ services:
       METRICS_UTILITY_BUCKET_NAME: "metricsutilitys3"
       METRICS_UTILITY_BUCKET_REGION: "us-east-1"
       METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
+      METRICS_UTILITY_DB_HOST: "postgres"
     entrypoint: |
       sh -c '
         set -e
@@ -113,6 +114,7 @@ services:
       METRICS_UTILITY_BUCKET_NAME: "metricsutilitys3"
       METRICS_UTILITY_BUCKET_REGION: "us-east-1"
       METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
+      METRICS_UTILITY_DB_HOST: "postgres"
     entrypoint: |
       sh -c '
         set -e


### PR DESCRIPTION
Issue: AAP-38819, AAP-39221, AAP-41884

Add a bare s3 test that just tests the s3 upload didn't fail.

And make DB host configurable by setting `METRICS_UTILITY_DB_HOST`, add to compose envs & ci.

---

|env|METRICS_UTILITY_BUCKET_ENDPOINT|METRICS_UTILITY_DB_HOST|
|-|-|-|
|bare|none, `http://localhost:9000` default|none, `localhost` default|
|github|`http://localhost:9000`|`localhost`|
|compose|`http://minio:9000`|`postgres`|