### PR TITLE
AAP-41409 - Data generator script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+help:
+	@echo help sync test coverage lint fix
+
+sync:
+	uv run sync
+
+test:
+	uv run pytest -s -v
+
+coverage:
+	uv run pytest -s -v --cov=. --cov-report=html
+
+lint:
+	uv run ruff check
+	uv run ruff format --check
+
+fix:
+	uv run ruff check --fix
+	uv run ruff format
+
+.PHONY: help sync test coverage lint fix

--- a/generator.py
+++ b/generator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import datetime
 import glob
 import io
@@ -139,9 +140,13 @@ def process_tarballs(path, temp_dir, enabled_set):
 
 class Main:
     def __init__(self):
-        self.set_config()
+        self.parse_env()
+        self.parse_args()
 
-    def set_config(self):
+        if self.verbose:
+            print('config', vars(self))
+
+    def parse_env(self):
         year = datetime.datetime.now(tz=datetime.timezone.utc).year
 
         # data_collection_status = ()
@@ -177,7 +182,33 @@ class Main:
             filter(bool, os.getenv('SELECTED_DATA', 'job_host_summary,main_host,main_indirectmanagednodeaudit,main_jobevent').split(','))
         )
 
-        print('config', vars(self))
+    def parse_args(self):
+        parser = argparse.ArgumentParser(
+            prog='generator',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="""
+Environment vars:
+    MAIN_JOBHOSTSUMMARY_SIZE (default: 10000)
+    MAIN_JOBHOSTSUMMARY_UNIQUE_SIZE (default: 2000)
+    MAIN_HOST_SIZE (default: 10000)
+    MAIN_HOST_UNIQUE_SIZE (default: 2000)
+    MAIN_INDIRECT_SIZE (default: 10000)
+    MAIN_INDIRECT_UNIQUE_SIZE (default: 2000)
+    MAIN_JOBEVENT_SIZE (default: 10000)
+    MAIN_JOBEVENT_UNIQUE_SIZE (default: 2000)
+    SOURCE_DATA_PATH (default: ./metrics_utility/test/test_data/data/{year}/**/*.tar.gz)
+    OUTPUT_DATA_PATH (default: ./metrics_utility/test/test_data/data/)
+    INPUT_DATE_FROM (default: lastyear-01-01)
+    INPUT_DATE_TO (default: year-01-01)
+    OUTPUT_DATE_FROM (default: year-01-01)
+    OUTPUT_DATE_TO (default: nextyear-01-01)
+    SELECTED_DATA (default: job_host_summary,main_host,main_indirectmanagednodeaudit,main_jobevent)
+        """,
+        )
+        parser.add_argument('-v', '--verbose', action='store_true')
+        args = parser.parse_args()
+
+        self.verbose = args.verbose
 
     def concat(self, name, data):
         if name not in self.selected:
@@ -194,10 +225,12 @@ class Main:
 
     def load(self):
         self.loaded = dict((s, None) for s in self.selected)
-        print('loaded', self.loaded)
+        if self.verbose:
+            print('loaded', self.loaded)
 
         tarballs = glob.glob(self.source_tarballs, recursive=True)
-        print('tarballs', tarballs)
+        if self.verbose:
+            print('tarballs', tarballs)
 
         for file in tarballs:
             with tempfile.TemporaryDirectory(prefix='metrics-generator') as temp_dir:
@@ -208,7 +241,8 @@ class Main:
                 self.concat('main_indirectmanagednodeaudit', data['indirect_nodes'])
                 self.concat('main_jobevent', data['main_jobevent'])
 
-        print('loaded', self.loaded)
+        if self.verbose:
+            print('loaded', self.loaded)
 
     def save(self):
         target = pathlib.Path(self.output_data_path).joinpath(self.output_to.strftime('%Y/%m/%d'))
@@ -239,10 +273,12 @@ class Main:
             out = data_collection_status_data(self.selected, self.output_from, self.output_to)
             self.add_to_tar('data_collection_status.csv', out, tar, self.output_to)
 
-        print(f'created {filename}')
+        if self.verbose:
+            print(f'created {filename}')
 
     def add_to_tar(self, filename, content, tar, timestamp):
-        print(filename, content.to_csv(index=False))
+        if self.verbose:
+            print(filename, content.to_csv(index=False))
 
         buf = content.to_csv(index=False).encode('utf-8')
         info = tarfile.TarInfo(f'./{filename}')

--- a/generator.py
+++ b/generator.py
@@ -40,27 +40,32 @@ playful proud quick quiet shiny strong swift thoughtful vibrant warm witty'
     return f'{adjective}-{noun}-{number}'
 
 
-# repeat each line enough times we reach target_size
 def rule_multiply(df, target_size):
+    """repeat each line enough times we reach target_size"""
     return df.loc[np.repeat(df.index, math.ceil(target_size / len(df)))].reset_index(drop=True)
 
 
-# change each field to a random date between from, to
+def rule_crop(df, target_size):
+    """remove every row after target_size"""
+    return df.loc[: (target_size - 1)]
+
+
 def rule_dates(df, fields, output_from, output_to):
+    """change each field to a random date between from, to"""
     for f in fields:
         df[f] = df[f].apply(lambda _old: random_date(output_from, output_to))
     return df
 
 
-# change each field to a sequential number
 def rule_ids(df, fields):
+    """change each field to a sequential number"""
     for f in fields:
         df[f] = range(len(df))
     return df
 
 
-# change each field to a random hostname-like string
 def rule_hostname(df, fields):
+    """change each field to a random hostname-like string"""
     for f in fields:
         df[f] = df[f].apply(lambda _old: random_hostname())
     return df
@@ -71,6 +76,7 @@ def job_host_summary_data(df, config, output_from, output_to):
     df = rule_multiply(df, config[1])  # unique
     df = rule_hostname(df, ['host_name'])
     df = rule_multiply(df, config[0])  # total
+    df = rule_crop(df, config[0])  # total
     df = rule_ids(df, ['id'])
     df = rule_dates(df, ['created', 'modified', 'job_created'], output_from, output_to)
     return df
@@ -81,6 +87,7 @@ def main_host_data(df, config, output_from, output_to):
     df = rule_multiply(df, config[1])  # unique
     df = rule_hostname(df, ['host_name'])
     df = rule_multiply(df, config[0])  # total
+    df = rule_crop(df, config[0])  # total
     df = rule_ids(df, ['host_id'])
     df = rule_dates(df, ['last_automation'], output_from, output_to)
     return df
@@ -91,6 +98,7 @@ def main_indirectmanagednodeaudit_data(df, config, output_from, output_to):
     df = rule_multiply(df, config[1])  # unique
     df = rule_hostname(df, ['host_name'])
     df = rule_multiply(df, config[0])  # total
+    df = rule_crop(df, config[0])  # total
     df = rule_ids(df, ['id'])
     df = rule_dates(df, ['created', 'job_created'], output_from, output_to)
     return df
@@ -101,6 +109,7 @@ def main_jobevent_data(df, config, output_from, output_to):
     df = rule_multiply(df, config[1])  # unique
     df = rule_hostname(df, ['host_name'])
     df = rule_multiply(df, config[0])  # total
+    df = rule_crop(df, config[0])  # total
     df = rule_ids(df, ['main_jobhostsummary_id'])
     df = rule_dates(df, ['main_jobhostsummary_created', 'created', 'modified', 'job_created'], output_from, output_to)
     return df

--- a/generator.py
+++ b/generator.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 import datetime
 import glob
+import io
 import math
 import numpy as np
 import os
 import pandas as pd
+import pathlib
 import random
+import tarfile
 import tempfile
 from metrics_utility.automation_controller_billing.extract.extractor_common import process_tarballs
 
@@ -22,15 +25,14 @@ def random_date(earliest, latest):
 
 
 def random_hostname():
-    nouns = 'armadillo axolotl badger beetle bison buffalo capybara caribou cassowary chameleon cheetah cobra coyote dolphin eagle elephant falcon ferret flamingo fox gazelle giraffe hippo ibex jaguar kangaroo koala lemur leopard lynx macaw meerkat narwhal octopus orangutan otter owl panda panther peacock pelican penguin pigeon puma rabbit raven rhino sparrow tiger toucan turtle whale wolf wombat zebra'.split(
-        ' '
-    )
-    adjectives = 'bold brave bright calm cheerful clever eager gentle graceful happy honest jolly kind lively lucky merry nice noble peaceful playful proud quick quiet shiny strong swift thoughtful vibrant warm witty'.split(
-        ' '
-    )
+    nouns = 'armadillo axolotl badger beetle bison buffalo capybara caribou cassowary chameleon cheetah cobra coyote dolphin eagle elephant falcon \
+ferret flamingo fox gazelle giraffe hippo ibex jaguar kangaroo koala lemur leopard lynx macaw meerkat narwhal octopus orangutan otter owl panda \
+panther peacock pelican penguin pigeon puma rabbit raven rhino sparrow tiger toucan turtle whale wolf wombat zebra'
+    adjectives = 'bold brave bright calm cheerful clever eager gentle graceful happy honest jolly kind lively lucky merry nice noble peaceful \
+playful proud quick quiet shiny strong swift thoughtful vibrant warm witty'
 
-    adjective = random.choice(adjectives)
-    noun = random.choice(nouns)
+    adjective = random.choice(adjectives.split(' '))
+    noun = random.choice(nouns.split(' '))
     number = random.randint(100, 999)
 
     return f'{adjective}-{noun}-{number}'
@@ -147,6 +149,7 @@ class Main:
 
         # source tarball glob
         self.source_tarballs = os.getenv('SOURCE_DATA_PATH', f'./metrics_utility/test/test_data/data/{year}/**/*.tar.gz')
+        self.output_data_path = os.getenv('OUTPUT_DATA_PATH', './metrics_utility/test/test_data/data/')
 
         # input and output date range
         self.input_from = parse_date(os.getenv('INPUT_DATE_FROM', f'{year - 1}-01-01'))
@@ -193,24 +196,44 @@ class Main:
         print('loaded', self.loaded)
 
     def save(self):
-        if 'job_host_summary' in self.loaded:
-            out = job_host_summary_data(self.loaded['job_host_summary'], self.job_host_summary, self.output_from, self.output_to)
-            print('job_host_summary.csv', out.to_csv(index=False))
-        if 'main_host' in self.loaded:
-            out = main_host_data(self.loaded['main_host'], self.main_host, self.output_from, self.output_to)
-            print('main_host.csv', out.to_csv(index=False))
-        if 'main_indirectmanagednodeaudit' in self.loaded:
-            out = main_indirectmanagednodeaudit_data(
-                self.loaded['main_indirectmanagednodeaudit'], self.main_indirectmanagednodeaudit, self.output_from, self.output_to
-            )
-            print('main_indirectmanagednodeaudit.csv', out.to_csv(index=False))
-        if 'main_jobevent' in self.loaded:
-            out = main_jobevent_data(self.loaded['main_jobevent'], self.main_jobevent, self.output_from, self.output_to)
-            print('main_jobevent.csv', out.to_csv(index=False))
-        # always
-        out = data_collection_status_data(self.selected, self.output_from, self.output_to)
-        print('data_collection_status.csv', out.to_csv(index=False))
-        # TODO: tar.add
+        target = pathlib.Path(self.output_data_path).joinpath(self.output_to.strftime('%Y/%m/%d'))
+        os.makedirs(target, exist_ok=True)
+
+        uuid = '00000000-0000-0000-0000-000000000000'
+        name_base = f'{uuid}-{self.output_from.strftime("%Y-%m-%d-%H%M%S%z")}-{self.output_to.strftime("%Y-%m-%d-%H%M%S%z")}'
+        index = len(list(target.glob(f'{name_base}-*.*')))
+        tarname = f'{name_base}-{index}.tar.gz'
+
+        filename = target.joinpath(tarname)
+        with tarfile.open(filename, 'w:gz') as tar:
+            if 'job_host_summary' in self.loaded:
+                out = job_host_summary_data(self.loaded['job_host_summary'], self.job_host_summary, self.output_from, self.output_to)
+                self.add_to_tar('job_host_summary.csv', out, tar, self.output_to)
+            if 'main_host' in self.loaded:
+                out = main_host_data(self.loaded['main_host'], self.main_host, self.output_from, self.output_to)
+                self.add_to_tar('main_host.csv', out, tar, self.output_to)
+            if 'main_indirectmanagednodeaudit' in self.loaded:
+                out = main_indirectmanagednodeaudit_data(
+                    self.loaded['main_indirectmanagednodeaudit'], self.main_indirectmanagednodeaudit, self.output_from, self.output_to
+                )
+                self.add_to_tar('main_indirectmanagednodeaudit.csv', out, tar, self.output_to)
+            if 'main_jobevent' in self.loaded:
+                out = main_jobevent_data(self.loaded['main_jobevent'], self.main_jobevent, self.output_from, self.output_to)
+                self.add_to_tar('main_jobevent.csv', out, tar, self.output_to)
+            # always
+            out = data_collection_status_data(self.selected, self.output_from, self.output_to)
+            self.add_to_tar('data_collection_status.csv', out, tar, self.output_to)
+
+        print(f'created {filename}')
+
+    def add_to_tar(self, filename, content, tar, timestamp):
+        print(filename, content.to_csv(index=False))
+
+        buf = content.to_csv(index=False).encode('utf-8')
+        info = tarfile.TarInfo(f'./{filename}')
+        info.size = len(buf)
+        info.mtime = timestamp.timestamp()
+        tar.addfile(info, fileobj=io.BytesIO(buf))
 
 
 if __name__ == '__main__':

--- a/generator.py
+++ b/generator.py
@@ -237,7 +237,11 @@ Environment vars:
         if self.verbose:
             print('loaded', self.loaded)
 
-        tarballs = glob.glob(self.source_tarballs, recursive=True)
+        if os.path.isdir(self.source_tarballs):
+            tarballs = glob.glob(os.path.join(self.source_tarballs, '**/*.tar.gz'), recursive=True)
+        else:
+            tarballs = glob.glob(self.source_tarballs, recursive=True)
+
         if self.verbose:
             print('tarballs', tarballs)
 

--- a/generator.py
+++ b/generator.py
@@ -249,6 +249,7 @@ Environment vars:
                 self.concat('main_host', data['main_host'])
                 self.concat('main_indirectmanagednodeaudit', data['indirect_nodes'])
                 self.concat('main_jobevent', data['main_jobevent'])
+                self.config_json = data['config']
 
         if self.verbose:
             print('loaded', self.loaded)
@@ -266,30 +267,37 @@ Environment vars:
         with tarfile.open(filename, 'w:gz') as tar:
             if 'job_host_summary' in self.loaded:
                 out = job_host_summary_data(self.loaded['job_host_summary'], self.job_host_summary, self.output_from, self.output_to)
-                self.add_to_tar('job_host_summary.csv', out, tar, self.output_to)
+                self.csv_to_tar('job_host_summary.csv', out, tar, self.output_to)
             if 'main_host' in self.loaded:
                 out = main_host_data(self.loaded['main_host'], self.main_host, self.output_from, self.output_to)
-                self.add_to_tar('main_host.csv', out, tar, self.output_to)
+                self.csv_to_tar('main_host.csv', out, tar, self.output_to)
             if 'main_indirectmanagednodeaudit' in self.loaded:
                 out = main_indirectmanagednodeaudit_data(
                     self.loaded['main_indirectmanagednodeaudit'], self.main_indirectmanagednodeaudit, self.output_from, self.output_to
                 )
-                self.add_to_tar('main_indirectmanagednodeaudit.csv', out, tar, self.output_to)
+                self.csv_to_tar('main_indirectmanagednodeaudit.csv', out, tar, self.output_to)
             if 'main_jobevent' in self.loaded:
                 out = main_jobevent_data(self.loaded['main_jobevent'], self.main_jobevent, self.output_from, self.output_to)
-                self.add_to_tar('main_jobevent.csv', out, tar, self.output_to)
+                self.csv_to_tar('main_jobevent.csv', out, tar, self.output_to)
             # always
             out = data_collection_status_data(self.selected, self.output_from, self.output_to)
-            self.add_to_tar('data_collection_status.csv', out, tar, self.output_to)
+            self.csv_to_tar('data_collection_status.csv', out, tar, self.output_to)
+            self.json_to_tar('config.json', self.config_json, tar, self.output_to)
 
         if self.verbose:
             print(f'created {filename}')
 
+    def csv_to_tar(self, filename, content, tar, timestamp):
+        return self.add_to_tar(filename, content.to_csv(index=False), tar, timestamp)
+
+    def json_to_tar(self, filename, content, tar, timestamp):
+        return self.add_to_tar(filename, json.dumps(content), tar, timestamp)
+
     def add_to_tar(self, filename, content, tar, timestamp):
         if self.verbose:
-            print(filename, content.to_csv(index=False))
+            print(filename, content)
 
-        buf = content.to_csv(index=False).encode('utf-8')
+        buf = content.encode('utf-8')
         info = tarfile.TarInfo(f'./{filename}')
         info.size = len(buf)
         info.mtime = timestamp.timestamp()

--- a/generator.py
+++ b/generator.py
@@ -2,6 +2,7 @@
 import datetime
 import glob
 import io
+import json
 import math
 import numpy as np
 import os
@@ -10,7 +11,7 @@ import pathlib
 import random
 import tarfile
 import tempfile
-from metrics_utility.automation_controller_billing.extract.extractor_common import process_tarballs
+from metrics_utility.automation_controller_billing.extract.base import Base
 
 
 def parse_date(str):
@@ -120,6 +121,20 @@ def data_collection_status_data(selected, output_from, output_to):
             )
         )
     )
+
+
+def process_tarballs(path, temp_dir, enabled_set):
+    class ProcessTarballs(Base):
+        # load config.json
+        def load_config(self, file_path):
+            with open(file_path) as f:
+                return json.loads(f.read())
+
+        # extract csv based on generator SELECTED_DATA
+        def csv_enabled(self, name):
+            return name in enabled_set
+
+    return ProcessTarballs().process_tarballs(path, temp_dir)
 
 
 class Main:

--- a/generator.py
+++ b/generator.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+import datetime
+import glob
+import math
+import numpy as np
+import os
+import pandas as pd
+import random
+import tempfile
+from metrics_utility.automation_controller_billing.extract.extractor_common import process_tarballs
+
+
+def parse_date(str):
+    return datetime.datetime.fromisoformat(str).astimezone(datetime.timezone.utc)
+
+
+def random_date(earliest, latest):
+    tsmin = earliest.timestamp()
+    tsmax = latest.timestamp()
+    rand = tsmin + (random.random() * (tsmax - tsmin))
+    return datetime.datetime.fromtimestamp(rand, tz=datetime.timezone.utc)
+
+
+def random_hostname():
+    nouns = 'armadillo axolotl badger beetle bison buffalo capybara caribou cassowary chameleon cheetah cobra coyote dolphin eagle elephant falcon ferret flamingo fox gazelle giraffe hippo ibex jaguar kangaroo koala lemur leopard lynx macaw meerkat narwhal octopus orangutan otter owl panda panther peacock pelican penguin pigeon puma rabbit raven rhino sparrow tiger toucan turtle whale wolf wombat zebra'.split(
+        ' '
+    )
+    adjectives = 'bold brave bright calm cheerful clever eager gentle graceful happy honest jolly kind lively lucky merry nice noble peaceful playful proud quick quiet shiny strong swift thoughtful vibrant warm witty'.split(
+        ' '
+    )
+
+    adjective = random.choice(adjectives)
+    noun = random.choice(nouns)
+    number = random.randint(100, 999)
+
+    return f'{adjective}-{noun}-{number}'
+
+
+# repeat each line enough times we reach target_size
+def rule_multiply(df, target_size):
+    return df.loc[np.repeat(df.index, math.ceil(target_size / len(df)))].reset_index(drop=True)
+
+
+# change each field to a random date between from, to
+def rule_dates(df, fields, output_from, output_to):
+    for f in fields:
+        df[f] = df[f].apply(lambda _old: random_date(output_from, output_to))
+    return df
+
+
+# change each field to a sequential number
+def rule_ids(df, fields):
+    for f in fields:
+        df[f] = range(len(df))
+    return df
+
+
+# change each field to a random hostname-like string
+def rule_hostname(df, fields):
+    for f in fields:
+        df[f] = df[f].apply(lambda _old: random_hostname())
+    return df
+
+
+# ? host_remote_id ? ansible_host_variable ?
+def job_host_summary_data(df, config, output_from, output_to):
+    df = rule_multiply(df, config[1])  # unique
+    df = rule_hostname(df, ['host_name'])
+    df = rule_multiply(df, config[0])  # total
+    df = rule_ids(df, ['id'])
+    df = rule_dates(df, ['created', 'modified', 'job_created'], output_from, output_to)
+    return df
+
+
+# ? ansible_host_variable ? canonical_facts ? facts ?
+def main_host_data(df, config, output_from, output_to):
+    df = rule_multiply(df, config[1])  # unique
+    df = rule_hostname(df, ['host_name'])
+    df = rule_multiply(df, config[0])  # total
+    df = rule_ids(df, ['host_id'])
+    df = rule_dates(df, ['last_automation'], output_from, output_to)
+    return df
+
+
+# ? host_remote_id ? canonical_facts ? facts ?
+def main_indirectmanagednodeaudit_data(df, config, output_from, output_to):
+    df = rule_multiply(df, config[1])  # unique
+    df = rule_hostname(df, ['host_name'])
+    df = rule_multiply(df, config[0])  # total
+    df = rule_ids(df, ['id'])
+    df = rule_dates(df, ['created', 'job_created'], output_from, output_to)
+    return df
+
+
+# ? main_jobhostsummary_id ?
+def main_jobevent_data(df, config, output_from, output_to):
+    df = rule_multiply(df, config[1])  # unique
+    df = rule_hostname(df, ['host_name'])
+    df = rule_multiply(df, config[0])  # total
+    df = rule_ids(df, ['main_jobhostsummary_id'])
+    df = rule_dates(df, ['main_jobhostsummary_created', 'created', 'modified', 'job_created'], output_from, output_to)
+    return df
+
+
+def data_collection_status_data(selected, output_from, output_to):
+    return pd.DataFrame(
+        list(
+            map(
+                lambda file: {
+                    'collection_start_timestamp': datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+                    'since': output_from.isoformat(),
+                    'until': output_to.isoformat(),
+                    'file_name': f'{file}.csv',
+                    'status': 'ok',
+                    'elapsed': str(int((output_to - output_from).total_seconds())),
+                },
+                selected,
+            )
+        )
+    )
+
+
+class Main:
+    def __init__(self):
+        self.set_config()
+
+    def set_config(self):
+        year = datetime.datetime.now(tz=datetime.timezone.utc).year
+
+        # data_collection_status = ()
+        self.job_host_summary = (
+            int(os.getenv('MAIN_JOBHOSTSUMMARY_SIZE', '10000')),
+            int(os.getenv('MAIN_JOBHOSTSUMMARY_UNIQUE_SIZE', '2000')),
+        )
+        self.main_host = (
+            int(os.getenv('MAIN_HOST_SIZE', '10000')),
+            int(os.getenv('MAIN_HOST_UNIQUE_SIZE', '2000')),
+        )
+        self.main_indirectmanagednodeaudit = (
+            int(os.getenv('MAIN_INDIRECT_SIZE', '10000')),
+            int(os.getenv('MAIN_INDIRECT_UNIQUE_SIZE', '2000')),
+        )
+        self.main_jobevent = (
+            int(os.getenv('MAIN_JOBEVENT_SIZE', '10000')),
+            int(os.getenv('MAIN_JOBEVENT_UNIQUE_SIZE', '2000')),
+        )
+
+        # source tarball glob
+        self.source_tarballs = os.getenv('SOURCE_DATA_PATH', f'./metrics_utility/test/test_data/data/{year}/**/*.tar.gz')
+
+        # input and output date range
+        self.input_from = parse_date(os.getenv('INPUT_DATE_FROM', f'{year - 1}-01-01'))
+        self.input_to = parse_date(os.getenv('INPUT_DATE_TO', f'{year}-01-01'))
+        self.output_from = parse_date(os.getenv('OUTPUT_DATE_FROM', f'{year}-01-01'))
+        self.output_to = parse_date(os.getenv('OUTPUT_DATE_TO', f'{year + 1}-01-01'))
+
+        # csvs to expand
+        self.selected = set(
+            filter(bool, os.getenv('SELECTED_DATA', 'job_host_summary,main_host,main_indirectmanagednodeaudit,main_jobevent').split(','))
+        )
+
+        print('config', vars(self))
+
+    def concat(self, name, data):
+        if name not in self.selected:
+            return
+
+        if data.empty:
+            return
+
+        if self.loaded[name] is None:
+            self.loaded[name] = data
+            return
+
+        self.loaded[name] = pd.concat([self.loaded[name], data], ignore_index=True)
+
+    def load(self):
+        self.loaded = dict((s, None) for s in self.selected)
+        print('loaded', self.loaded)
+
+        tarballs = glob.glob(self.source_tarballs, recursive=True)
+        print('tarballs', tarballs)
+
+        for file in tarballs:
+            with tempfile.TemporaryDirectory(prefix='metrics-generator') as temp_dir:
+                data = process_tarballs(file, temp_dir, enabled_set=self.selected)
+
+                self.concat('job_host_summary', data['job_host_summary'])
+                self.concat('main_host', data['main_host'])
+                self.concat('main_indirectmanagednodeaudit', data['indirect_nodes'])
+                self.concat('main_jobevent', data['main_jobevent'])
+
+        print('loaded', self.loaded)
+
+    def save(self):
+        if 'job_host_summary' in self.loaded:
+            out = job_host_summary_data(self.loaded['job_host_summary'], self.job_host_summary, self.output_from, self.output_to)
+            print('job_host_summary.csv', out.to_csv(index=False))
+        if 'main_host' in self.loaded:
+            out = main_host_data(self.loaded['main_host'], self.main_host, self.output_from, self.output_to)
+            print('main_host.csv', out.to_csv(index=False))
+        if 'main_indirectmanagednodeaudit' in self.loaded:
+            out = main_indirectmanagednodeaudit_data(
+                self.loaded['main_indirectmanagednodeaudit'], self.main_indirectmanagednodeaudit, self.output_from, self.output_to
+            )
+            print('main_indirectmanagednodeaudit.csv', out.to_csv(index=False))
+        if 'main_jobevent' in self.loaded:
+            out = main_jobevent_data(self.loaded['main_jobevent'], self.main_jobevent, self.output_from, self.output_to)
+            print('main_jobevent.csv', out.to_csv(index=False))
+        # always
+        out = data_collection_status_data(self.selected, self.output_from, self.output_to)
+        print('data_collection_status.csv', out.to_csv(index=False))
+        # TODO: tar.add
+
+
+if __name__ == '__main__':
+    main = Main()
+    main.load()
+    main.save()

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -3,6 +3,38 @@ import os
 import tarfile
 
 
+CSV_SHEETS = {
+    'job_host_summary': [
+        'ccsp_summary',
+        'indirectly_managed_nodes',
+        'inventory_scope',
+        'managed_nodes',
+        'managed_nodes_by_organizations',
+        'usage_by_organizations',
+    ],
+    'main_host': [
+        'inventory_scope',
+        'jobs',
+        'managed_nodes',
+        'managed_nodes_by_organizations',
+        'usage_by_collections',
+        'usage_by_modules',
+        'usage_by_roles',
+    ],
+    'main_indirectmanagednodeaudit': [
+        'indirectly_managed_nodes',
+        'managed_nodes',
+        'usage_by_organizations',
+    ],
+    'main_jobevent': [
+        'usage_by_collections',
+        'usage_by_modules',
+        'usage_by_organizations',
+        'usage_by_roles',
+    ],
+}
+
+
 class Base:
     def process_tarballs(self, path, temp_dir):
         _safe_extract(path, temp_dir)
@@ -22,35 +54,17 @@ class Base:
             'main_jobevent': empty_dataframe,
             'main_host': empty_dataframe,
         }
-        if self.required_sheets(
-            [
-                'ccsp_summary',
-                'managed_nodes',
-                'indirectly_managed_nodes',
-                'inventory_scope',
-                'usage_by_organizations',
-                'managed_nodes_by_organizations',
-            ]
-        ):
+
+        if self.csv_enabled('job_host_summary'):
             needed_data['job_host_summary'] = self.build_data_batch(temp_dir, 'job_host_summary')
 
-        if self.required_sheets(['managed_nodes', 'indirectly_managed_nodes', 'usage_by_organizations']):
+        if self.csv_enabled('main_indirectmanagednodeaudit'):
             needed_data['indirect_nodes'] = self.build_data_batch(temp_dir, 'main_indirectmanagednodeaudit')
 
-        if self.required_sheets(['usage_by_collections', 'usage_by_roles', 'usage_by_modules', 'usage_by_organizations']):
+        if self.csv_enabled('main_jobevent'):
             needed_data['main_jobevent'] = self.build_data_batch(temp_dir, 'main_jobevent')
 
-        if self.required_sheets(
-            [
-                'jobs',
-                'managed_nodes_by_organizations',
-                'managed_nodes',
-                'inventory_scope',
-                'usage_by_collections',
-                'usage_by_modules',
-                'managed_nodes',
-            ]
-        ):
+        if self.csv_enabled('main_host'):
             needed_data['main_host'] = self.build_data_batch(temp_dir, 'main_host')
 
         return needed_data
@@ -65,7 +79,11 @@ class Base:
         else:
             return pd.DataFrame([{}])
 
-    def required_sheets(self, sheets_required):
+    def csv_enabled(self, name):
+        """Enable CSV extraction based on list of rendered sheets"""
+        return self.sheet_enabled(CSV_SHEETS[name])
+
+    def sheet_enabled(self, sheets_required):
         """
         Checks for METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS values and return those values.
         If none found, give it the default CCSP report sheet options.


### PR DESCRIPTION
Issue: AAP-41409 (related to AAP-41410)

Adds `generator.py`: generate new csv by multiplying rows and applying rules
    
* loads all tarballs from a `SOURCE_DATA_PATH` glob
* loads all csvs in `SELECTED_DATA` (comma-separated list) (and last `config.json`)
* concatenates the data from all tarballs together (each kind of csv as one dataframe)
* for each table
   * repeats each row until there are at least `MAIN_{JOBHOSTSUMMARY,HOST,INDIRECT,JOBEVENT}_UNIQUE_SIZE` items
   * randomizes hostname fields
   * repeats each row until there are at least `MAIN_{JOBHOSTSUMMARY,HOST,INDIRECT,JOBEVENT}_SIZE` items
   * crops row count down to `MAIN_{JOBHOSTSUMMARY,HOST,INDIRECT,JOBEVENT}_SIZE` items
   * recomputes sequential ids
   * randomizes date fields, staying within an interval between `OUTPUT_DATE_FROM` and `OUTPUT_DATE_TO`
* converts back to csv
* saves to `OUTPUT_DATA_PATH` (`$OUTPUT_DATA_PATH/Y/M/D/*.tar.gz`)

(Supports `--help` to see the env var names, `--verbose` to see what's happening.)

(Doesn't know how to split tars, but, do we need to?)

---

```
$ uv run ./generator.py --help
usage: generator [-h] [-v]

options:
  -h, --help     show this help message and exit
  -v, --verbose

Environment vars:
    MAIN_JOBHOSTSUMMARY_SIZE (default: 10000)
    MAIN_JOBHOSTSUMMARY_UNIQUE_SIZE (default: 2000)
    MAIN_HOST_SIZE (default: 10000)
    MAIN_HOST_UNIQUE_SIZE (default: 2000)
    MAIN_INDIRECT_SIZE (default: 10000)
    MAIN_INDIRECT_UNIQUE_SIZE (default: 2000)
    MAIN_JOBEVENT_SIZE (default: 10000)
    MAIN_JOBEVENT_UNIQUE_SIZE (default: 2000)
    SOURCE_DATA_PATH (default: ./metrics_utility/test/test_data/data/{year}/**/*.tar.gz)
    OUTPUT_DATA_PATH (default: ./metrics_utility/test/test_data/data/)
    INPUT_DATE_FROM (default: lastyear-01-01)
    INPUT_DATE_TO (default: year-01-01)
    OUTPUT_DATE_FROM (default: year-01-01)
    OUTPUT_DATE_TO (default: nextyear-01-01)
    SELECTED_DATA (default: job_host_summary,main_host,main_indirectmanagednodeaudit,main_jobevent)
```

Example output: https://docs.google.com/spreadsheets/d/1ohWtDmgKOqRFDc1YWk545FRvITSbLg4S/edit?usp=sharing&ouid=112307144989328414652&rtpof=true&sd=true