### PR TITLE
Fixup combine_* function naming

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: "Pytest tests"
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   pytest:

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -133,11 +133,11 @@ class Base:
                 df[col] = df[[f'{col}_x', f'{col}_y']].min(axis=1)
             elif operations.get(col) == 'max':
                 df[col] = df[[f'{col}_x', f'{col}_y']].max(axis=1)
-            elif operations.get(col) == 'set_merge':
+            elif operations.get(col) == 'combine_set':
                 df[col] = df.apply(lambda row: combine_set(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
-            elif operations.get(col) == 'dict_merge':
+            elif operations.get(col) == 'combine_json':
                 df[col] = df.apply(lambda row: combine_json(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
-            elif operations.get(col) == 'dict_set_merge':
+            elif operations.get(col) == 'combine_json_values':
                 df[col] = df.apply(lambda row: combine_json_values(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
             else:
                 df[col] = df[[f'{col}_x', f'{col}_y']].sum(axis=1)

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
@@ -84,10 +84,10 @@ class DataframeInventoryScope(Base):
                         self.data_columns(),
                         operations={
                             'last_automation': 'max',
-                            'organizations': 'set_merge',
-                            'inventories': 'set_merge',
-                            'canonical_facts': 'dict_set_merge',
-                            'facts': 'dict_set_merge',
+                            'organizations': 'combine_set',
+                            'inventories': 'combine_set',
+                            'canonical_facts': 'combine_json_values',
+                            'facts': 'combine_json_values',
                         },
                     )
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -137,10 +137,10 @@ class DataframeJobhostSummaryUsage(Base):
                             'last_automation': 'max',
                             'job_created': 'max',
                             'managed_node_type': 'min',
-                            'manage_node_types': 'set_merge',
-                            'events': 'set_merge',
-                            'canonical_facts': 'dict_set_merge',
-                            'facts': 'dict_set_merge',
+                            'manage_node_types': 'combine_set',
+                            'events': 'combine_set',
+                            'canonical_facts': 'combine_json_values',
+                            'facts': 'combine_json_values',
                         },
                     )
 


### PR DESCRIPTION
Fixup function naming,
sync names `set_merge`,`dict_merge`,`dict_set_merge` -> `combine_set`,`combine_json`,`combine_json_values`
related to #78.