### PR TITLE
Start 0.4.2 changelog, fixup pglock import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,6 @@
 
 ## 0.4.1
 - relax boto3 requirement so it builds with any version available
+
+## 0.4.2 (unreleased)
+- allow importing pglock from either awx or django-ansible-base

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -2,8 +2,6 @@ import contextlib
 import json
 import logging
 
-import importlib.util
-
 import insights_analytics_collector as base
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -18,11 +18,12 @@ from metrics_utility.automation_controller_billing.package.factory import Factor
 
 from awx.main.utils import datetime_hook
 
-if importlib.util.find_spec('ansible_base') is None:
-    # 2.4
+# work around https://github.com/ansible/awx/pull/15676
+try:
+    # 2.4, early 2.5
     from awx.main.utils.pglock import advisory_lock
-else:
-    # 2.5
+except ImportError:
+    # later 2.5, 2.6
     from ansible_base.lib.utils.db import advisory_lock
 
 logger = logging.getLogger('metrics_utility.collector')

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -131,7 +131,7 @@ def config(since, **kwargs):
         'logging_aggregators': settings.LOG_AGGREGATOR_LOGGERS,
         'external_logger_enabled': settings.LOG_AGGREGATOR_ENABLED,
         'external_logger_type': getattr(settings, 'LOG_AGGREGATOR_TYPE', None),
-        'metrics_utility_version': '0.4.1',  # TODO read from setup.cfg
+        'metrics_utility_version': '0.4.2',  # TODO read from setup.cfg
         'billing_provider_params': {},  # Is being overwritten in collector.gather by set ENV VARS
     }
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -47,7 +47,7 @@ class ManagementUtility(management.ManagementUtility):
         # 'django-admin --help' to work, for backwards compatibility.
         elif subcommand == 'version' or self.argv[1:] == ['--version']:
             # sys.stdout.write(django.get_version() + "\n")
-            sys.stdout.write('0.4.1' + '\n')
+            sys.stdout.write('0.4.2' + '\n')
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.4.1
+version = 0.4.2
 
 [options]
 packages = find:


### PR DESCRIPTION
(Was #83, pre-rebase)

These are changes originally planned for a 0.4.2 release, which we didn't end up doing.
Porting these to current devel:

* starts a 0.4.2 (unreleased) changelog entry
* updates the versions everywhere
* fixes the `advisory_lock` import - checking for django-ansible-base is problematic in early 2.5 which has dab, but not a version with the change - just try/catch it

This should fix tests using 2.5 controller with nightly metrics util.