### PR TITLE
Tests - bump coverage by running simple tests in both modes

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -5,13 +5,15 @@ import glob
 import io
 import json
 import math
-import numpy as np
 import os
-import pandas as pd
 import pathlib
 import random
 import tarfile
 import tempfile
+
+import numpy as np
+import pandas as pd
+
 from metrics_utility.automation_controller_billing.extract.base import Base
 
 

--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -6,9 +6,7 @@ import sys
 from metrics_utility.management_utility import ManagementUtility
 
 
-def manage():
-    """Run a ManagementUtility."""
-
+def prepare():
     # Tries to find awx modules. They are either in venv, or can be configured through AWX_PATH ENV
     spec = importlib.util.find_spec('awx')
     if spec is None:
@@ -29,6 +27,11 @@ def manage():
 
     prepare_env()
     django.setup()
+
+
+def manage():
+    """Run a ManagementUtility."""
+    prepare()
 
     utility = ManagementUtility(sys.argv)
     utility.execute()

--- a/metrics_utility/test/ccspv_reports/conftest.py
+++ b/metrics_utility/test/ccspv_reports/conftest.py
@@ -1,24 +1,11 @@
 import os
 
-from contextlib import contextmanager
 from datetime import datetime
 
 import openpyxl
 import pytest
 
 from openpyxl import Workbook
-
-
-@contextmanager
-def temporary_env(new_env):
-    """Temporarily update os.environ with new_env."""
-    original = os.environ.copy()
-    os.environ.update(new_env)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(original)
 
 
 def validate_sheet_tab_names(file_path, expected_sheets):

--- a/metrics_utility/test/ccspv_reports/test_CCSP.py
+++ b/metrics_utility/test/ccspv_reports/test_CCSP.py
@@ -1,11 +1,10 @@
-import subprocess
-import sys
-
 from datetime import datetime
 
 import pytest
 
 from conftest import validate_sheet_columns, validate_sheet_tab_names
+
+from metrics_utility.test.util import run_build_ext, run_build_int
 
 
 env_vars = {
@@ -20,7 +19,6 @@ env_vars = {
     'METRICS_UTILITY_REPORT_SKU': 'MCT3752MO',
     'METRICS_UTILITY_REPORT_EMAIL': 'email@email.com',
     'METRICS_UTILITY_REPORT_TYPE': 'CCSP',
-    'AWX_LOGGING_MODE': 'stdout',
 }
 
 file_path = './metrics_utility/test/test_data/reports/2024/02/CCSP-2024-02.xlsx'
@@ -226,16 +224,29 @@ expected_sheets = {
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
-    python_executable = sys.executable
-    result = subprocess.run(
-        [python_executable, 'manage.py', 'build_report', '--month=2024-02', '--force'],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env_vars,
-    )
+    run_build_ext(env_vars, ['--month=2024-02', '--force'])
 
-    assert result.returncode == 0
+    validate_sheet_columns(file_path, expected_sheets, 14)
+    validate_sheet_tab_names(file_path, expected_sheets)
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+@pytest.mark.parametrize(
+    'cleanup',
+    [
+        file_path,
+    ],
+    indirect=True,
+)
+def test_import(cleanup):
+    # test_command doesn't collect coverage
+    run_build_int(
+        env_vars,
+        {
+            'month': '2024-02',
+            'force': True,
+        },
+    )
 
     validate_sheet_columns(file_path, expected_sheets, 14)
     validate_sheet_tab_names(file_path, expected_sheets)

--- a/metrics_utility/test/ccspv_reports/test_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_CCSPv2.py
@@ -1,11 +1,10 @@
-import subprocess
-import sys
-
 from datetime import datetime
 
 import pytest
 
 from conftest import validate_sheet_columns, validate_sheet_tab_names
+
+from metrics_utility.test.util import run_build_ext, run_build_int
 
 
 env_vars = {
@@ -24,7 +23,6 @@ env_vars = {
     'METRICS_UTILITY_REPORT_SKU': 'MCT3752MO',
     'METRICS_UTILITY_REPORT_EMAIL': 'email@email.com',
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
-    'AWX_LOGGING_MODE': 'stdout',
 }
 
 file_path = './metrics_utility/test/test_data/reports/2024/02/CCSPv2-2024-02.xlsx'
@@ -143,16 +141,30 @@ expected_sheets = {
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
-    python_executable = sys.executable
-    result = subprocess.run(
-        [python_executable, 'manage.py', 'build_report', '--month=2024-02', '--force'],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env_vars,
-    )
+    run_build_ext(env_vars, ['--month=2024-02', '--force'])
 
-    assert result.returncode == 0
+    validate_sheet_columns(file_path, expected_sheets, 6)
+    validate_sheet_tab_names(file_path, expected_sheets)
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+@pytest.mark.parametrize(
+    'cleanup',
+    [
+        file_path,
+    ],
+    indirect=True,
+)
+def test_import(cleanup):
+    """Build xlsx report using build command and test its contents."""
+
+    run_build_int(
+        env_vars,
+        {
+            'month': '2024-02',
+            'force': True,
+        },
+    )
 
     validate_sheet_columns(file_path, expected_sheets, 6)
     validate_sheet_tab_names(file_path, expected_sheets)

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
@@ -4,9 +4,9 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 # This test will run on all data, making sure we're backwards compatible and will generate all
@@ -36,20 +36,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2024-02-20',
             'until': '2025-03-02',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_indirect.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_indirect.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -34,20 +34,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-02-25',
             'until': '2025-02-26',
             'ephemeral': None,
             'force': True,
             'verbose': True,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_scope.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_scope.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -34,20 +34,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-03-01',
             'until': '2025-03-02',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -46,20 +46,16 @@ date_today = datetime.now().strftime('%b %d, %Y')
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-02-13',
             'until': '2025-02-13',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         workbook = openpyxl.load_workbook(filename=file_path)

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
@@ -4,9 +4,9 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 # This test will run on all data, making sure we're backwards compatible and will generate all
@@ -36,20 +36,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2024-02-20',
             'until': '2025-03-02',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_indirect.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_indirect.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -34,20 +34,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-02-25',
             'until': '2025-02-26',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_nodes_by_orgs.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_nodes_by_orgs.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import NaT, Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -33,21 +33,16 @@ date_today = datetime.now().strftime('%b %d, %Y')
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
-    # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-03-01',
             'until': '2025-03-02',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_scope.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_scope.py
@@ -4,10 +4,10 @@ import openpyxl
 import pandas
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -35,20 +35,16 @@ def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
 
     # Running a command python way, so we can work with debugger in the code
-    with temporary_env(env_vars):
-        options = {
+    run_build_int(
+        env_vars,
+        {
             'since': '2025-03-01',
             'until': '2025-03-02',
             'ephemeral': None,
             'force': True,
             'verbose': False,
-        }
-
-        # Instantiate your command
-        command = Command()
-
-        # Call the handle() method directly with the options.
-        command.handle(**options)
+        },
+    )
 
     try:
         # test workbook is openable with the lib we're creating it with

--- a/metrics_utility/test/gather/test_directory_gather.py
+++ b/metrics_utility/test/gather/test_directory_gather.py
@@ -1,18 +1,17 @@
 import glob
 import os
-import subprocess
-import sys
 
 from datetime import datetime
 
 import pytest
+
+from metrics_utility.test.util import run_gather_ext, run_gather_int
 
 
 env_vars = {
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
     'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
     'METRICS_UTILITY_SHIP_TARGET': 'directory',
-    'AWX_LOGGING_MODE': 'stdout',
 }
 
 year = datetime.now().strftime('%Y')
@@ -36,15 +35,20 @@ def cleanup_glob():
 def test_command(cleanup_glob):
     """Build xlsx report using build command and test its contents."""
 
-    python_executable = sys.executable
-    result = subprocess.run(
-        [python_executable, 'manage.py', 'gather_automation_controller_billing_data', '--ship', '--until=10m', '--force'],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env_vars,
-    )
+    run_gather_ext(env_vars, ['--ship', '--until=10m'])
 
-    assert result.returncode == 0
+    validate_exists(file_glob)
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_import(cleanup_glob):
+    # test_command doesn't collect coverage
+    run_gather_int(
+        env_vars,
+        {
+            'ship': True,
+            'until': '10m',
+        },
+    )
 
     validate_exists(file_glob)

--- a/metrics_utility/test/gather/test_s3_gather.py
+++ b/metrics_utility/test/gather/test_s3_gather.py
@@ -1,8 +1,8 @@
 import os
-import subprocess
-import sys
 
 import pytest
+
+from metrics_utility.test.util import run_gather_ext, run_gather_int
 
 
 env_vars = {
@@ -14,23 +14,23 @@ env_vars = {
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
     'METRICS_UTILITY_SHIP_PATH': 'metrics-utility/shipped_data',
     'METRICS_UTILITY_SHIP_TARGET': 's3',
-    'AWX_LOGGING_MODE': 'stdout',
 }
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_command():
     """Build xlsx report using build command and test its contents."""
-
-    python_executable = sys.executable
-    result = subprocess.run(
-        [python_executable, 'manage.py', 'gather_automation_controller_billing_data', '--ship', '--until=10m', '--force'],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env_vars,
-    )
-
-    assert result.returncode == 0
-
+    run_gather_ext(env_vars, ['--ship', '--until=10m'])
     # mc ls -r local/metricsutilitys3/metrics-utility/shipped_data/data/
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_import():
+    # test_command doesn't collect coverage
+    run_gather_int(
+        env_vars,
+        {
+            'ship': True,
+            'until': '10m',
+        },
+    )

--- a/metrics_utility/test/snapshot_tests/snapshot_utils.py
+++ b/metrics_utility/test/snapshot_tests/snapshot_utils.py
@@ -161,10 +161,8 @@ def run_snapshot_definition(data: DataShape) -> str:
     """
     env_vars = copy.deepcopy(data['env_vars'])
     env_vars['AWX_LOGGING_MODE'] = 'stdout'
-    python_executable = sys.executable
 
-    params = []
-    params.append(python_executable)
+    params = [sys.executable]
     params.extend(data['params'])
 
     # Runs command, in future, we want to support also calling the test function directly due to mocking datetime.now

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+import sys
+
+from contextlib import contextmanager
+
+import pytest
+
+from metrics_utility import prepare
+
+
+@contextmanager
+def temporary_env(new_env):
+    """Temporarily update os.environ with new_env."""
+    original = os.environ.copy()
+    os.environ.update(new_env)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original)
+
+
+# Running a command as an external command, to test we can
+
+
+def _run_ext(env, name, args):
+    result = subprocess.run(
+        [sys.executable, 'manage.py', name, *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={'AWX_LOGGING_MODE': 'stdout', **env},
+    )
+
+    status = result.returncode
+    if status != 0:
+        pytest.fail(result.stderr)
+
+    assert status == 0
+
+
+def run_build_ext(env, args):
+    _run_ext(env, 'build_report', args)
+
+
+def run_gather_ext(env, args):
+    _run_ext(env, 'gather_automation_controller_billing_data', args)
+
+
+# Running a command python way, so we can work with debugger in the code, and collect coverage
+
+
+def run_build_int(env, options):
+    prepare()
+    from metrics_utility.management.commands.build_report import Command
+
+    with temporary_env(env):
+        Command().handle(**options)
+
+
+def run_gather_int(env, options):
+    prepare()
+    from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
+
+    with temporary_env(env):
+        Command().handle(**options)

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -64,4 +64,5 @@ def run_gather_int(env, options):
     from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
 
     with temporary_env(env):
-        Command().handle(**options)
+        # .handle does exit(0), breaking tests
+        Command()._handle(**options)


### PR DESCRIPTION
Follows #89, AAP-39225

Move the logic of running the command from tests - internally or externally - to a util file,
always call `run_build_ext`, `run_build_int`, `run_gather_ext` or `run_gather_int`.

The `_ext` variants use a subprocess, and take `(env dict, args array)`,
the `_int` variants use a `Command` import, and take `(env dict, options dict)`.

And updates every test file that only called the `_ext` variant to call both.
This *should* increase coverage because the `_ext` variant doesn't collect it (=> related to #89).

Importing the gather command fails from tests, because awx is not mocked - call metrics utility `prepare()` to set up the mocks even in tests.

Also updates tests running metrics-utility as a command to explicitly output the command stderr, instead of seeing it as part of an exception - fixes escaped newlines :)

(And gather doesn't do `--force`, removed from tests.)