### PR TITLE
Enable dependabot for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+
+  - package-ecosystem: 'uv'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
~~Issue: AAP-38541~~

Docs: https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories

Enable dependabot for uv (but not `setup.*` - that would be `pip`).

---

uv manages dev dependencies, used for local development, and github CI.
setup.cfg manages prod dependencies, used in prod and platform testing.

We can have different sets of dependencies as long as we're compatible with both - this requires reliable platform testing.