### PR TITLE
Ensures that indirectly_managed_nodes sheet has the correct columns

### DIFF
--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -144,7 +144,10 @@ class ReportCCSPv2(Base):
             self.wb.create_sheet(title='Indirectly Managed nodes')
             ws = self.wb.worksheets[sheet_index]
             indirects = job_host_summary_dataframe[job_host_summary_dataframe['managed_node_type'] == INDIRECT]
-            func(1, ws, indirects, managed_node_type='indirect')
+            ## This function creates the correct columns for this sheet.  Using the func variable from above
+            ## can result in the wrong columns for this sheet if `managed_nodes_by_organization`
+            ## exists in the METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS env var.
+            self._build_data_section_usage_by_node(1, ws, indirects, managed_node_type='indirect')
             sheet_index += 1
 
         if 'inventory_scope' in self.optional_report_sheets():

--- a/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
+++ b/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 
 import openpyxl
-import pandas
 import pytest
 
-from conftest import temporary_env
+from conftest import temporary_env, transform_sheet
+from pandas import Timestamp, read_excel
 
 from metrics_utility.management.commands.build_report import Command
 
@@ -26,9 +26,7 @@ env_vars = {
     'METRICS_UTILITY_REPORT_EMAIL': 'email@email.com',
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
 }
-
-indirect_nodes_and_managed_by_org_file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx'
-indirectly_managed_nodes_file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx'
+file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-25--2025-02-26.xlsx'
 date_today = datetime.now().strftime('%b %d, %Y')
 
 
@@ -36,7 +34,7 @@ date_today = datetime.now().strftime('%b %d, %Y')
 @pytest.mark.parametrize(
     'cleanup',
     [
-        indirect_nodes_and_managed_by_org_file_path,
+        file_path,
     ],
     indirect=True,
 )
@@ -46,24 +44,16 @@ def test_command(cleanup):
     # indirectly_managed_nodes_workbook = None
     try:
         ## Loads workbook for both reports
-        indirectly_managed_nodes_workbook = openpyxl.load_workbook(filename=indirectly_managed_nodes_file_path)
-        indirectly_managed_nodes_and_managed_by_orgs_workbook = openpyxl.load_workbook(filename=indirect_nodes_and_managed_by_org_file_path)
+        indirectly_managed_nodes_workbook = openpyxl.load_workbook(filename=file_path)
+        indirectly_managed_nodes_and_managed_by_orgs_workbook = openpyxl.load_workbook(filename=file_path)
+        indirectly_managed_nodes_only_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
+        indirectly_managed_nodes_managed_by_orgs_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
+        for sheet in [indirectly_managed_nodes_only_sheet, indirectly_managed_nodes_managed_by_orgs_sheet]:
+            validate_indirect_managed_nodes(sheet)
+            validate_indirect_managed_nodes(sheet)
+            validate_usage_by_organization(sheet)
 
-        ## Reads the sheets from both workbooks
-        indirectly_managed_nodes_only_sheet = pandas.read_excel(indirectly_managed_nodes_file_path, sheet_name='Indirectly Managed nodes')
-        indirectly_managed_nodes_managed_by_orgs_sheet = pandas.read_excel(
-            indirect_nodes_and_managed_by_org_file_path, sheet_name='Indirectly Managed nodes'
-        )
-
-        ##Grabs column titles from both sheets
-        indirect_managed_columns = [col.title() for col in indirectly_managed_nodes_only_sheet.columns]
-        org_managed_columns = [col.title() for col in indirectly_managed_nodes_managed_by_orgs_sheet.columns]
-
-        ## Asserts that all column titles exist in both sheets
-        for indirect_managed_col in indirect_managed_columns:
-            for org_managed_col in org_managed_columns:
-                assert indirect_managed_col in org_managed_columns and org_managed_col in indirect_managed_columns
-
+        validate_columns(indirectly_managed_nodes_managed_by_orgs_sheet, indirectly_managed_nodes_managed_by_orgs_sheet)
     finally:
         indirectly_managed_nodes_workbook.close()
         indirectly_managed_nodes_and_managed_by_orgs_workbook.close()
@@ -82,3 +72,98 @@ def build_workbook(optional_sheets):
         }
         command = Command()
         command.handle(**options)
+
+
+def validate_managed_nodes(sheet):
+    assert transform_sheet(sheet.to_dict()) == {
+        0: {
+            'Automated by organizations': 1,
+            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
+            'Host name': 'host_1',
+            'Job runs': 4,
+            'Last automation': Timestamp('2025-02-25 08:39:08.049000'),
+            'Number of task runs': 16,
+        },
+        1: {
+            'Automated by organizations': 1,
+            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
+            'Host name': 'host_2',
+            'Job runs': 2,
+            'Last automation': Timestamp('2025-02-25 08:39:08.049000'),
+            'Number of task runs': 8,
+        },
+        2: {
+            'Automated by organizations': 1,
+            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
+            'Host name': 'localhost',
+            'Job runs': 19,
+            'Last automation': Timestamp('2025-02-25 12:27:58.985000'),
+            'Number of task runs': 66,
+        },
+    }
+
+
+def validate_indirect_managed_nodes(sheet):
+    assert transform_sheet(sheet.to_dict()) == {
+        0: {
+            'Automated by organizations': 1,
+            'Canonical Facts': '{"ansible_vmware_moid": ["vm-87211", "vm-87212", "vm-87213"], '
+            '"ansible_vmware_bios_uuid": ["420b1367-1e11-c9d7-4d0f-c3b3cba9ae16", '
+            '"420b188b-16f2-a839-756d-c627378fdcb2", '
+            '"420ba1d2-3793-215c-30f0-5957a405d4e6"], '
+            '"ansible_vmware_instance_uuid": '
+            '["500b1a63-d55d-bf21-c104-1617888dd7d2", '
+            '"500b3d2e-9abe-8ee1-98ea-bf67b591c104", '
+            '"500bb935-a219-17d7-8e7e-9296f3af6be2"]}',
+            'Events': '["vmware.vmware.guest_info"]',
+            'Facts': '{"device_type": ["VM"]}',
+            'First automation': Timestamp('2025-02-25 09:33:11.557000'),
+            'Host name': 'indirect_host_1',
+            'Job runs': 7,
+            'Last automation': Timestamp('2025-02-25 10:48:56.984000'),
+            'Manage Node Types': '["INDIRECT"]',
+            'Number of task runs': 14,
+        },
+        1: {
+            'Automated by organizations': 1,
+            'Canonical Facts': '{"ansible_vmware_moid": ["vm-87212", "vm-87213"], '
+            '"ansible_vmware_bios_uuid": ["420b1367-1e11-c9d7-4d0f-c3b3cba9ae16", '
+            '"420ba1d2-3793-215c-30f0-5957a405d4e6"], '
+            '"ansible_vmware_instance_uuid": '
+            '["500b1a63-d55d-bf21-c104-1617888dd7d2", '
+            '"500b3d2e-9abe-8ee1-98ea-bf67b591c104"]}',
+            'Events': '["vmware.vmware.guest_info"]',
+            'Facts': '{"device_type": ["VM"]}',
+            'First automation': Timestamp('2025-02-25 10:48:57.035000'),
+            'Host name': 'indirect_host_2',
+            'Job runs': 5,
+            'Last automation': Timestamp('2025-02-25 13:42:53.114000'),
+            'Manage Node Types': '["INDIRECT"]',
+            'Number of task runs': 10,
+        },
+    }
+
+
+def validate_usage_by_organization(sheet):
+    assert transform_sheet(sheet.to_dict()) == {
+        0: {
+            'Job runs': 19,
+            'Non-unique indirect managed nodes automated': 12,
+            'Non-unique managed nodes automated': 25,
+            'Number of task runs': 114,
+            'Organization name': 'Default',
+            'Unique indirect managed nodes automated': 2,
+            'Unique managed nodes automated': 3,
+        },
+    }
+
+
+def validate_columns(sheet1, sheet2):
+    ##Grabs column titles from both sheets
+    sheet1_columns = [col.title() for col in sheet1.columns]
+    sheet2_columns = [col.title() for col in sheet2.columns]
+
+    ## Asserts that all column titles exist in both sheets
+    for sheet1_columns in sheet1:
+        for sheet2_columns in sheet2:
+            assert sheet1_columns in sheet2 and sheet2_columns in sheet1

--- a/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
+++ b/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
@@ -1,12 +1,10 @@
-from datetime import datetime
-
 import openpyxl
 import pytest
 
-from conftest import temporary_env, transform_sheet
+from conftest import transform_sheet
 from pandas import Timestamp, read_excel
 
-from metrics_utility.management.commands.build_report import Command
+from metrics_utility.test.util import run_build_int
 
 
 env_vars = {
@@ -27,7 +25,6 @@ env_vars = {
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
 }
 file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-25--2025-02-26.xlsx'
-date_today = datetime.now().strftime('%b %d, %Y')
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
@@ -39,74 +36,67 @@ date_today = datetime.now().strftime('%b %d, %Y')
     indirect=True,
 )
 def test_command(cleanup):
-    build_workbook('indirectly_managed_nodes')
-    build_workbook('indirectly_managed_nodes,managed_nodes_by_organizations')
-    # indirectly_managed_nodes_workbook = None
+    indirectly_managed_nodes_and_managed_by_orgs_workbook = None
     try:
-        ## Loads workbook for both reports
-        indirectly_managed_nodes_workbook = openpyxl.load_workbook(filename=file_path)
-        indirectly_managed_nodes_and_managed_by_orgs_workbook = openpyxl.load_workbook(filename=file_path)
-        indirectly_managed_nodes_only_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
-        indirectly_managed_nodes_managed_by_orgs_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
-        for sheet in [indirectly_managed_nodes_only_sheet, indirectly_managed_nodes_managed_by_orgs_sheet]:
-            validate_indirect_managed_nodes(sheet)
-            validate_indirect_managed_nodes(sheet)
-            validate_usage_by_organization(sheet)
+        ## Loads workbook with METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS which
+        ## modifies the reports that get generated.  Primarily, this test is meant
+        ## to ensure that the Indirectly Managed nodes sheet is consistent regardless of
+        ## which the values associated with METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS.
 
-        validate_columns(indirectly_managed_nodes_managed_by_orgs_sheet, indirectly_managed_nodes_managed_by_orgs_sheet)
-    finally:
-        indirectly_managed_nodes_workbook.close()
-        indirectly_managed_nodes_and_managed_by_orgs_workbook.close()
-
-
-def build_workbook(optional_sheets):
-    """Build xlsx report using build command and test its contents."""
-
-    with temporary_env({**env_vars, 'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': optional_sheets}):
+        # Builds a workbook with indirectly_managed_nodes as the only value for
+        # METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
         options = {
-            'since': '2025-02-13',
-            'until': '2025-02-13',
+            'since': '2025-02-25',
+            'until': '2025-02-26',
             'ephemeral': None,
             'force': True,
             'verbose': False,
         }
-        command = Command()
-        command.handle(**options)
 
+        run_build_int(
+            {
+                **env_vars,
+                'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': 'indirectly_managed_nodes',
+            },
+            options,
+        )
+        indirectly_managed_nodes_workbook = openpyxl.load_workbook(filename=file_path)
+        indirectly_managed_nodes_only_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
 
-def validate_managed_nodes(sheet):
-    assert transform_sheet(sheet.to_dict()) == {
-        0: {
-            'Automated by organizations': 1,
-            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
-            'Host name': 'host_1',
-            'Job runs': 4,
-            'Last automation': Timestamp('2025-02-25 08:39:08.049000'),
-            'Number of task runs': 16,
-        },
-        1: {
-            'Automated by organizations': 1,
-            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
-            'Host name': 'host_2',
-            'Job runs': 2,
-            'Last automation': Timestamp('2025-02-25 08:39:08.049000'),
-            'Number of task runs': 8,
-        },
-        2: {
-            'Automated by organizations': 1,
-            'First automation': Timestamp('2025-02-25 08:35:52.345000'),
-            'Host name': 'localhost',
-            'Job runs': 19,
-            'Last automation': Timestamp('2025-02-25 12:27:58.985000'),
-            'Number of task runs': 66,
-        },
-    }
+        # Builds a workbook with indirectly_managed_nodes,managed_nodes_by_organizations as the only value for
+        # METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
+        run_build_int(
+            {
+                **env_vars,
+                'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': 'indirectly_managed_nodes,managed_nodes_by_organizations',
+            },
+            options,
+        )
+
+        indirectly_managed_nodes_and_managed_by_orgs_workbook = openpyxl.load_workbook(filename=file_path)
+        indirectly_managed_nodes_managed_by_orgs_sheet = read_excel(file_path, sheet_name='Indirectly Managed nodes')
+
+        # Loops through both Indirectly Managed nodes sheets. One from each workbook.
+        for sheet in [indirectly_managed_nodes_only_sheet, indirectly_managed_nodes_managed_by_orgs_sheet]:
+            # Asserts that each sheet has the expected column names and data values.
+            validate_indirect_managed_nodes(sheet)
+
+    finally:
+        # indirectly_managed_nodes_workbook.close()
+        indirectly_managed_nodes_and_managed_by_orgs_workbook.close()
+        indirectly_managed_nodes_workbook.close()
 
 
 def validate_indirect_managed_nodes(sheet):
     assert transform_sheet(sheet.to_dict()) == {
         0: {
+            'Host name': 'indirect_host_1',
             'Automated by organizations': 1,
+            'Job runs': 7,
+            'Number of task runs': 14,
+            'First automation': Timestamp('2025-02-25 09:33:11.557000'),
+            'Last automation': Timestamp('2025-02-25 10:48:56.984000'),
+            'Manage Node Types': '["INDIRECT"]',
             'Canonical Facts': '{"ansible_vmware_moid": ["vm-87211", "vm-87212", "vm-87213"], '
             '"ansible_vmware_bios_uuid": ["420b1367-1e11-c9d7-4d0f-c3b3cba9ae16", '
             '"420b188b-16f2-a839-756d-c627378fdcb2", '
@@ -117,15 +107,15 @@ def validate_indirect_managed_nodes(sheet):
             '"500bb935-a219-17d7-8e7e-9296f3af6be2"]}',
             'Events': '["vmware.vmware.guest_info"]',
             'Facts': '{"device_type": ["VM"]}',
-            'First automation': Timestamp('2025-02-25 09:33:11.557000'),
-            'Host name': 'indirect_host_1',
-            'Job runs': 7,
-            'Last automation': Timestamp('2025-02-25 10:48:56.984000'),
-            'Manage Node Types': '["INDIRECT"]',
-            'Number of task runs': 14,
         },
         1: {
+            'Host name': 'indirect_host_2',
             'Automated by organizations': 1,
+            'Job runs': 5,
+            'Number of task runs': 10,
+            'First automation': Timestamp('2025-02-25 10:48:57.035000'),
+            'Last automation': Timestamp('2025-02-25 13:42:53.114000'),
+            'Manage Node Types': '["INDIRECT"]',
             'Canonical Facts': '{"ansible_vmware_moid": ["vm-87212", "vm-87213"], '
             '"ansible_vmware_bios_uuid": ["420b1367-1e11-c9d7-4d0f-c3b3cba9ae16", '
             '"420ba1d2-3793-215c-30f0-5957a405d4e6"], '
@@ -134,36 +124,5 @@ def validate_indirect_managed_nodes(sheet):
             '"500b3d2e-9abe-8ee1-98ea-bf67b591c104"]}',
             'Events': '["vmware.vmware.guest_info"]',
             'Facts': '{"device_type": ["VM"]}',
-            'First automation': Timestamp('2025-02-25 10:48:57.035000'),
-            'Host name': 'indirect_host_2',
-            'Job runs': 5,
-            'Last automation': Timestamp('2025-02-25 13:42:53.114000'),
-            'Manage Node Types': '["INDIRECT"]',
-            'Number of task runs': 10,
         },
     }
-
-
-def validate_usage_by_organization(sheet):
-    assert transform_sheet(sheet.to_dict()) == {
-        0: {
-            'Job runs': 19,
-            'Non-unique indirect managed nodes automated': 12,
-            'Non-unique managed nodes automated': 25,
-            'Number of task runs': 114,
-            'Organization name': 'Default',
-            'Unique indirect managed nodes automated': 2,
-            'Unique managed nodes automated': 3,
-        },
-    }
-
-
-def validate_columns(sheet1, sheet2):
-    ##Grabs column titles from both sheets
-    sheet1_columns = [col.title() for col in sheet1.columns]
-    sheet2_columns = [col.title() for col in sheet2.columns]
-
-    ## Asserts that all column titles exist in both sheets
-    for sheet1_columns in sheet1:
-        for sheet2_columns in sheet2:
-            assert sheet1_columns in sheet2 and sheet2_columns in sheet1

--- a/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
+++ b/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+import openpyxl
+import pandas
+import pytest
+
+from conftest import temporary_env
+
+from metrics_utility.management.commands.build_report import Command
+
+
+env_vars = {
+    'METRICS_UTILITY_PRICE_PER_NODE': '11.55',
+    'METRICS_UTILITY_REPORT_RHN_LOGIN': 'test_login',
+    'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
+    'METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME': 'Customer A',
+    'METRICS_UTILITY_REPORT_END_USER_STATE': 'TX',
+    'METRICS_UTILITY_REPORT_SKU_DESCRIPTION': 'EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)',
+    'METRICS_UTILITY_REPORT_H1_HEADING': 'CCSP NA Direct Reporting Template',
+    'METRICS_UTILITY_REPORT_END_USER_CITY': 'Springfield',
+    'METRICS_UTILITY_REPORT_PO_NUMBER': '123',
+    'METRICS_UTILITY_SHIP_TARGET': 'directory',
+    'METRICS_UTILITY_REPORT_END_USER_COUNTRY': 'US',
+    'METRICS_UTILITY_REPORT_COMPANY_NAME': 'Partner A',
+    'METRICS_UTILITY_REPORT_SKU': 'MCT3752MO',
+    'METRICS_UTILITY_REPORT_EMAIL': 'email@email.com',
+    'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
+}
+
+indirect_nodes_and_managed_by_org_file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx'
+indirectly_managed_nodes_file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx'
+date_today = datetime.now().strftime('%b %d, %Y')
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+@pytest.mark.parametrize(
+    'cleanup',
+    [
+        indirect_nodes_and_managed_by_org_file_path,
+    ],
+    indirect=True,
+)
+def test_command(cleanup):
+    build_workbook('indirectly_managed_nodes')
+    build_workbook('indirectly_managed_nodes,managed_nodes_by_organizations')
+    # indirectly_managed_nodes_workbook = None
+    try:
+        ## Loads workbook for both reports
+        indirectly_managed_nodes_workbook = openpyxl.load_workbook(filename=indirectly_managed_nodes_file_path)
+        indirectly_managed_nodes_and_managed_by_orgs_workbook = openpyxl.load_workbook(filename=indirect_nodes_and_managed_by_org_file_path)
+
+        ## Reads the sheets from both workbooks
+        indirectly_managed_nodes_only_sheet = pandas.read_excel(indirectly_managed_nodes_file_path, sheet_name='Indirectly Managed nodes')
+        indirectly_managed_nodes_managed_by_orgs_sheet = pandas.read_excel(
+            indirect_nodes_and_managed_by_org_file_path, sheet_name='Indirectly Managed nodes'
+        )
+
+        ##Grabs column titles from both sheets
+        indirect_managed_columns = [col.title() for col in indirectly_managed_nodes_only_sheet.columns]
+        org_managed_columns = [col.title() for col in indirectly_managed_nodes_managed_by_orgs_sheet.columns]
+
+        ## Asserts that all column titles exist in both sheets
+        for indirect_managed_col in indirect_managed_columns:
+            for org_managed_col in org_managed_columns:
+                assert indirect_managed_col in org_managed_columns and org_managed_col in indirect_managed_columns
+
+    finally:
+        indirectly_managed_nodes_workbook.close()
+        indirectly_managed_nodes_and_managed_by_orgs_workbook.close()
+
+
+def build_workbook(optional_sheets):
+    """Build xlsx report using build command and test its contents."""
+
+    with temporary_env({**env_vars, 'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': optional_sheets}):
+        options = {
+            'since': '2025-02-13',
+            'until': '2025-02-13',
+            'ephemeral': None,
+            'force': True,
+            'verbose': False,
+        }
+        command = Command()
+        command.handle(**options)


### PR DESCRIPTION
AAP-41419

## Description
This PR fixes a bug where the columns for the Indirectly managed nodes sheet were not consistently the same columns.  To resolve this I realized that when we add `managed_nodes_by_organizations` to the optional sheet env var it was forcing the use an a function for the `indirectly_managed_nodes` sheet as well.  This PR resolves that bug, and adds a test to ensure it doesn't return.
## Testing
I added a test that creates to reports with different env vars.  Then the test inspects each report and checks that each column consists in each report thus ensuring consistent columns and data.

### Steps to Test

1.Run the new test.

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.
