### PR TITLE
[AAP-42965] Should fix the lack of code coverage reporting

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,8 +7,11 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout metrics-utility (${{ github.ref }})"
+      - name: "Checkout metrics-utility (${{ github.event.pull_request.head.ref }})"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
AAP-42965


## Description
Sonar cloud has stopped reporting code coverage on our prs.  This pr does:
1) Ensures that the github action files used in the PR checks is the file that is part of the pr (if there is 1) and then defaults to the check files on devel if there isn't 1.

2) Additionally, after looking at other repos in our org ([DAB](https://github.com/ansible/django-ansible-base/tree/devel/.github)) and trying to understand how they get their coverage report I added a new file  `sonar-cloud.yml` which handles the steps to send the report to sonar cloud, and updated `sonar-project.properties`.  I'm not confident that this step works because I can't test it.  Currently our pr checks use files on devel only and are not using the `.yml` files in this pr.  
