### PR TITLE
run pytest on push - to collect coverage for the devel branch

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,7 @@
 name: "Pytest tests"
 
 on:
+  push:
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
Right now, we're collecting coverage from PR branches,
but the workflow never runs on `devel` - enabling that :)

Closes #107  (I believe)