### PR TITLE
Add optional report sheet showing collection coverage

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -88,8 +88,6 @@ def combine_json_values(val1, val2):
 
 
 class Base:
-    LOG_PREFIX = '[AAPBillingReport] '
-
     def __init__(self, extractor, month, extra_params):
         self.logger = logger
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_collection_status.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_collection_status.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+
+
+# dataframe for data_collection_status.csv
+class DataframeCollectionStatus(Base):
+    def build_dataframe(self):
+        # all-rows dataframe, no aggregation
+        dataframe = None
+
+        for date in self.dates():
+            for data in self.extractor.iter_batches(date=date):
+                batch = data['data_collection_status']
+                if batch.empty:
+                    continue
+
+                # Merge batches
+                if dataframe is None:
+                    dataframe = batch
+                else:
+                    dataframe = pd.concat([dataframe, batch], ignore_index=True)
+
+        if dataframe is None or dataframe.empty:
+            return None
+
+        dataframe['collection_start_timestamp'] = pd.to_datetime(dataframe['collection_start_timestamp'], format='ISO8601').dt.tz_localize(None)
+        dataframe['since'] = pd.to_datetime(dataframe['since'], format='ISO8601').dt.tz_localize(None)
+        dataframe['until'] = pd.to_datetime(dataframe['until'], format='ISO8601').dt.tz_localize(None)
+
+        return dataframe

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class DataframeContentUsage(Base):
-    LOG_PREFIX = '[AAPBillingReport] '
-
     def build_dataframe(self):
         # A monthly rollup dataframe
         content_explorer_rollup = None

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class DataframeInventoryScope(Base):
-    LOG_PREFIX = '[AAPBillingReport] '
-
     def build_dataframe(self):
         # A daily rollup dataframe
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -16,8 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class DataframeJobhostSummaryUsage(Base):
-    LOG_PREFIX = '[AAPBillingReport] '
-
     def build_dataframe(self):
         # A daily rollup dataframe
         billing_data_monthly_rollup = None

--- a/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py
@@ -13,8 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 class DBDataframeHostMetric(Base):
-    LOG_PREFIX = '[AAPBillingReport] '
-
     def build_dataframe(self):
         host_metric_concat = None
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
@@ -1,3 +1,4 @@
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_collection_status import DataframeCollectionStatus
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import DataframeContentUsage
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_inventory_scope import DataframeInventoryScope
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_jobhost_summary_usage import DataframeJobhostSummaryUsage
@@ -25,6 +26,7 @@ class Factory:
                 self._get_dataframe_jobhost_summary_usage().build_dataframe(),
                 self._get_dataframe_content_usage().build_dataframe(),
                 self._get_dataframe_inventory_scope().build_dataframe(),
+                self._get_dataframe_collection_status().build_dataframe(),
             )
         elif self.report_type == 'RENEWAL_GUIDANCE':
             return (self._get_db_dataframe_host_metric_usage().build_dataframe(),)
@@ -32,6 +34,9 @@ class Factory:
             return (self._get_dataframe_jobhost_summary_usage().build_dataframe(), self._get_dataframe_content_usage().build_dataframe())
         else:
             raise NotSupportedFactory(f'Factory for {self.ship_target} not supported')
+
+    def _get_dataframe_collection_status(self):
+        return DataframeCollectionStatus(extractor=self.extractor, month=self.month, extra_params=self.extra_params)
 
     def _get_dataframe_jobhost_summary_usage(self):
         return DataframeJobhostSummaryUsage(extractor=self.extractor, month=self.month, extra_params=self.extra_params)

--- a/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
@@ -34,26 +34,20 @@ class Factory:
             raise NotSupportedFactory(f'Factory for {self.ship_target} not supported')
 
     def _get_dataframe_jobhost_summary_usage(self):
-        # Return default S3 loader
         return DataframeJobhostSummaryUsage(extractor=self.extractor, month=self.month, extra_params=self.extra_params)
 
     def _get_dataframe_content_usage(self):
-        # Return default S3 loader
         return DataframeContentUsage(
-            # return DataframeSummarizedByOrgAndHostv2(
             extractor=self.extractor,
             month=self.month,
             extra_params=self.extra_params,
         )
 
     def _get_dataframe_inventory_scope(self):
-        # Return dataframe
         return DataframeInventoryScope(extractor=self.extractor, month=self.month, extra_params=self.extra_params)
 
     def _get_db_dataframe_host_metric_usage(self):
-        # Return default S3 loader
         return DBDataframeHostMetric(
-            # return DataframeSummarizedByOrgAndHostv2(
             extractor=self.extractor,
             month=self.month,
             extra_params=self.extra_params,

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -38,6 +38,9 @@ CSV_SHEETS = {
         'usage_by_organizations',
         'usage_by_roles',
     ],
+    'data_collection_status': [
+        'data_collection_status',
+    ],
 }
 
 
@@ -67,11 +70,15 @@ class Base:
         empty_dataframe = pd.DataFrame([{}])
         needed_data = {
             'config': config,
+            'data_collection_status': empty_dataframe,
             'indirect_nodes': empty_dataframe,
             'job_host_summary': empty_dataframe,
             'main_host': empty_dataframe,
             'main_jobevent': empty_dataframe,
         }
+
+        if self.csv_enabled('data_collection_status'):
+            needed_data['data_collection_status'] = self.build_data_batch(temp_dir, 'data_collection_status')
 
         if self.csv_enabled('job_host_summary'):
             needed_data['job_host_summary'] = self.build_data_batch(temp_dir, 'job_host_summary')

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -8,6 +8,7 @@ import pandas as pd
 from metrics_utility.debug_utils import print_debug
 
 
+# csv name => [ sheet_names ]
 CSV_SHEETS = {
     'job_host_summary': [
         'ccsp_summary',
@@ -66,10 +67,10 @@ class Base:
         empty_dataframe = pd.DataFrame([{}])
         needed_data = {
             'config': config,
-            'job_host_summary': empty_dataframe,
             'indirect_nodes': empty_dataframe,
-            'main_jobevent': empty_dataframe,
+            'job_host_summary': empty_dataframe,
             'main_host': empty_dataframe,
+            'main_jobevent': empty_dataframe,
         }
 
         if self.csv_enabled('job_host_summary'):
@@ -102,8 +103,7 @@ class Base:
 
     def sheet_enabled(self, sheets_required):
         """
-        Checks for METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS values and return those values.
-        If none found, give it the default CCSP report sheet options.
+        Checks if any sheets_required item is in METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
         Returns a boolean so we know which sheets to provide in the report.
         """
         sheet_options = self.extra_params.get('optional_sheets')

--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -7,8 +7,6 @@ from django.db import connection
 
 
 class ExtractorControllerDB:
-    LOG_PREFIX = '[ExtractorDirectory]'
-
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
         super().__init__()
 

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -17,6 +17,8 @@ class Base:
     RED_COLOR_HEX = 'FF0000'
     LIGHT_BLUE_COLOR_HEX = 'd4eaf3'
     GREEN_COLOR_HEX = '92d050'
+    YELLOW_WARNING_COLOR_HEX = 'FFCC17'
+
     FONT = 'Arial'
     PRICE_FORMAT = '$#,##0.00'
     HOST_NAME = 'Host name'
@@ -44,6 +46,17 @@ class Base:
         # Otherwise, return the cell unchanged.
         return cell
 
+    def add_sheet(self, title, sheet_index, widths=None):
+        self.wb.create_sheet(title=title)
+        ws = self.wb.worksheets[sheet_index]
+        if widths:
+            self.set_widths(ws, widths)
+        return ws
+
+    def set_widths(self, ws, widths):
+        for key, value in widths.items():
+            ws.column_dimensions[get_column_letter(key)].width = value
+
     def _fix_event_host_names(self, mapping_dataframe, destination_dataframe):
         if destination_dataframe is None:
             return None
@@ -67,142 +80,7 @@ class Base:
 
         return destination_dataframe
 
-    def _build_data_section_usage_by_node_with_org_details(self, current_row, ws, dataframe, mode=None, managed_node_type=None):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
-        header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
-        value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
-
-        # Rename the columns based on the template
-        ccsp_report_dataframe = dataframe.groupby('host_name', dropna=False).agg(
-            organizations=('organization_name', 'nunique'),
-            host_runs=('host_name', 'count'),
-            task_runs=('task_runs', 'sum'),
-            first_automation=('first_automation', 'min'),
-            last_automation=('last_automation', 'max'),
-        )
-        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
-        columns = [
-            'host_name',
-            'organizations',
-            'host_runs',
-            'task_runs',
-            'first_automation',
-            'last_automation',
-        ]
-        if mode == 'by_organization':
-            # Filter some columns out based on mode
-            columns = [col for col in columns if col not in ['organizations']]
-
-        ccsp_report_dataframe = ccsp_report_dataframe.reindex(columns=columns)
-
-        # Create dataframe with hostname and orgs as columns, having last automation for each host
-        pivoted_dataframe = dataframe.pivot_table(
-            index='host_name',
-            columns='organization_name',
-            values='last_automation',
-            aggfunc='max',  # You can use 'max', 'min', 'mean', etc., depending on your needs
-        )
-
-        # Set index on host_name for join
-        ccsp_report_dataframe.set_index('host_name', inplace=True)
-
-        # Join the list of orgs to the pivoted_dataframe having org last updated as columns
-        ccsp_report_dataframe = ccsp_report_dataframe.join(pivoted_dataframe, how='left')
-        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
-
-        labels = {
-            'host_name': self.HOST_NAME,
-            'organizations': 'Automated by\norganizations',
-            'host_runs': self.JOB_RUNS,  # Job runs is the same as host_runs, Non-unique managed nodes automated
-            'task_runs': self.NUM_OF_TASKS_OR_RUNS,
-            'first_automation': 'First\nautomation',
-            'last_automation': 'Last\nautomation',
-        }
-        labels = {k: v for k, v in labels.items() if k in columns}
-        ccsp_report_dataframe = ccsp_report_dataframe.rename(columns=labels)
-
-        row_counter = 0
-        rows = dataframe_to_rows(ccsp_report_dataframe, index=False)
-        for r_idx, row in enumerate(rows, current_row):
-            for c_idx, value in enumerate(row, 1):
-                cell = ws.cell(row=r_idx, column=c_idx)
-                cell.value = value
-
-                if row_counter == 0:
-                    # set header style
-                    cell.font = header_font
-                    rd = ws.row_dimensions[r_idx]
-                    rd.height = 25
-                else:
-                    # set value style
-                    cell.font = value_font
-
-            row_counter += 1
-
-        return current_row + row_counter
-
-    def _build_data_section_usage_by_job(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
-        header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
-        value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
-
-        dataframe['job_remote_id_install_uuid'] = list(zip(dataframe['job_remote_id'], dataframe['install_uuid']))
-
-        # Rename the columns based on the template
-        ccsp_report_dataframe = dataframe.groupby(['organization_name', 'job_template_name'], dropna=False).agg(
-            job_runs=('job_remote_id_install_uuid', 'nunique'),
-            host_runs_unique=('host_name', 'nunique'),
-            host_runs=('host_name', 'count'),
-            task_runs=('task_runs', 'sum'),
-            first_run=('job_created', 'min'),
-            last_run=('job_created', 'max'),
-        )
-        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
-        ccsp_report_dataframe = ccsp_report_dataframe.reindex(
-            columns=['job_template_name', 'organization_name', 'job_runs', 'host_runs_unique', 'host_runs', 'task_runs', 'first_run', 'last_run']
-        )
-
-        ccsp_report_dataframe = ccsp_report_dataframe.rename(
-            columns={
-                'job_template_name': 'Job template\nname',
-                'organization_name': 'Organization\nname',
-                'job_runs': self.JOB_RUNS,
-                'host_runs_unique': self.HOST_RUNS_UNIQUE,
-                'host_runs': self.HOST_RUNS,
-                'task_runs': self.NUM_OF_TASKS_OR_RUNS,
-                'first_run': 'First\nrun',
-                'last_run': 'Last\nrun',
-            }
-        )
-
-        row_counter = 0
-        rows = dataframe_to_rows(ccsp_report_dataframe, index=False)
-        for r_idx, row in enumerate(rows, current_row):
-            for c_idx, value in enumerate(row, 1):
-                cell = ws.cell(row=r_idx, column=c_idx)
-                cell.value = value
-
-                if row_counter == 0:
-                    # set header style
-                    cell.font = header_font
-                    rd = ws.row_dimensions[r_idx]
-                    rd.height = 25
-                else:
-                    # set value style
-                    cell.font = value_font
-
-            row_counter += 1
-
-        return current_row + row_counter
-
     def _build_data_section_scope(self, current_row, ws, dataframe, mode=None):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -256,9 +134,6 @@ class Base:
         return current_row + row_counter
 
     def _build_data_section_usage_by_node(self, current_row, ws, dataframe, mode=None, managed_node_type=None):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -340,9 +215,6 @@ class Base:
         return current_row + row_counter
 
     def _build_data_section_usage_by_collections(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -388,9 +260,6 @@ class Base:
         return current_row + row_counter
 
     def _build_data_section_usage_by_roles(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -437,9 +306,6 @@ class Base:
         return current_row + row_counter
 
     def _build_data_section_usage_by_modules(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -17,7 +17,7 @@ class Base:
     RED_COLOR_HEX = 'FF0000'
     LIGHT_BLUE_COLOR_HEX = 'd4eaf3'
     GREEN_COLOR_HEX = '92d050'
-    YELLOW_WARNING_COLOR_HEX = 'FFCC17'
+    YELLOW_COLOR_HEX = 'ffcc17'
 
     FONT = 'Arial'
     PRICE_FORMAT = '$#,##0.00'

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -3,7 +3,6 @@
 ######################################
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 from metrics_utility.automation_controller_billing.report.base import Base
@@ -11,13 +10,6 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSP(Base):
-    BLACK_COLOR_HEX = '00000000'
-    WHITE_COLOR_HEX = '00FFFFFF'
-    BLUE_COLOR_HEX = '000000FF'
-    GREEN_COLOR_HEX = '0000FF00'
-    FONT = 'Arial'
-    PRICE_FORMAT = '$#,##0.00'
-
     def __init__(self, dataframe, report_period, extra_params):
         # Create the workbook and worksheet
         self.wb = Workbook()
@@ -102,38 +94,33 @@ class ReportCCSP(Base):
 
         # Create the workbook and worksheets
         self.wb.remove(self.wb.active)  # delete the default sheet
-        self.wb.create_sheet(title='Usage Reporting')
 
         # First sheet with billing
-        ws = self.wb.worksheets[0]
-
-        self._init_dimensions(ws)
+        sheet_index = 0
+        ws = self.add_sheet('Usage Reporting', sheet_index, self.config['column_widths'])
         current_row = self._build_heading_h1(1, ws)
         current_row = self._build_header(current_row, ws)
         current_row = self._build_heading_h2(current_row, ws)
         current_row = self._build_sku_description(current_row, ws)
         self._build_data_section(current_row, ws, job_host_summary_dataframe)
+        sheet_index += 1
 
         # Add optional sheets
-        sheet_index = 1
         if 'managed_nodes' in self.optional_report_sheets():
             # Sheet with list of managed nodes
-            self.wb.create_sheet(title='Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
             directs = job_host_summary_dataframe[job_host_summary_dataframe['managed_node_type'] == DIRECT]
             self._build_data_section_usage_by_node(1, ws, directs, managed_node_type='direct')
             sheet_index += 1
 
         if 'indirectly_managed_nodes' in self.optional_report_sheets():
-            self.wb.create_sheet(title='Indirectly Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Indirectly Managed nodes', sheet_index, self.config['data_column_widths'])
             indirects = job_host_summary_dataframe[job_host_summary_dataframe['managed_node_type'] == INDIRECT]
             self._build_data_section_usage_by_node(1, ws, indirects, managed_node_type='indirect')
             sheet_index += 1
 
         if 'inventory_scope' in self.optional_report_sheets():
-            self.wb.create_sheet(title='Inventory Scope')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Inventory Scope', sheet_index, self.config['data_column_widths'])
             scope = scope_dataframe
             self._build_data_section_scope(1, ws, scope)
             sheet_index += 1
@@ -141,30 +128,23 @@ class ReportCCSP(Base):
         if events_dataframe is not None:
             if 'usage_by_collections' in self.optional_report_sheets():
                 # Sheet with usage by collections
-                self.wb.create_sheet(title='Usage by collections')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by collections', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_collections(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_roles' in self.optional_report_sheets():
                 # Sheet with usage by roles
-                self.wb.create_sheet(title='Usage by roles')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by roles', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_roles(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_modules' in self.optional_report_sheets():
                 # Sheet with usage by modules
-                self.wb.create_sheet(title='Usage by modules')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by modules', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_modules(1, ws, events_dataframe)
                 sheet_index += 1
 
         return self.wb
-
-    def _init_dimensions(self, ws):
-        for key, value in self.config['column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
 
     def _build_heading_h1(self, current_row, ws):
         # Merge cells and insert the h1 heading

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -70,9 +70,12 @@ class ReportCCSPv2(Base):
 
         default_data_column_widths = {1: 40, 2: 20, 3: 20, 4: 20, 5: 20, 6: 20}
 
+        default_status_column_widths = {1: 36, 2: 20, 3: 20, 4: 36, 5: 15, 6: 15, 7: 20}
+
         self.config['sku_description'] = default_sku_description
         self.config['column_widths'] = default_column_widths
         self.config['data_column_widths'] = default_data_column_widths
+        self.config['status_column_widths'] = default_status_column_widths
 
     def _apply_filter(self, job_host_summary_dataframe, events_dataframe):
         if self.extra_params['report_organization_filter'] is not None:
@@ -88,6 +91,7 @@ class ReportCCSPv2(Base):
         job_host_summary_dataframe = self.dataframe[0]
         events_dataframe = self.dataframe[1]
         scope_dataframe = self.dataframe[2]
+        status_dataframe = self.dataframe[3]
 
         # Fix host names in the event data, to take in account the variables
         events_dataframe = self._fix_event_host_names(job_host_summary_dataframe, events_dataframe)
@@ -178,7 +182,99 @@ class ReportCCSPv2(Base):
                 self._build_data_section_usage_by_node(1, ws, filtered_job_host_summary_dataframe, mode='by_organization')
                 sheet_index += 1
 
+        if 'data_collection_status' in self.optional_report_sheets():
+            ws = self.add_sheet('Data collection status', sheet_index, self.config['status_column_widths'])
+            current_row = self._build_data_section_collection_missing(1, ws, status_dataframe)
+            current_row += 1  # gap
+            self._build_data_section_collection_status(current_row, ws, status_dataframe)
+            sheet_index += 1
+
         return self.wb
+
+    def _build_table(self, current_row, ws, rows):
+        row_counter = 0
+
+        for r_idx, row in enumerate(rows, current_row):
+            for c_idx, value in enumerate(row, 1):
+                cell = ws.cell(row=r_idx, column=c_idx)
+                cell.value = value
+            row_counter += 1
+
+        return current_row + row_counter
+
+    def _build_data_section_collection_missing(self, current_row, ws, df):
+        # skip failed collects
+        df = df[df['status'] == 'ok']
+
+        # find gaps between until -> next since
+        df = df.sort_values(['file_name', 'collection_start_timestamp']).reset_index(drop=True)
+        df['next_since'] = df.groupby('file_name')['since'].shift(-1)
+        df['gap'] = df['next_since'] - df['until']
+
+        # skip if under 2 seconds
+        threshold = timedelta(seconds=2)
+        dataframe = df[df['gap'] > threshold].copy()
+
+        dataframe = dataframe[['file_name', 'until', 'next_since', 'gap']]
+        dataframe = dataframe.rename(
+            columns={
+                'file_name': 'CSV filename',
+                'until': 'Missing from',
+                'next_since': 'Missing until',
+                'gap': 'Gap in seconds',
+            }
+        )
+
+        rows = dataframe_to_rows(dataframe, index=False)
+        return self._build_table(current_row, ws, rows)
+
+    def _build_data_section_collection_status(self, first_row, ws, df):
+        # time difference between the current and previous row with the same file_name & sort
+        df = df.sort_values(['file_name', 'collection_start_timestamp']).reset_index(drop=True)
+        df['time_diff'] = df.groupby('file_name')['collection_start_timestamp'].diff()
+        df = df.sort_values('collection_start_timestamp').reset_index(drop=True)
+
+        median_diff = df['time_diff'].median()
+
+        dataframe = df.rename(
+            columns={
+                'collection_start_timestamp': 'Collection timestamp',
+                'since': 'Filter since',
+                'until': 'Filter until',
+                'file_name': 'CSV filename',
+                'status': 'Status',
+                'elapsed': 'Elapsed',
+                'time_diff': 'Time since\nprevious collection',  # col_index
+            }
+        )
+
+        rows = dataframe_to_rows(dataframe, index=False)
+        next_row = self._build_table(first_row, ws, rows)
+
+        # apply styling to highlight unusual collection intervals
+
+        success_background = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
+        warning_background = PatternFill('solid', fgColor=self.YELLOW_WARNING_COLOR_HEX)
+        danger_background = PatternFill('solid', fgColor=self.RED_COLOR_HEX)
+
+        threshold_warning = 2 * median_diff
+        threshold_danger = 3 * median_diff
+
+        col_index = df.columns.to_list().index('time_diff')
+
+        rows = ws.iter_rows(min_row=first_row + 1, max_row=next_row, min_col=col_index + 1, max_col=col_index + 1)
+        for row in rows:
+            for cell in row:
+                if cell.value is None or pd.isnull(cell.value):
+                    continue
+                if cell.value >= threshold_danger:
+                    cell.fill = danger_background
+                elif cell.value >= threshold_warning:
+                    cell.fill = warning_background
+                else:
+                    cell.fill = success_background
+
+        return next_row
 
     def _build_data_section_usage_by_node_with_org_details(self, current_row, ws, dataframe, mode=None, managed_node_type=None):
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -203,6 +203,8 @@ class ReportCCSPv2(Base):
         return current_row + row_counter
 
     def _build_data_section_collection_missing(self, current_row, ws, df):
+        """builds a table showing any gaps not covered by any since-until collection interval"""
+
         # skip failed collects
         df = df[df['status'] == 'ok']
 
@@ -254,7 +256,7 @@ class ReportCCSPv2(Base):
         # apply styling to highlight unusual collection intervals
 
         success_background = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
-        warning_background = PatternFill('solid', fgColor=self.YELLOW_WARNING_COLOR_HEX)
+        warning_background = PatternFill('solid', fgColor=self.YELLOW_COLOR_HEX)
         danger_background = PatternFill('solid', fgColor=self.RED_COLOR_HEX)
 
         threshold_warning = 2 * median_diff

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -3,11 +3,12 @@
 ######################################
 import time
 
+from datetime import timedelta
+
 import pandas as pd
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 from metrics_utility.automation_controller_billing.report.base import Base
@@ -15,15 +16,6 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSPv2(Base):
-    # BLACK_COLOR_HEX = "00000000"
-    # WHITE_COLOR_HEX = "00FFFFFF"
-    # BLUE_COLOR_HEX = "000000FF"
-    # RED_COLOR_HEX = "FF0000"
-    # LIGHT_BLUE_COLOR_HEX = "d4eaf3"
-    # GREEN_COLOR_HEX = "92d050"
-    # FONT = "Arial"
-    # PRICE_FORMAT = '$#,##0.00'
-
     def __init__(self, dataframe, report_period, extra_params):
         self.wb = Workbook()
 
@@ -93,13 +85,13 @@ class ReportCCSPv2(Base):
         return job_host_summary_dataframe, events_dataframe
 
     def build_spreadsheet(self):
-        # Fix host names in the event data, to take in account the variables
         job_host_summary_dataframe = self.dataframe[0]
         events_dataframe = self.dataframe[1]
-        events_dataframe = self._fix_event_host_names(job_host_summary_dataframe, events_dataframe)
-        # TODO: also apply organization filter
         scope_dataframe = self.dataframe[2]
 
+        # Fix host names in the event data, to take in account the variables
+        events_dataframe = self._fix_event_host_names(job_host_summary_dataframe, events_dataframe)
+        # TODO: also apply organization filter
         job_host_summary_dataframe, events_dataframe = self._apply_filter(job_host_summary_dataframe, events_dataframe)
 
         # Create the workbook and worksheets
@@ -109,9 +101,7 @@ class ReportCCSPv2(Base):
         sheet_index = 0
 
         if 'ccsp_summary' in self.optional_report_sheets():
-            self.wb.create_sheet(title='Usage Reporting')
-            ws = self.wb.worksheets[sheet_index]
-            self._init_dimensions(ws)
+            ws = self.add_sheet('Usage Reporting', sheet_index, self.config['column_widths'])
             current_row = self._build_heading_h1(1, ws)
             current_row = self._build_header(current_row, ws)
             current_row = self._build_po_number(current_row, ws)
@@ -120,9 +110,7 @@ class ReportCCSPv2(Base):
             sheet_index += 1
 
         if 'jobs' in self.optional_report_sheets():
-            # Sheet with usage by org
-            self.wb.create_sheet(title='Jobs')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Jobs', sheet_index, self.config['data_column_widths'])
             self._build_data_section_usage_by_job(1, ws, job_host_summary_dataframe)
             sheet_index += 1
 
@@ -134,15 +122,13 @@ class ReportCCSPv2(Base):
 
         if 'managed_nodes' in self.optional_report_sheets():
             # Sheet with list of managed nodes
-            self.wb.create_sheet(title='Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
             directs = job_host_summary_dataframe[job_host_summary_dataframe['managed_node_type'] == DIRECT]
             func(1, ws, directs, managed_node_type='direct')
             sheet_index += 1
 
         if 'indirectly_managed_nodes' in self.optional_report_sheets():
-            self.wb.create_sheet(title='Indirectly Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Indirectly Managed nodes', sheet_index, self.config['data_column_widths'])
             indirects = job_host_summary_dataframe[job_host_summary_dataframe['managed_node_type'] == INDIRECT]
             ## This function creates the correct columns for this sheet.  Using the func variable from above
             ## can result in the wrong columns for this sheet if `managed_nodes_by_organization`
@@ -151,38 +137,33 @@ class ReportCCSPv2(Base):
             sheet_index += 1
 
         if 'inventory_scope' in self.optional_report_sheets():
-            self.wb.create_sheet(title='Inventory Scope')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Inventory Scope', sheet_index, self.config['data_column_widths'])
             scope = scope_dataframe
             self._build_data_section_scope(1, ws, scope)
             sheet_index += 1
 
         if 'usage_by_organizations' in self.optional_report_sheets():
             # Sheet with usage by org
-            self.wb.create_sheet(title='Usage by organizations')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Usage by organizations', sheet_index, self.config['data_column_widths'])
             self._build_data_section_usage_by_org(1, ws, job_host_summary_dataframe)
             sheet_index += 1
 
         if events_dataframe is not None:
             if 'usage_by_collections' in self.optional_report_sheets():
                 # Sheet with usage by collections
-                self.wb.create_sheet(title='Usage by collections')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by collections', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_collections(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_roles' in self.optional_report_sheets():
                 # Sheet with usage by roles
-                self.wb.create_sheet(title='Usage by roles')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by roles', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_roles(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_modules' in self.optional_report_sheets():
                 # Sheet with usage by modules
-                self.wb.create_sheet(title='Usage by modules')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by modules', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_modules(1, ws, events_dataframe)
                 sheet_index += 1
 
@@ -190,8 +171,7 @@ class ReportCCSPv2(Base):
             # Sheet with list of managed nodes by organization, this will generate multiple tabs
             organization_names = sorted(job_host_summary_dataframe['organization_name'].unique())
             for organization_name in organization_names:
-                self.wb.create_sheet(title=organization_name)
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet(organization_name, sheet_index, self.config['data_column_widths'])
 
                 # Filter the data for a certain organization
                 filtered_job_host_summary_dataframe = job_host_summary_dataframe[job_host_summary_dataframe['organization_name'] == organization_name]
@@ -200,10 +180,133 @@ class ReportCCSPv2(Base):
 
         return self.wb
 
-    def _build_data_section_usage_by_org(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
+    def _build_data_section_usage_by_node_with_org_details(self, current_row, ws, dataframe, mode=None, managed_node_type=None):
+        header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
+        value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
+        # Rename the columns based on the template
+        ccsp_report_dataframe = dataframe.groupby('host_name', dropna=False).agg(
+            organizations=('organization_name', 'nunique'),
+            host_runs=('host_name', 'count'),
+            task_runs=('task_runs', 'sum'),
+            first_automation=('first_automation', 'min'),
+            last_automation=('last_automation', 'max'),
+        )
+        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
+        columns = [
+            'host_name',
+            'organizations',
+            'host_runs',
+            'task_runs',
+            'first_automation',
+            'last_automation',
+        ]
+        if mode == 'by_organization':
+            # Filter some columns out based on mode
+            columns = [col for col in columns if col not in ['organizations']]
+
+        ccsp_report_dataframe = ccsp_report_dataframe.reindex(columns=columns)
+
+        # Create dataframe with hostname and orgs as columns, having last automation for each host
+        pivoted_dataframe = dataframe.pivot_table(
+            index='host_name',
+            columns='organization_name',
+            values='last_automation',
+            aggfunc='max',  # You can use 'max', 'min', 'mean', etc., depending on your needs
+        )
+
+        # Set index on host_name for join
+        ccsp_report_dataframe.set_index('host_name', inplace=True)
+
+        # Join the list of orgs to the pivoted_dataframe having org last updated as columns
+        ccsp_report_dataframe = ccsp_report_dataframe.join(pivoted_dataframe, how='left')
+        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
+
+        labels = {
+            'host_name': self.HOST_NAME,
+            'organizations': 'Automated by\norganizations',
+            'host_runs': self.JOB_RUNS,  # Job runs is the same as host_runs, Non-unique managed nodes automated
+            'task_runs': self.NUM_OF_TASKS_OR_RUNS,
+            'first_automation': 'First\nautomation',
+            'last_automation': 'Last\nautomation',
+        }
+        labels = {k: v for k, v in labels.items() if k in columns}
+        ccsp_report_dataframe = ccsp_report_dataframe.rename(columns=labels)
+
+        row_counter = 0
+        rows = dataframe_to_rows(ccsp_report_dataframe, index=False)
+        for r_idx, row in enumerate(rows, current_row):
+            for c_idx, value in enumerate(row, 1):
+                cell = ws.cell(row=r_idx, column=c_idx)
+                cell.value = value
+
+                if row_counter == 0:
+                    # set header style
+                    cell.font = header_font
+                    rd = ws.row_dimensions[r_idx]
+                    rd.height = 25
+                else:
+                    # set value style
+                    cell.font = value_font
+
+            row_counter += 1
+
+        return current_row + row_counter
+
+    def _build_data_section_usage_by_job(self, current_row, ws, dataframe):
+        header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
+        value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
+
+        dataframe['job_remote_id_install_uuid'] = list(zip(dataframe['job_remote_id'], dataframe['install_uuid']))
+
+        # Rename the columns based on the template
+        ccsp_report_dataframe = dataframe.groupby(['organization_name', 'job_template_name'], dropna=False).agg(
+            job_runs=('job_remote_id_install_uuid', 'nunique'),
+            host_runs_unique=('host_name', 'nunique'),
+            host_runs=('host_name', 'count'),
+            task_runs=('task_runs', 'sum'),
+            first_run=('job_created', 'min'),
+            last_run=('job_created', 'max'),
+        )
+        ccsp_report_dataframe = ccsp_report_dataframe.reset_index()
+        ccsp_report_dataframe = ccsp_report_dataframe.reindex(
+            columns=['job_template_name', 'organization_name', 'job_runs', 'host_runs_unique', 'host_runs', 'task_runs', 'first_run', 'last_run']
+        )
+
+        ccsp_report_dataframe = ccsp_report_dataframe.rename(
+            columns={
+                'job_template_name': 'Job template\nname',
+                'organization_name': 'Organization\nname',
+                'job_runs': self.JOB_RUNS,
+                'host_runs_unique': self.HOST_RUNS_UNIQUE,
+                'host_runs': self.HOST_RUNS,
+                'task_runs': self.NUM_OF_TASKS_OR_RUNS,
+                'first_run': 'First\nrun',
+                'last_run': 'Last\nrun',
+            }
+        )
+
+        row_counter = 0
+        rows = dataframe_to_rows(ccsp_report_dataframe, index=False)
+        for r_idx, row in enumerate(rows, current_row):
+            for c_idx, value in enumerate(row, 1):
+                cell = ws.cell(row=r_idx, column=c_idx)
+                cell.value = value
+
+                if row_counter == 0:
+                    # set header style
+                    cell.font = header_font
+                    rd = ws.row_dimensions[r_idx]
+                    rd.height = 25
+                else:
+                    # set value style
+                    cell.font = value_font
+
+            row_counter += 1
+
+        return current_row + row_counter
+
+    def _build_data_section_usage_by_org(self, current_row, ws, dataframe):
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -264,10 +367,6 @@ class ReportCCSPv2(Base):
             row_counter += 1
 
         return current_row + row_counter
-
-    def _init_dimensions(self, ws):
-        for key, value in self.config['column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
 
     def _build_heading_h1(self, current_row, ws):
         # Merge cells and insert the h1 heading

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 from metrics_utility.automation_controller_billing.helpers import parse_number_of_days
@@ -71,45 +70,38 @@ class ReportRenewalGuidance(Base):
 
         # Create the workbook and worksheets
         self.wb.remove(self.wb.active)  # delete the default sheet
-        self.wb.create_sheet(title='Usage Reporting')
 
         # First sheet with billing
-        ws = self.wb.worksheets[0]
-
-        self._init_dimensions(ws)
+        sheet_index = 0
+        ws = self.add_sheet('Usage Reporting', sheet_index, self.config['column_widths'])
         current_row = self._build_heading_h1(1, ws)
         current_row = self._build_header(current_row, ws)
 
         current_row = self._build_updated_timestamp(current_row, ws)
         self._build_data_section(current_row, ws, host_metric_dataframe, ephemeral_usage_dataframe)
+        sheet_index += 1
 
         # Add optional sheets
-        sheet_index = 1
         if 'managed_nodes' in self.optional_report_sheets():
             # Sheet with list of managed nodes
             if self.extra_params.get('opt_ephemeral') is None:
-                self.wb.create_sheet(title='Managed nodes')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_host_metrics(1, ws, self.df_managed_nodes_query(host_metric_dataframe))
                 sheet_index += 1
             else:
-                self.wb.create_sheet(title='Managed nodes')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_host_metrics(1, ws, self.df_managed_nodes_query(host_metric_dataframe, ephemeral=False))
                 sheet_index += 1
 
-                self.wb.create_sheet(title='Managed nodes ephemeral')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Managed nodes ephemeral', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_host_metrics(1, ws, self.df_managed_nodes_query(host_metric_dataframe, ephemeral=True))
                 sheet_index += 1
 
-                self.wb.create_sheet(title='Managed nodes ephemeral usage')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Managed nodes ephemeral usage', sheet_index, self.config['uniform_column_widths'])
                 self._build_data_section_ephemeral_usage(1, ws, ephemeral_usage_dataframe)
                 sheet_index += 1
 
-            self.wb.create_sheet(title='Deleted Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Deleted Managed nodes', sheet_index, self.config['data_column_widths'])
             self._build_data_section_host_metrics(1, ws, self.df_deleted_managed_nodes_query(host_metric_dataframe))
             sheet_index += 1
 
@@ -181,10 +173,6 @@ class ReportRenewalGuidance(Base):
             )
 
         return pd.DataFrame(ephemeral_usage_intervals)
-
-    def _init_dimensions(self, ws):
-        for key, value in self.config['column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
 
     def _build_data_section(self, current_row, ws, dataframe, ephemeral_usage_dataframe):
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
@@ -294,9 +282,6 @@ class ReportRenewalGuidance(Base):
         return current_row + row_counter
 
     def _build_data_section_host_metrics(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -361,9 +346,6 @@ class ReportRenewalGuidance(Base):
         return current_row + row_counter
 
     def _build_data_section_ephemeral_usage(self, current_row, ws, dataframe):
-        for key, value in self.config['uniform_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance_v2.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 from metrics_utility.automation_controller_billing.report.base import Base
@@ -80,62 +79,52 @@ class ReportRenewalGuidanceV2(Base):
 
         # Create the workbook and worksheets
         self.wb.remove(self.wb.active)  # delete the default sheet
-        self.wb.create_sheet(title='Usage Reporting')
 
         # First sheet with billing
-        ws = self.wb.worksheets[0]
-
-        self._init_dimensions(ws)
+        sheet_index = 0
+        ws = self.add_sheet('Usage Reporting', sheet_index, self.config['column_widths'])
         current_row = self._build_heading_h1(1, ws)
         current_row = self._build_header(current_row, ws)
         current_row = self._build_po_number(current_row, ws)
         current_row = self._build_updated_timestamp(current_row, ws)
         self._build_data_section(current_row, ws, job_host_summary_dataframe)
+        sheet_index += 1
 
         # Add optional sheets
-        sheet_index = 1
         if 'managed_nodes' in self.optional_report_sheets():
             # Sheet with list of managed nodes
-            self.wb.create_sheet(title='Managed nodes')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
             self._build_data_section_usage_by_node(1, ws, job_host_summary_dataframe)
             sheet_index += 1
 
         if 'usage_by_organizations' in self.optional_report_sheets():
             # Sheet with usage by org
-            self.wb.create_sheet(title='Usage by organizations')
-            ws = self.wb.worksheets[sheet_index]
+            ws = self.add_sheet('Usage by organizations', sheet_index, self.config['data_column_widths'])
             self._build_data_section_usage_by_org(1, ws, job_host_summary_dataframe)
             sheet_index += 1
 
         if events_dataframe is not None:
             if 'usage_by_collections' in self.optional_report_sheets():
                 # Sheet with usage by collections
-                self.wb.create_sheet(title='Usage by collections')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by collections', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_collections(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_roles' in self.optional_report_sheets():
                 # Sheet with usage by roles
-                self.wb.create_sheet(title='Usage by roles')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by roles', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_roles(1, ws, events_dataframe)
                 sheet_index += 1
 
             if 'usage_by_modules' in self.optional_report_sheets():
                 # Sheet with usage by modules
-                self.wb.create_sheet(title='Usage by modules')
-                ws = self.wb.worksheets[sheet_index]
+                ws = self.add_sheet('Usage by modules', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_usage_by_modules(1, ws, events_dataframe)
                 sheet_index += 1
 
         return self.wb
 
     def _build_data_section_usage_by_org(self, current_row, ws, dataframe):
-        for key, value in self.config['data_column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
-
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -174,10 +163,6 @@ class ReportRenewalGuidanceV2(Base):
             row_counter += 1
 
         return current_row + row_counter
-
-    def _init_dimensions(self, ws):
-        for key, value in self.config['column_widths'].items():
-            ws.column_dimensions[get_column_letter(key)].width = value
 
     def _build_heading_h1(self, current_row, ws):
         # Merge cells and insert the h1 heading

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
@@ -3,8 +3,6 @@ import os
 
 
 class ReportSaverDirectory:
-    LOG_PREFIX = '[ExtractorDirectory]'
-
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
         self.extra_params = extra_params
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -122,7 +122,7 @@ class Command(BaseCommand):
 
         report_dataframe = DataframeEngineFactory(extractor=extractor, month=month, extra_params=extra_params).create()
 
-        if report_dataframe[0] is None or report_dataframe[0].empty:
+        if all(item is None or item.empty for item in report_dataframe):
             if opt_since is not None:
                 self.logger.info(f'No billing data for input date range {extra_params["since_date"]}--{extra_params["until_date"]}')
             else:

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
@@ -27,7 +27,7 @@ env_vars = {
     'METRICS_UTILITY_REPORT_EMAIL': 'email@email.com',
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
     'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': 'ccsp_summary,managed_nodes,usage_by_organizations,'
-    'usage_by_collections,usage_by_roles,usage_by_modules',
+    'usage_by_collections,usage_by_roles,usage_by_modules,data_collection_status',
 }
 
 file_path = './metrics_utility/test/test_data/reports/2025/02/CCSPv2-2025-02-13--2025-02-13.xlsx'

--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -24,3 +24,7 @@ uv run ./manage.py build_report --month=2024-04 --force "$@"
 
 set -x
 ls -l metrics_utility/test/test_data/reports/2024/04/
+
+if which xlsx2csv; then
+  xlsx2csv -a ./metrics_utility/test/test_data//reports/2024/04/CCSPv2-2024-04.xlsx
+fi

--- a/run-perf
+++ b/run-perf
@@ -89,7 +89,7 @@ run_default_sheets() {
 }
 
 run_all_sheets() {
-  export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS=ccsp_summary,indirectly_managed_nodes,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles
+  export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS=ccsp_summary,indirectly_managed_nodes,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles,data_collection_status
 
   echo all sheets
   /usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \


### PR DESCRIPTION
Issue: AAP-41887

(Started from #100, kudos to @AlexSCorey)

This adds a new optional "Data collection status" sheet to the CCSPv2 report,
enabled by `METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS=data_collection_status,...`.

The data is based on `data_collection_status.csv` output by the collector.

It lists collection instances (when data was actually gathered), highlighting:
* unusual gaps between collections (based on `collection_start_timestamp`)
* gaps in collected intervals (based on `since` vs `until`)

---

Also, a bit of cleanup/refactoring in reports (first commit):

remove unused (and inaccurate) LOG_PREFIX from a bunch of places
remove copypased (and inaccurate) comments
fix a couple of comments
    
move `_build_data_section_usage_by_node_with_org_details` & `_build_data_section_usage_by_job` from report base to report_ccsp_v2 (only used there)
    
replace `_init_dimensions` for main sheet + same for loop in each `_build_*` function,
move into base `add_sheet(title, sheet_index, widths=None)`
    
Fail with "No billing data" only when all dataframes are empty
([0] may be None if no sheets are using it even when data is available)

---

Example output:

* https://docs.google.com/spreadsheets/d/1ohWtDmgKOqRFDc1YWk545FRvITSbLg4S/edit?gid=1350376622#gid=1350376622 (last sheet)
* https://docs.google.com/spreadsheets/d/1kDx82n1IVF0T4ZY2Iuz2bDh5fJT9A6mV/edit?gid=1669669102#gid=1669669102 (only sheet)
