### PR TITLE
Update CHANGELOG for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ## 0.4.2
 
 - add indirectly managed nodes support, sheets
+- add scope (hosts across all inventories) support, sheets
 - count only reachable hosts into ccsp
 - add optional collector coverage sheet
 - allow importing pglock from either awx or django-ansible-base (2.4/2.5 compatibility)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix return codes
 
 ## 0.4.0
+
 - Adding RENEWAL_GUIDANCE reports having host fact based dedup and detection of ephemeral hosts
 - removing obsolete host_metric command
 - adding organization usage details into CCSPv2 report
@@ -53,7 +54,19 @@
 - introducing S3 adapter for CCSP types of reports
 
 ## 0.4.1
+
 - relax boto3 requirement so it builds with any version available
 
-## 0.4.2 (unreleased)
-- allow importing pglock from either awx or django-ansible-base
+## 0.4.2
+
+- add indirectly managed nodes support, sheets
+- count only reachable hosts into ccsp
+- add optional collector coverage sheet
+- allow importing pglock from either awx or django-ansible-base (2.4/2.5 compatibility)
+- perf: reduce need to load data only used by optional sheets
+- handle missing job_created for older job_host_summary data
+- basic param validation for --since, --until
+- better error handling for missing data
+- dev: added tests, mock data generator, scripts, docs, linters, workflows
+- dev: standalone mode with just postgres; python 3.13
+- dev: merge in insights-analytics-generator base lib


### PR DESCRIPTION
A CHANGELOG update for ~~0.4.2~~ 0.5.0 (fixup in #121)  :tada: 

---

This is a condensed version of what github would generate, which is...

```
## What's Changed
* Add Pull Request Template by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/35
* Fix CI  by @ZitaNemeckova in https://github.com/ansible/metrics-utility/pull/38
* Add testing data to gitignore by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/43
* Test Repository Branch Protection Rules with Dummy PR: README Update [AAP-38413] by @art-tapin in https://github.com/ansible/metrics-utility/pull/40
* Fix failing report over data from 2024 by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/39
* add pre-commit with ruff by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/42
* add data and complete test for ccspv2 file by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/41
* AAP-39154 - add pr-checks.yml by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/46
* Add missing developer documentation for the pre-commit hook setup [AAP-38768] by @art-tapin in https://github.com/ansible/metrics-utility/pull/44
* Add imported dependencies by @himdel in https://github.com/ansible/metrics-utility/pull/45
* run ruff on repo by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/50
* configure linters to use uv+ruff and remove superlinter by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/49
* AAP-39264: add helpful settings to ruff linter by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/53
* AAP-39214 - Fine tune pytest by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/55
* AAP-39220 : Run ccspv2 build_report outside awx by @himdel in https://github.com/ansible/metrics-utility/pull/51
* docs: add virtual environment handling + .gitignore update by @art-tapin in https://github.com/ansible/metrics-utility/pull/54
* Sonarcloud integration by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/59
* AAP-39699 - fixing ValueError( by @larrymou9 in https://github.com/ansible/metrics-utility/pull/58
* Milan snapshot test by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/56
* test  simple ccsp file by @ShaiahWren in https://github.com/ansible/metrics-utility/pull/60
* Fix error message when data not found by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/63
* [AAP-38577] Docs: Add Contributors Guide by @art-tapin in https://github.com/ansible/metrics-utility/pull/62
* [AAP-38577] Docs: Refactor README.md & Relocate Legacy Installation Guide by @art-tapin in https://github.com/ansible/metrics-utility/pull/61
* [AAP-38577] Fix links in docs by @art-tapin in https://github.com/ansible/metrics-utility/pull/64
* AAP-40225 - Add more complex data by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/67
* Add prints by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/66
* Run ccsp2 gather_automation_controller_billing_data outside awx by @himdel in https://github.com/ansible/metrics-utility/pull/52
* Add more complex ccsp tests by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/70
* [AAP-38819] - Setting up pytest + S3 (Minio) + example test by @himdel in https://github.com/ansible/metrics-utility/pull/71
* Update github workflows - enable postgres, minio by @himdel in https://github.com/ansible/metrics-utility/pull/72
* Remove duplicate sonarcloud workflow by @himdel in https://github.com/ansible/metrics-utility/pull/76
* Pytest enable by @himdel in https://github.com/ansible/metrics-utility/pull/74
* Indirectly managed nodes by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/75
* Tweak sonar duplication checks by @Ladas in https://github.com/ansible/metrics-utility/pull/80
* Changing sonar config name by @Ladas in https://github.com/ansible/metrics-utility/pull/81
* Update READMEs by @himdel in https://github.com/ansible/metrics-utility/pull/77
* MVP for scope count by @Ladas in https://github.com/ansible/metrics-utility/pull/78
* Count only reachable hosts into ccsp by @Ladas in https://github.com/ansible/metrics-utility/pull/79
* compose.yml updates by @himdel in https://github.com/ansible/metrics-utility/pull/84
* Test gather with directory output by @himdel in https://github.com/ansible/metrics-utility/pull/85
* s3 test: make sure upload succeeds by @himdel in https://github.com/ansible/metrics-utility/pull/88
* Build report searches through only the sheets the user is requesting. by @AlexSCorey in https://github.com/ansible/metrics-utility/pull/86
* Format by @himdel in https://github.com/ansible/metrics-utility/pull/90
* AAP-39225 : Github workflow to gate for code coverage in tests. by @AlexSCorey in https://github.com/ansible/metrics-utility/pull/89
* Fixup combine_* function naming by @himdel in https://github.com/ansible/metrics-utility/pull/93
* Start 0.4.2 changelog, fixup pglock import by @himdel in https://github.com/ansible/metrics-utility/pull/94
* Allow python 3.13 by @himdel in https://github.com/ansible/metrics-utility/pull/96
* AAP-41409 - Data generator script by @himdel in https://github.com/ansible/metrics-utility/pull/91
* Enable isort by @himdel in https://github.com/ansible/metrics-utility/pull/97
* Tests - bump coverage by running simple tests in both modes by @himdel in https://github.com/ansible/metrics-utility/pull/95
* [AAP-42965] Should fix the lack of code coverage reporting by @AlexSCorey in https://github.com/ansible/metrics-utility/pull/106
* Ensures that indirectly_managed_nodes sheet has the correct columns by @AlexSCorey in https://github.com/ansible/metrics-utility/pull/99
* Bump SonarSource/sonarqube-scan-action from 4 to 5 by @dependabot in https://github.com/ansible/metrics-utility/pull/102
* Move insights-analytics-collector into metrics-utility by @himdel in https://github.com/ansible/metrics-utility/pull/92
* run pytest on push - to collect coverage for the devel branch by @himdel in https://github.com/ansible/metrics-utility/pull/108
* Sonar 2 - update workflow for running on devel branch by @himdel in https://github.com/ansible/metrics-utility/pull/109
* AAP-41410 - Generator updates by @himdel in https://github.com/ansible/metrics-utility/pull/111
* Add optional report sheet showing collection coverage by @himdel in https://github.com/ansible/metrics-utility/pull/110
* AAP-44676 - Count only direct hosts in quantity by @MilanPospisil in https://github.com/ansible/metrics-utility/pull/117
* Since,until - better param validation by @himdel in https://github.com/ansible/metrics-utility/pull/114
* CCSP* `build_dataframe`: don't return None on empty by @himdel in https://github.com/ansible/metrics-utility/pull/118
* Collection coverage - notice gaps at beginning,end of interval by @himdel in https://github.com/ansible/metrics-utility/pull/115

## New Contributors
* @MilanPospisil made their first contribution in https://github.com/ansible/metrics-utility/pull/35
* @ZitaNemeckova made their first contribution in https://github.com/ansible/metrics-utility/pull/38
* @art-tapin made their first contribution in https://github.com/ansible/metrics-utility/pull/40
* @ShaiahWren made their first contribution in https://github.com/ansible/metrics-utility/pull/42
* @himdel made their first contribution in https://github.com/ansible/metrics-utility/pull/45
* @AlexSCorey made their first contribution in https://github.com/ansible/metrics-utility/pull/86
* @dependabot made their first contribution in https://github.com/ansible/metrics-utility/pull/102

**Full Changelog**: https://github.com/ansible/metrics-utility/compare/0.4.1...0.4.2
```