### PR TITLE
Change version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 - relax boto3 requirement so it builds with any version available
 
-## 0.4.2
+## 0.5.0
 
 - add indirectly managed nodes support, sheets
 - add scope (hosts across all inventories) support, sheets

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -129,7 +129,7 @@ def config(since, **kwargs):
         'logging_aggregators': settings.LOG_AGGREGATOR_LOGGERS,
         'external_logger_enabled': settings.LOG_AGGREGATOR_ENABLED,
         'external_logger_type': getattr(settings, 'LOG_AGGREGATOR_TYPE', None),
-        'metrics_utility_version': '0.4.2',  # TODO read from setup.cfg
+        'metrics_utility_version': '0.5.0',  # TODO read from setup.cfg
         'billing_provider_params': {},  # Is being overwritten in collector.gather by set ENV VARS
     }
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -48,7 +48,7 @@ class ManagementUtility(management.ManagementUtility):
         # 'django-admin --help' to work, for backwards compatibility.
         elif subcommand == 'version' or self.argv[1:] == ['--version']:
             # sys.stdout.write(django.get_version() + "\n")
-            sys.stdout.write('0.4.2' + '\n')
+            sys.stdout.write('0.5.0' + '\n')
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.4.2
+version = 0.5.0
 
 [options]
 packages = find:


### PR DESCRIPTION
Issue: AAP-38426

Fixup the about-to-be-released version number ... assumed 0.4.2 but the Issue mentions 0.5.0,
and 0.4.2 sounds too 2.4-like, or 2024-like, not doing that ..  bumping version to 0.5.0 instead.

This corresponds to 2.5.20250507.