### PR TITLE
Post-release - bump version to 0.5.1dev; add version mapping table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,7 @@
 - dev: added tests, mock data generator, scripts, docs, linters, workflows
 - dev: standalone mode with just postgres; python 3.13
 - dev: merge in insights-analytics-generator base lib
+
+## 0.5.1dev
+
+- TODO

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ Please note that this is the upstream documentation for the metrics-utility proj
 
 As the project grows, more guides and references will be added to the `/docs` folder.
 
+## Version mapping
+
+|metrics-utility version|AAP version|
+|-|-|
+|0.4.1|2.4\*|
+|0.5.0|2.5-20250507|
+
 ## Contributing
 
 Please follow our [Contributor's Guide](./docs/contributing/CONTRIBUTING.md) for details on submitting changes and documentation standards.

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -129,7 +129,7 @@ def config(since, **kwargs):
         'logging_aggregators': settings.LOG_AGGREGATOR_LOGGERS,
         'external_logger_enabled': settings.LOG_AGGREGATOR_ENABLED,
         'external_logger_type': getattr(settings, 'LOG_AGGREGATOR_TYPE', None),
-        'metrics_utility_version': '0.5.0',  # TODO read from setup.cfg
+        'metrics_utility_version': '0.5.1dev',  # TODO read from setup.cfg
         'billing_provider_params': {},  # Is being overwritten in collector.gather by set ENV VARS
     }
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -48,7 +48,7 @@ class ManagementUtility(management.ManagementUtility):
         # 'django-admin --help' to work, for backwards compatibility.
         elif subcommand == 'version' or self.argv[1:] == ['--version']:
             # sys.stdout.write(django.get_version() + "\n")
-            sys.stdout.write('0.5.0' + '\n')
+            sys.stdout.write('0.5.1dev' + '\n')
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.5.0
+version = 0.5.1dev
 
 [options]
 packages = find:


### PR DESCRIPTION
Follows #121, #120 

Now that 0.5.0 is released, bump the version to a 0.5.1dev, just so we can tell those apart :).

And add a version mapping table to the README.