### PR TITLE
Switch from quay.io to mirror.gcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 help:
-	@echo help sync test coverage lint fix
+	@echo help sync test coverage lint fix compose
 
 sync:
 	uv run sync
@@ -18,4 +18,7 @@ fix:
 	uv run ruff check --fix
 	uv run ruff format
 
-.PHONY: help sync test coverage lint fix
+compose:
+	docker compose -f tools/docker/docker-compose.yaml up
+
+.PHONY: help sync test coverage lint fix compose

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more about the development setup, see the [Developer Setup Guide](./docs/dev
 
 ### Tests (standalone)
 
-Run tests using `uv run pytest -s -v`. Some tests depend on a running postgres & minio instance - run `docker compose -f tools/docker/docker-compose.yaml up` to get one. You may need to `docker login quay.io` first.
+Run tests using `uv run pytest -s -v`. Some tests depend on a running postgres & minio instance - run `docker compose -f tools/docker/docker-compose.yaml up` to get one.
 
 You can also run pytest inside a container too - to run all tests once, you can `docker compose -f tools/docker/docker-compose.yaml --profile=pytest up`.
 For more flexibility, use:

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -32,7 +32,7 @@ podman run --name "$NAME" --replace \
     -v "$ROLES":/docker-entrypoint-initdb.d/init-roles.sql:ro \
     -v "$SCHEMA":/docker-entrypoint-initdb.d/init-schema.sql:ro \
     -p 5432:5432 \
-    -d quay.io/cloudservices/postgres
+    -d mirror.gcr.io/postgres
 
 tries=5
 until pg_isready -h localhost; do

--- a/run-renewal
+++ b/run-renewal
@@ -19,7 +19,7 @@ podman run --name "$NAME" --replace \
     -v "$ROLES":/docker-entrypoint-initdb.d/init-roles.sql:ro \
     -v "$SCHEMA":/docker-entrypoint-initdb.d/init-schema.sql:ro \
     -p 5432:5432 \
-    -d quay.io/cloudservices/postgres
+    -d mirror.gcr.io/postgres
 
 tries=5
 until pg_isready -h localhost; do

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: "quay.io/cloudservices/minio:latest"
+    image: "mirror.gcr.io/minio/minio"
     container_name: minio
     ports:
       - "9000:9000"
@@ -13,7 +13,7 @@ services:
     command: server /minio-data --console-address ":9001"
 
   minio-setup:
-    image: "quay.io/cloudservices/mc:latest"
+    image: "mirror.gcr.io/minio/mc"
     depends_on:
       - minio
     entrypoint: |
@@ -33,7 +33,7 @@ services:
       '
 
   postgres:
-    image: "quay.io/cloudservices/postgres"
+    image: "mirror.gcr.io/postgres"
     container_name: postgres
     environment:
       POSTGRES_DB: "awx"
@@ -46,7 +46,7 @@ services:
       - ./latest.sql:/docker-entrypoint-initdb.d/init-schema.sql
 
   postgres-wait:
-    image: "quay.io/cloudservices/postgres"
+    image: "mirror.gcr.io/postgres"
     depends_on:
       - postgres
     command: |
@@ -58,7 +58,7 @@ services:
       '
 
   metrics-utility:
-    image: "quay.io/fedora/python-311"
+    image: "mirror.gcr.io/python"
     container_name: metrics-utility
     depends_on:
       minio-setup:
@@ -97,7 +97,7 @@ services:
       context: .
       args:
         SRC_MOUNT: /app
-    image: "quay.io/fedora/python-311"
+    image: "mirror.gcr.io/python"
     container_name: metrics-utility-env
     depends_on:
       minio-setup:


### PR DESCRIPTION
Seems like quay login is a problem,
but these containers can be obtained from any dockerhub mirror,
=> switching to mirror.gcr.io.

(The containers are the same, except possibly more up to date versions, just different source.)
Tests still pass locally.

And added a `make compose` target.