### PR TITLE
AAP-45801: use gtime when available

### DIFF
--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -19,8 +19,7 @@ export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
-TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
-
+TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --month=2024-04 --force "$@"
 

--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -19,7 +19,9 @@ export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --month=2024-04 --force "$@"
 
 set -x

--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -19,7 +19,7 @@ export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
-TIME=`which gtime && echo 'gtime' || echo 'time'`
+TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --month=2024-04 --force "$@"

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -44,7 +44,7 @@ until pg_isready -h localhost; do
   tries=`expr "$tries" - 1`
 done
 
-TIME=`which gtime && echo 'gtime' || echo 'time'`
+TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -19,6 +19,8 @@ export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
+TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
+
 SCHEMA=`realpath "tools/docker/latest.sql"`
 ROLES=`realpath "tools/docker/roles.sql"`
 NAME=ccsp2-gather-`basename "$SCHEMA" .sql`
@@ -43,8 +45,6 @@ until pg_isready -h localhost; do
 
   tries=`expr "$tries" - 1`
 done
-
-TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -44,7 +44,9 @@ until pg_isready -h localhost; do
   tries=`expr "$tries" - 1`
 done
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"
 
 podman stop "$NAME"

--- a/run-perf
+++ b/run-perf
@@ -20,7 +20,7 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=2000
 export OUTPUT_DATE_FROM=2026-01-01
 export OUTPUT_DATE_TO=2026-02-01
 
-TIME=`which gtime && echo 'gtime' || echo 'time'`
+TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
@@ -36,8 +36,6 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=20000
 
 export OUTPUT_DATE_FROM=2026-02-01
 export OUTPUT_DATE_TO=2026-03-01
-
-TIME=`which gtime && echo 'gtime' || echo 'time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
@@ -55,7 +53,6 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=200000
 export OUTPUT_DATE_FROM=2026-03-01
 export OUTPUT_DATE_TO=2026-04-01
 
-TIME=`which gtime && echo 'gtime' || echo 'time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
@@ -73,7 +70,7 @@ uv run ./generator.py
 #export OUTPUT_DATE_FROM=2026-04-01
 #export OUTPUT_DATE_TO=2026-05-01
 #
-#TIME=`which gtime && echo 'gtime' || echo 'time'`
+# $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 #uv run ./generator.py
 
 
@@ -87,7 +84,6 @@ run_default_sheets() {
   export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
 
   echo default sheets
-  TIME=`which gtime && echo 'gtime' || echo 'time'`
   $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
   uv run ./manage.py build_report --force "$@"
 }
@@ -96,7 +92,6 @@ run_all_sheets() {
   export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS=ccsp_summary,indirectly_managed_nodes,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles,data_collection_status
 
   echo all sheets
-  TIME=`which gtime && echo 'gtime' || echo 'time'`
   $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
   uv run ./manage.py build_report --force "$@"
 }

--- a/run-perf
+++ b/run-perf
@@ -20,7 +20,8 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=2000
 export OUTPUT_DATE_FROM=2026-01-01
 export OUTPUT_DATE_TO=2026-02-01
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
 echo gen 100,000
@@ -36,7 +37,8 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=20000
 export OUTPUT_DATE_FROM=2026-02-01
 export OUTPUT_DATE_TO=2026-03-01
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
 # ~5 minutes
@@ -53,7 +55,8 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=200000
 export OUTPUT_DATE_FROM=2026-03-01
 export OUTPUT_DATE_TO=2026-04-01
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 
 ## ~50 minutes
@@ -70,7 +73,7 @@ uv run ./generator.py
 #export OUTPUT_DATE_FROM=2026-04-01
 #export OUTPUT_DATE_TO=2026-05-01
 #
-#/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+#TIME=`which gtime && echo 'gtime' || echo 'time'`
 #uv run ./generator.py
 
 
@@ -84,7 +87,8 @@ run_default_sheets() {
   export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
 
   echo default sheets
-  /usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+  TIME=`which gtime && echo 'gtime' || echo 'time'`
+  $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
   uv run ./manage.py build_report --force "$@"
 }
 
@@ -92,7 +96,8 @@ run_all_sheets() {
   export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS=ccsp_summary,indirectly_managed_nodes,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles,data_collection_status
 
   echo all sheets
-  /usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+  TIME=`which gtime && echo 'gtime' || echo 'time'`
+  $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
   uv run ./manage.py build_report --force "$@"
 }
 

--- a/run-perf
+++ b/run-perf
@@ -20,7 +20,7 @@ export MAIN_JOBEVENT_UNIQUE_SIZE=2000
 export OUTPUT_DATE_FROM=2026-01-01
 export OUTPUT_DATE_TO=2026-02-01
 
-TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
+TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./generator.py
 

--- a/run-renewal
+++ b/run-renewal
@@ -6,6 +6,8 @@ export METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE"
 export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="controller_db"
 
+TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
+
 SCHEMA=`realpath "tools/docker/latest.sql"`
 ROLES=`realpath "tools/docker/roles.sql"`
 NAME=renewal-`basename "$SCHEMA" .sql`
@@ -30,8 +32,6 @@ until pg_isready -h localhost; do
 
   tries=`expr "$tries" - 1`
 done
-
-TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --since=12months --ephemeral=1month --force "$@"

--- a/run-renewal
+++ b/run-renewal
@@ -31,7 +31,7 @@ until pg_isready -h localhost; do
   tries=`expr "$tries" - 1`
 done
 
-TIME=`which gtime && echo 'gtime' || echo 'time'`
+TIME=`which gtime && echo 'gtime' || echo '/usr/bin/time'`
 
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --since=12months --ephemeral=1month --force "$@"

--- a/run-renewal
+++ b/run-renewal
@@ -31,7 +31,9 @@ until pg_isready -h localhost; do
   tries=`expr "$tries" - 1`
 done
 
-/usr/bin/time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+TIME=`which gtime && echo 'gtime' || echo 'time'`
+
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --since=12months --ephemeral=1month --force "$@"
 
 podman stop "$NAME"


### PR DESCRIPTION
[[AAP-45801](https://issues.redhat.com/browse/AAP-45801)]

## Description

As a user of the metrics utility that generates ccspv files, I want build and gather scripts to be compatible across operating systems, including Mac and GNU. 

The change ensures that the script will use gtime if it's available (likely on macOS with GNU coreutils) and fall back to the standard time command if gtime is not found, providing better cross-platform compatibility.




### Steps to Test

Run the following commands:

./run-ccsp2-build
./run-ccsp2-gather
./run-perf
./run-renewal


### Expected Results

On all operating systems, the scripts should be executable.

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
