### PR TITLE
Error handling for environment vars - s3 edition

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -14,7 +14,7 @@ from metrics_utility.automation_controller_billing.helpers import parse_date_par
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
-from metrics_utility.management.validation import handle_directory_ship_target, handle_not_crc, handle_not_s3, handle_not_ship, handle_s3_ship_target
+from metrics_utility.management.validation import handle_directory_ship_target, handle_not_crc, handle_not_s3, handle_s3_ship_target
 from metrics_utility.metric_utils import get_optional_collectors
 
 
@@ -154,11 +154,8 @@ class Command(BaseCommand):
         self.logger.info(f'Report generated into {ship_target}: {report_saver_engine.report_spreadsheet_destination_path}')
 
     def _handle_ship_target(self, ship_target):
-        if ship_target == 'controller_db':
-            handle_not_crc()
-            handle_not_s3()
-            return {} # ship_path set in handle_extra_params
-        elif ship_target == 'directory':
+        if ship_target in ['controller_db', 'directory']:
+            # controller_db is just directory but with different extractor
             handle_not_crc()
             handle_not_s3()
             return handle_directory_ship_target()
@@ -172,26 +169,19 @@ class Command(BaseCommand):
     def _handle_extra_params(self, ship_target=None):
         base = self._handle_ship_target(ship_target)
 
-        ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
         report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
         price_per_node = float(os.getenv('METRICS_UTILITY_PRICE_PER_NODE', 0))
 
-        # FIXME: already checked inside handle_ .. except crc (not here) / controller_db .. but required there?
-        if not ship_path:
-            raise MissingRequiredEnvVar(
-                'Missing required env variable METRICS_UTILITY_SHIP_PATH, having destination for the generated data and for the built reports'
-            )
-
         if not report_type:
             raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_REPORT_TYPE.')
-        elif report_type not in ['CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE']:
+
+        if report_type not in ['CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE']:
             raise BadRequiredEnvVar(
                 "Bad value for required env variable METRICS_UTILITY_REPORT_TYPE, allowed values are: ['CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE']"
             )
 
         base.update(
             {
-                'ship_path': ship_path,
                 'report_type': report_type,
                 'price_per_node': price_per_node,
                 # XLSX specific params

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -14,7 +14,7 @@ from metrics_utility.automation_controller_billing.helpers import parse_date_par
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
-from metrics_utility.management.validation import handle_directory_ship_target, handle_s3_ship_target
+from metrics_utility.management.validation import handle_directory_ship_target, handle_not_crc, handle_not_s3, handle_not_ship, handle_s3_ship_target
 from metrics_utility.metric_utils import get_optional_collectors
 
 
@@ -155,17 +155,19 @@ class Command(BaseCommand):
 
     def _handle_ship_target(self, ship_target):
         if ship_target == 'controller_db':
-            return {}
+            handle_not_crc()
+            handle_not_s3()
+            return {} # ship_path set in handle_extra_params
         elif ship_target == 'directory':
-            return handle_directory_ship_target(ship_target)
+            handle_not_crc()
+            handle_not_s3()
+            return handle_directory_ship_target()
         elif ship_target == 's3':
-            return handle_s3_ship_target(ship_target)
+            handle_not_crc()
+            return handle_s3_ship_target()
         else:
-            raise BadShipTarget(
-                'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var'
-                ', allowed value for local report generation are '
-                "['s3', 'directory', 'controller_db']"
-            )
+            allowed = ', '.join(['controller_db', 'directory', 's3'])
+            raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')
 
     def _handle_extra_params(self, ship_target=None):
         base = self._handle_ship_target(ship_target)
@@ -174,6 +176,7 @@ class Command(BaseCommand):
         report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
         price_per_node = float(os.getenv('METRICS_UTILITY_PRICE_PER_NODE', 0))
 
+        # FIXME: already checked inside handle_ .. except crc (not here) / controller_db .. but required there?
         if not ship_path:
             raise MissingRequiredEnvVar(
                 'Missing required env variable METRICS_UTILITY_SHIP_PATH, having destination for the generated data and for the built reports'

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -20,7 +20,6 @@ from metrics_utility.management.validation import (
     handle_directory_ship_target,
     handle_not_crc,
     handle_not_s3,
-    handle_not_ship,
     handle_s3_ship_target,
 )
 

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -15,7 +15,14 @@ from metrics_utility.exceptions import (
     NoAnalyticsCollected,
     UnparsableParameter,
 )
-from metrics_utility.management.validation import handle_crc_ship_target, handle_directory_ship_target, handle_s3_ship_target
+from metrics_utility.management.validation import (
+    handle_crc_ship_target,
+    handle_directory_ship_target,
+    handle_not_crc,
+    handle_not_s3,
+    handle_not_ship,
+    handle_s3_ship_target,
+)
 
 
 help_since = 'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
@@ -97,13 +104,18 @@ class Command(BaseCommand):
 
     def _handle_ship_target(self, ship_target):
         if ship_target == 'crc':
-            return handle_crc_ship_target(ship_target)
+            handle_not_s3()
+            return handle_crc_ship_target()
         elif ship_target == 'directory':
-            return handle_directory_ship_target(ship_target)
+            handle_not_crc()
+            handle_not_s3()
+            return handle_directory_ship_target()
         elif ship_target == 's3':
-            return handle_s3_ship_target(ship_target)
+            handle_not_crc()
+            return handle_s3_ship_target()
         else:
-            raise BadShipTarget('Unexpected value for METRICS_UTILITY_SHIP_TARGET env var, allowed values are [crc, s3, directory]')
+            allowed = ', '.join(['crc', 'directory', 's3'])
+            raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')
 
     def _handle_datelike(self, value, help=''):
         if not value:

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,36 +1,48 @@
+import logging
 import os
 
 from metrics_utility.exceptions import MissingRequiredEnvVar
 
 
-def handle_directory_ship_target(ship_target):
+logger = logging.getLogger(__name__)
+
+
+def handle_directory_ship_target():
     ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
 
     if not ship_path:
-        raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_SHIP_PATH, having destination for the generated data')
+        raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_SHIP_PATH - destination for the generated data')
 
     return {'ship_path': ship_path}
 
 
-def handle_s3_ship_target(ship_target):
+def handle_s3_ship_target():
     ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
     bucket_name = os.getenv('METRICS_UTILITY_BUCKET_NAME', None)
     bucket_endpoint = os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', None)
-    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION', None)
-    # Define S3 credentials
+    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION', None)  # optional
+
+    # S3 credentials
     bucket_access_key = os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', None)
     bucket_secret_key = os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY', None)
 
+    missing = []
+    if not bucket_name:
+        missing += ['METRICS_UTILITY_BUCKET_NAME - name of S3 bucket']
+    if not bucket_endpoint:
+        missing += ['METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com']
+    if not bucket_access_key:
+        missing += ['METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key']
+    if not bucket_secret_key:
+        missing += ['METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key']
     if not ship_path:
-        raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_SHIP_PATH, having destination for the generated data')
+        missing += ['METRICS_UTILITY_SHIP_PATH - destination for the generated data']
+    # bucket_region is optional
 
-    if not bucket_name or not bucket_endpoint or not bucket_access_key or not bucket_secret_key:
-        raise MissingRequiredEnvVar(
-            'Missing one of required env variables for S3 configuration, namely: METRICS_UTILITY_BUCKET_NAME,'
-            'METRICS_UTILITY_BUCKET_ENDPOINT, METRICS_UTILITY_BUCKET_ACCESS_KEY '
-            'and METRICS_UTILITY_BUCKET_SECRET_KEY.'
-        )
+    if missing:
+        raise MissingRequiredEnvVar(f'Missing some required env variables for S3 configuration, namely: {", ".join(missing)}.')
 
+    # S3Handler params
     return {
         'ship_path': ship_path,
         'bucket_name': bucket_name,
@@ -41,7 +53,25 @@ def handle_s3_ship_target(ship_target):
     }
 
 
-def handle_crc_ship_target(ship_target):
+def handle_not_s3():
+    surplus = []
+
+    if os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', None):
+        surplus += ['METRICS_UTILITY_BUCKET_ACCESS_KEY']
+    if os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', None):
+        surplus += ['METRICS_UTILITY_BUCKET_ENDPOINT']
+    if os.getenv('METRICS_UTILITY_BUCKET_NAME', None):
+        surplus += ['METRICS_UTILITY_BUCKET_NAME']
+    if os.getenv('METRICS_UTILITY_BUCKET_REGION', None):
+        surplus += ['METRICS_UTILITY_BUCKET_REGION']
+    if os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY', None):
+        surplus += ['METRICS_UTILITY_BUCKET_SECRET_KEY']
+
+    if surplus:
+        logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="s3": {", ".join(surplus)}')
+
+
+def handle_crc_ship_target():
     billing_provider = os.getenv('METRICS_UTILITY_BILLING_PROVIDER', None)
     red_hat_org_id = os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID', None)
 
@@ -57,4 +87,24 @@ def handle_crc_ship_target(ship_target):
     if red_hat_org_id:
         billing_provider_params['red_hat_org_id'] = red_hat_org_id
 
+    # only used for the other modes
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    if ship_path:
+        allowed = '", "'.join(['controller_db', 'directory', 's3'])
+        logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
+
     return billing_provider_params
+
+
+def handle_not_crc():
+    surplus = []
+
+    if os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', None):
+        surplus += ['METRICS_UTILITY_BILLING_ACCOUNT_ID']
+    if os.getenv('METRICS_UTILITY_BILLING_PROVIDER', None):
+        surplus += ['METRICS_UTILITY_BILLING_PROVIDER']
+    if os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID', None):
+        surplus += ['METRICS_UTILITY_RED_HAT_ORG_ID']
+
+    if surplus:
+        logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": {", ".join(surplus)}')

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -6,12 +6,14 @@ from metrics_utility.exceptions import MissingRequiredEnvVar
 
 logger = logging.getLogger(__name__)
 
+ship_path_description = 'place for collected data and built reports'
+
 
 def handle_directory_ship_target():
     ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
 
     if not ship_path:
-        raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_SHIP_PATH - destination for the generated data')
+        raise MissingRequiredEnvVar(f'Missing required env variable METRICS_UTILITY_SHIP_PATH - {ship_path_description}')
 
     return {'ship_path': ship_path}
 
@@ -36,7 +38,7 @@ def handle_s3_ship_target():
     if not bucket_secret_key:
         missing += ['METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key']
     if not ship_path:
-        missing += ['METRICS_UTILITY_SHIP_PATH - destination for the generated data']
+        missing += [f'METRICS_UTILITY_SHIP_PATH - {ship_path_description}']
     # bucket_region is optional
 
     if missing:

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -16,7 +16,14 @@ prepare()
 def temporary_env(new_env):
     """Temporarily update os.environ with new_env."""
     original = os.environ.copy()
-    os.environ.update(new_env)
+
+    # os.environ.update(new_env), but removing keys with None as value
+    for k, v in new_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
     try:
         yield
     finally:

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -4,10 +4,19 @@ from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar
 from metrics_utility.test.util import run_build_int, run_gather_int
 
 
+unset = {
+    'METRICS_UTILITY_BUCKET_ACCESS_KEY': None,
+    'METRICS_UTILITY_BUCKET_ENDPOINT': None,
+    'METRICS_UTILITY_BUCKET_NAME': None,
+    'METRICS_UTILITY_BUCKET_REGION': None,
+    'METRICS_UTILITY_BUCKET_SECRET_KEY': None,
+}
+
+
 def expect_build_error(env, klass):
     with pytest.raises(klass) as e:
         run_build_int(
-            env,
+            {**unset, **env},
             {
                 'month': '2022-01',
             },
@@ -18,7 +27,7 @@ def expect_build_error(env, klass):
 def expect_gather_error(env, klass):
     with pytest.raises(klass) as e:
         run_gather_int(
-            env,
+            {**unset, **env},
             {
                 'dry-run': True,
             },
@@ -68,6 +77,7 @@ def test_build_controller_db():
 def test_gather_crc(caplog):
     run_gather_int(
         {
+            **unset,
             'METRICS_UTILITY_SHIP_TARGET': 'crc',
             'METRICS_UTILITY_BILLING_PROVIDER': 'aws',
             'METRICS_UTILITY_BILLING_ACCOUNT_ID': '123456789012',
@@ -114,6 +124,7 @@ def test_gather_directory():
 
     run_gather_int(
         {
+            **unset,
             'METRICS_UTILITY_SHIP_TARGET': 'directory',
             'METRICS_UTILITY_SHIP_PATH': 'wherever',
         },
@@ -185,6 +196,7 @@ def test_gather_s3():
 
     run_gather_int(
         {
+            **unset,
             'METRICS_UTILITY_SHIP_TARGET': 's3',
             'METRICS_UTILITY_SHIP_PATH': 'wherever',
             'METRICS_UTILITY_BUCKET_NAME': 'something',
@@ -199,6 +211,7 @@ def test_gather_s3():
 
     run_gather_int(
         {
+            **unset,
             'METRICS_UTILITY_SHIP_TARGET': 's3',
             'METRICS_UTILITY_SHIP_PATH': 'wherever',
             'METRICS_UTILITY_BUCKET_NAME': 'something',

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -1,0 +1,205 @@
+import pytest
+
+from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar
+from metrics_utility.test.util import run_build_int, run_gather_int
+
+
+def expect_build_error(env, klass):
+    with pytest.raises(klass) as e:
+        run_build_int(
+            env,
+            {
+                'month': '2022-01',
+            },
+        )
+    return e.value
+
+
+def expect_gather_error(env, klass):
+    with pytest.raises(klass) as e:
+        run_gather_int(
+            env,
+            {
+                'dry-run': True,
+            },
+        )
+    return e.value
+
+
+def test_build_bad_target():
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'crc',
+        },
+        BadShipTarget,
+    )
+    assert e.name == 'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var (crc), allowed values: controller_db, directory, s3'
+
+
+def test_gather_bad_target():
+    e = expect_gather_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'controller_db',
+        },
+        BadShipTarget,
+    )
+    assert e.name == 'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var (controller_db), allowed values: crc, directory, s3'
+
+
+def test_build_controller_db():
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'controller_db',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'controller_db',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+
+
+def test_gather_crc(caplog):
+    run_gather_int(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'crc',
+            'METRICS_UTILITY_BILLING_PROVIDER': 'aws',
+            'METRICS_UTILITY_BILLING_ACCOUNT_ID': '123456789012',
+            'METRICS_UTILITY_SHIP_PATH': 'unexpected',
+        },
+        {
+            'dry-run': True,
+        },
+    )
+    assert caplog.messages[-1] == 'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="controller_db", "directory", "s3"'
+
+
+def test_build_directory(caplog):
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'directory',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'directory',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'unexpected',
+            'METRICS_UTILITY_BILLING_PROVIDER': 'unexpected',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+    assert caplog.messages[-1] == 'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="s3": METRICS_UTILITY_BUCKET_NAME'
+    assert caplog.messages[-2] == 'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": METRICS_UTILITY_BILLING_PROVIDER'
+
+
+def test_gather_directory():
+    e = expect_gather_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'directory',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+
+    run_gather_int(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 'directory',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+        },
+        {
+            'dry-run': True,
+        },
+    )
+
+
+def test_build_s3():
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert (
+        e.name
+        == 'Missing some required env variables for S3 configuration, namely: METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+    )
+
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'S3 access key',
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': 'S3 secret key',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'S3 access key',
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': 'S3 secret key',
+            'METRICS_UTILITY_BUCKET_REGION': 'optional',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+
+
+def test_gather_s3():
+    e = expect_gather_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert (
+        e.name
+        == 'Missing some required env variables for S3 configuration, namely: METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+    )
+
+    run_gather_int(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'S3 access key',
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': 'S3 secret key',
+        },
+        {
+            'dry-run': True,
+        },
+    )
+
+    run_gather_int(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'S3 access key',
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': 'S3 secret key',
+            'METRICS_UTILITY_BUCKET_REGION': 'optional',
+        },
+        {
+            'dry-run': True,
+        },
+    )

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -131,8 +131,12 @@ def test_build_s3():
         MissingRequiredEnvVar,
     )
     assert (
-        e.name
-        == 'Missing some required env variables for S3 configuration, namely: METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+        e.name == 'Missing some required env variables for S3 configuration, namely: '
+        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
+        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
+        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
+        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
+        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
     )
 
     e = expect_build_error(
@@ -171,8 +175,12 @@ def test_gather_s3():
         MissingRequiredEnvVar,
     )
     assert (
-        e.name
-        == 'Missing some required env variables for S3 configuration, namely: METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+        e.name == 'Missing some required env variables for S3 configuration, namely: '
+        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
+        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
+        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
+        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
+        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
     )
 
     run_gather_int(


### PR DESCRIPTION
Issue: AAP-45501
   
This updates error handling for these variables, when `METRICS_UTILITY_SHIP_TARGET === 's3'`
    
* `METRICS_UTILITY_BUCKET_ACCESS_KEY`
* `METRICS_UTILITY_BUCKET_ENDPOINT`
* `METRICS_UTILITY_BUCKET_NAME`
* `METRICS_UTILITY_BUCKET_REGION`
* `METRICS_UTILITY_BUCKET_SECRET_KEY`

(And cleans up a bit around `METRICS_UTILITY_SHIP_PATH`.)

Adds a non-fatal warning when present for different ship targets.