### PR TITLE
tests: Move prepare() to conftest.py

### DIFF
--- a/metrics_utility/test/conftest.py
+++ b/metrics_utility/test/conftest.py
@@ -1,0 +1,6 @@
+from metrics_utility import prepare
+
+
+# this updates python paths to include mock_awx/ (and not fail to find awx imports)
+# has to happen before any tests that import code that imports awx are imported
+prepare()

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -6,11 +6,6 @@ from contextlib import contextmanager
 
 import pytest
 
-from metrics_utility import prepare
-
-
-prepare()
-
 
 @contextmanager
 def temporary_env(new_env):


### PR DESCRIPTION
`prepare()` needs to be called before we import anything from awx, even transitively
otherwise the imports fail, instead of loading from `mock_awx/`

the problem with having it in util is that

```
from .......commands.gather import GatherBase

import .......test.util 
```

will fail on the first import before getting to the second

`conftest` seems to be running before any other testfile gets loaded (and doesn't need to be manually imported) :tada: 

Cc @AlexSCorey this might help with the issue you've been seeing?