### PR TITLE
[AAP-45575 AAP-45757]Adds host metrics mock data

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Import SQL dump"
         run: |
-          cat tools/docker/{roles,latest}.sql | sudo su - postgres -c psql
+          cat tools/docker/{roles,latest,main_hostmetric}.sql | sudo su - postgres -c psql
 
       - name: "Set up minio"
         env:

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,10 @@ fix:
 compose:
 	docker compose -f tools/docker/docker-compose.yaml up
 
+# This will populate the main_hostmetric table in the db with data. The database must be up and running first.
+populate_host_metrics:
+	docker cp tools/docker/main_hostmetric.sql postgres:/main_hostmetric.sql
+	docker exec postgres psql -U myuser -d awx -f /main_hostmetric.sql
+
+
 .PHONY: help sync test coverage lint fix compose

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -42,8 +42,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./roles.sql:/docker-entrypoint-initdb.d/init-roles.sql
-      - ./latest.sql:/docker-entrypoint-initdb.d/init-schema.sql
+      - ./roles.sql:/docker-entrypoint-initdb.d/init-0-roles.sql
+      - ./latest.sql:/docker-entrypoint-initdb.d/init-1-schema.sql
+      - ./main_hostmetric.sql:/docker-entrypoint-initdb.d/init-2-hostmetric.sql
 
   postgres-wait:
     image: "mirror.gcr.io/postgres"

--- a/tools/docker/main_hostmetric.sql
+++ b/tools/docker/main_hostmetric.sql
@@ -1,0 +1,21 @@
+INSERT INTO public.main_hostmetric (
+    hostname,
+    first_automation,
+    last_automation,
+    last_deleted,
+    automated_counter,
+    deleted_counter,
+    deleted,
+    used_in_inventories
+) VALUES
+('host-01.example.com', '2025-05-01T08:00:00+00', '2025-05-10T14:30:00+00', NULL, 12, 0, false, 3),
+('host-02.example.com', '2025-04-28T09:15:00+00', '2025-05-12T16:00:00+00', '2025-05-20T10:00:00+00', 5, 1, true, 1),
+('host-03.example.com', '2025-05-03T12:00:00+00', '2025-05-11T13:45:00+00', NULL, 7, 0, false, 2),
+('host-04.example.com', '2025-05-02T07:30:00+00', '2025-05-09T15:30:00+00', NULL, 10, 0, false, 5),
+('host-05.example.com', '2025-04-30T10:00:00+00', '2025-05-08T11:00:00+00', '2025-05-15T12:00:00+00', 3, 2, true, 0),
+('host-06.example.com', '2025-05-01T06:45:00+00', '2025-05-06T13:15:00+00', NULL, 6, 1, true, 1),
+('host-07.example.com', '2025-05-04T10:30:00+00', '2025-05-10T12:30:00+00', NULL, 8, 0, false, 4),
+('host-08.example.com', '2025-04-29T09:45:00+00', '2025-05-07T14:00:00+00', '2025-05-13T09:30:00+00', 4, 1, true, 2),
+('host-09.example.com', '2025-05-05T08:30:00+00', '2025-05-10T16:00:00+00', NULL, 9, 0, false, 3),
+('host-10.example.com', '2025-05-03T11:15:00+00', '2025-05-11T10:45:00+00', NULL, 11, 0, false, 2);
+;


### PR DESCRIPTION
Introduces a make command which will populate the postgres db with data for host_metrics, which will be useful when testing/working with the renewal guidance report.  This will help with AAP-45575 and AAP-45757