### PR TITLE
Cleanups around params

### DIFF
--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -15,16 +15,6 @@ class ExtractorControllerDB:
 
         self.logger = logger
 
-    def get_report_path(self, date):
-        path_prefix = f'{self.path}/reports'
-
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-
-        path = f'{path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self):
         with connection.cursor() as cursor:
             cursor.execute(self.pg_functions())

--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -25,16 +25,6 @@ class ExtractorDirectory(Base):
 
         return path
 
-    def get_report_path(self, date):
-        path_prefix = f'{self.path}/reports'
-
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-
-        path = f'{path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
             batch_size = self.batch_size()

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -32,14 +32,6 @@ class ExtractorS3(Base):
 
         return path
 
-    def get_report_path(self, date):
-        report_path_prefix = f'{self.path}/reports'
-
-        year, month = self._create_date_string(date)
-        path = f'{report_path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
             batch_size = self.batch_size()

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -126,7 +126,7 @@ def parse_number_of_days(value, help=''):
     raise UnparsableParameter(f"Can't parse parameter value {value} ({help})")
 
 
-def handle_month(month):
+def parse_month(month):
     """Process month argument"""
     if month is not None:
         try:

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -133,12 +133,12 @@ def handle_month(month):
     """Process month argument"""
     if month is not None:
         try:
-            date = datetime.datetime.strptime(f'{month}', '%Y-%m')
+            date = datetime.strptime(f'{month}', '%Y-%m')
         except ValueError:
             raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
     else:
         """Return last month if no month was passed"""
-        beginning_of_the_month = datetime.datetime.today().replace(day=1)
+        beginning_of_the_month = datetime.today().replace(day=1)
         beginning_of_the_previous_month = beginning_of_the_month - relativedelta(months=1)
         date = beginning_of_the_previous_month
         y = date.strftime('%Y')

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -1,15 +1,8 @@
 import json
-import re
 
-from datetime import datetime, timedelta, timezone
 from itertools import chain
 
 import pandas as pd
-
-from dateutil import parser
-from dateutil.relativedelta import relativedelta
-
-from metrics_utility.exceptions import DateFormatError, UnparsableParameter
 
 
 def parse_json_array(x):
@@ -62,84 +55,3 @@ def merge_arrays(values):
     # Flatten the list of lists and extract unique events
     unique = set(chain.from_iterable(valid_events))
     return list(unique)
-
-
-# should also suport quarters, start/end of month ("4mo_ago_beginning" vs "1 mo ago end"), but doesn't yet
-def parse_date_param(value, help=''):
-    if not value:
-        return None
-
-    value = value.strip().lower()
-    if value.isdigit():
-        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
-
-    now = datetime.now()
-    parsed_date = None
-
-    # N days ago, start of day
-    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)(\s*_*ago)?', value)
-    if match:
-        days_ago = int(match.group(1))
-        parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-
-    # N months ago, start of day
-    match = re.fullmatch(r'(\d+)\s*_*(mo|mon|mont|month|months)(\s*_*ago)?', value)
-    if match:
-        months_ago = int(match.group(1))
-        parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-
-    # N minutes ago
-    match = re.fullmatch(r'(\d+)\s*_*(m|mi|min|minu|minut|minute|minutes)(\s*_*ago)?', value)
-    if match:
-        minutes_ago = int(match.group(1))
-        parsed_date = now - timedelta(minutes=minutes_ago)
-
-    # actual date
-    if not parsed_date:
-        parsed_date = parser.parse(value)
-
-    # Add default UTC timezone
-    if parsed_date and parsed_date.tzinfo is None:
-        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
-
-    return parsed_date
-
-
-def parse_number_of_days(value, help=''):
-    if not value:
-        return None
-
-    value = value.strip().lower()
-    if value.isdigit():
-        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
-
-    # N days ago
-    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)', value)
-    if match:
-        return int(match.group(1))
-
-    # N months ago - using 30 days per month
-    match = re.fullmatch(r'(\d+)\s*_*(m|mo|mon|mont|month|months)', value)
-    if match:
-        return int(match.group(1)) * 30
-
-    raise UnparsableParameter(f"Can't parse parameter value {value} ({help})")
-
-
-def parse_month(month):
-    """Process month argument"""
-    if month is not None:
-        try:
-            date = datetime.strptime(f'{month}', '%Y-%m')
-        except ValueError:
-            raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
-    else:
-        """Return last month if no month was passed"""
-        beginning_of_the_month = datetime.today().replace(day=1)
-        beginning_of_the_previous_month = beginning_of_the_month - relativedelta(months=1)
-        date = beginning_of_the_previous_month
-        y = date.strftime('%Y')
-        m = date.strftime('%m')
-        month = f'{y}-{m}'
-
-    return month, date, date + relativedelta(months=1)

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -70,11 +70,14 @@ def merge_arrays(values):
 
 
 def parse_date_param(date_option):
+    if not date_option:
+        return None
+
     parsed_date = None
-    if date_option and date_option.endswith('d'):
+    if date_option.endswith('d'):
         days_ago = int(date_option[0:-1])
         parsed_date = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option and (date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months')):
+    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
         if date_option.endswith('mo'):
             suffix_length = len('mo')
         elif date_option.endswith('month'):
@@ -83,12 +86,13 @@ def parse_date_param(date_option):
             suffix_length = len('months')
         months_ago = int(date_option[0:-suffix_length])
         parsed_date = (datetime.datetime.now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option and date_option.endswith('m'):
+    elif date_option.endswith('m'):
         minutes_ago = int(date_option[0:-1])
         parsed_date = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
     else:
-        parsed_date = parser.parse(date_option) if date_option else None
-    # Add default utc timezone
+        parsed_date = parser.parse(date_option)
+
+    # Set timezone to UTC when missing
     if parsed_date and parsed_date.tzinfo is None:
         parsed_date = parsed_date.replace(tzinfo=timezone.utc)
 

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -12,11 +12,6 @@ from dateutil.relativedelta import relativedelta
 from metrics_utility.exceptions import DateFormatError, UnparsableParameter
 
 
-ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
-SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
-SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
-
-
 def parse_json_array(x):
     if pd.isnull(x):
         return []

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -1,7 +1,7 @@
-import datetime
 import json
+import re
 
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 from itertools import chain
 
 import pandas as pd
@@ -64,30 +64,40 @@ def merge_arrays(values):
     return list(unique)
 
 
-def parse_date_param(date_option):
-    if not date_option:
+def parse_date_param(value, help=''):
+    if not value:
         return None
 
-    parsed_date = None
-    if date_option.endswith('d'):
-        days_ago = int(date_option[0:-1])
-        parsed_date = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
-        months_ago = int(date_option[0:-suffix_length])
-        parsed_date = (datetime.datetime.now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('m'):
-        minutes_ago = int(date_option[0:-1])
-        parsed_date = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        parsed_date = parser.parse(date_option)
+    value = value.strip().lower()
+    if value.isdigit():
+        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
 
-    # Set timezone to UTC when missing
+    now = datetime.now()
+    parsed_date = None
+
+    # N days ago, start of day
+    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)', value)
+    if match:
+        days_ago = int(match.group(1))
+        parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # N months ago, start of day
+    match = re.fullmatch(r'(\d+)\s*(mo|mon|mont|month|months)', value)
+    if match:
+        months_ago = int(match.group(1))
+        parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # N minutes ago
+    match = re.fullmatch(r'(\d+)\s*(m|mi|min|minu|minut|minute|minutes)', value)
+    if match:
+        minutes_ago = int(match.group(1))
+        parsed_date = now - timedelta(minutes=minutes_ago)
+
+    # actual date
+    if not parsed_date:
+        parsed_date = parser.parse(value)
+
+    # Add default UTC timezone
     if parsed_date and parsed_date.tzinfo is None:
         parsed_date = parsed_date.replace(tzinfo=timezone.utc)
 

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -77,19 +77,19 @@ def parse_date_param(value, help=''):
     parsed_date = None
 
     # N days ago, start of day
-    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)([_\s]ago)?', value)
+    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)(\s*_*ago)?', value)
     if match:
         days_ago = int(match.group(1))
         parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N months ago, start of day
-    match = re.fullmatch(r'(\d+)\s*(mo|mon|mont|month|months)([_\s]ago)?', value)
+    match = re.fullmatch(r'(\d+)\s*_*(mo|mon|mont|month|months)(\s*_*ago)?', value)
     if match:
         months_ago = int(match.group(1))
         parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N minutes ago
-    match = re.fullmatch(r'(\d+)\s*(m|mi|min|minu|minut|minute|minutes)([_\s]ago)?', value)
+    match = re.fullmatch(r'(\d+)\s*_*(m|mi|min|minu|minut|minute|minutes)(\s*_*ago)?', value)
     if match:
         minutes_ago = int(match.group(1))
         parsed_date = now - timedelta(minutes=minutes_ago)
@@ -114,12 +114,12 @@ def parse_number_of_days(value, help=''):
         raise UnparsableParameter(f'Bare numbers are not valid ({help})')
 
     # N days ago
-    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)', value)
+    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)', value)
     if match:
         return int(match.group(1))
 
     # N months ago - using 30 days per month
-    match = re.fullmatch(r'(\d+)\s*(m|mo|mon|mont|month|months)', value)
+    match = re.fullmatch(r'(\d+)\s*_*(m|mo|mon|mont|month|months)', value)
     if match:
         return int(match.group(1)) * 30
 

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -64,6 +64,7 @@ def merge_arrays(values):
     return list(unique)
 
 
+# should also suport quarters, start/end of month ("4mo_ago_beginning" vs "1 mo ago end"), but doesn't yet
 def parse_date_param(value, help=''):
     if not value:
         return None
@@ -76,19 +77,19 @@ def parse_date_param(value, help=''):
     parsed_date = None
 
     # N days ago, start of day
-    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)', value)
+    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)([_\s]ago)?', value)
     if match:
         days_ago = int(match.group(1))
         parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N months ago, start of day
-    match = re.fullmatch(r'(\d+)\s*(mo|mon|mont|month|months)', value)
+    match = re.fullmatch(r'(\d+)\s*(mo|mon|mont|month|months)([_\s]ago)?', value)
     if match:
         months_ago = int(match.group(1))
         parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N minutes ago
-    match = re.fullmatch(r'(\d+)\s*(m|mi|min|minu|minut|minute|minutes)', value)
+    match = re.fullmatch(r'(\d+)\s*(m|mi|min|minu|minut|minute|minutes)([_\s]ago)?', value)
     if match:
         minutes_ago = int(match.group(1))
         parsed_date = now - timedelta(minutes=minutes_ago)
@@ -104,29 +105,25 @@ def parse_date_param(value, help=''):
     return parsed_date
 
 
-def parse_number_of_days(date_option):
-    if date_option and (date_option.endswith('d') or date_option.endswith('day') or date_option.endswith('days')):
-        if date_option.endswith('d'):
-            suffix_length = len('d')
-        elif date_option.endswith('day'):
-            suffix_length = len('day')
-        elif date_option.endswith('days'):
-            suffix_length = len('days')
+def parse_number_of_days(value, help=''):
+    if not value:
+        return None
 
-        days = int(date_option[0:-suffix_length])
-    elif date_option and (date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months')):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
+    value = value.strip().lower()
+    if value.isdigit():
+        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
 
-        days = int(date_option[0:-suffix_length]) * 30  # using 30 days per month
-    else:
-        raise UnparsableParameter(f"Can't parse parameter value {date_option}")
+    # N days ago
+    match = re.fullmatch(r'(\d+)\s*(d|da|day|days)', value)
+    if match:
+        return int(match.group(1))
 
-    return days
+    # N months ago - using 30 days per month
+    match = re.fullmatch(r'(\d+)\s*(m|mo|mon|mont|month|months)', value)
+    if match:
+        return int(match.group(1)) * 30
+
+    raise UnparsableParameter(f"Can't parse parameter value {value} ({help})")
 
 
 def handle_month(month):

--- a/metrics_utility/automation_controller_billing/report/factory.py
+++ b/metrics_utility/automation_controller_billing/report/factory.py
@@ -5,17 +5,12 @@ from metrics_utility.automation_controller_billing.report.report_renewal_guidanc
 
 class Factory:
     def __init__(self, report_period, report_dataframe, ship_target, extra_params):
-        if extra_params.get('report_period_range') is not None:
-            self.report_period = extra_params.get('report_period_range')
-        else:
-            self.report_period = report_period
-
+        self.report_period = report_period
         self.report_dataframe = report_dataframe
-
         self.ship_target = ship_target
+        self.extra_params = extra_params
 
         self.report_type = extra_params['report_type']
-        self.extra_params = extra_params
 
     def create(self):
         if self.report_type == 'CCSP':

--- a/metrics_utility/automation_controller_billing/report/factory.py
+++ b/metrics_utility/automation_controller_billing/report/factory.py
@@ -4,10 +4,8 @@ from metrics_utility.automation_controller_billing.report.report_renewal_guidanc
 
 
 class Factory:
-    def __init__(self, report_period, report_dataframe, ship_target, extra_params):
-        self.report_period = report_period
+    def __init__(self, report_dataframe, extra_params):
         self.report_dataframe = report_dataframe
-        self.ship_target = ship_target
         self.extra_params = extra_params
 
         self.report_type = extra_params['report_type']
@@ -22,12 +20,12 @@ class Factory:
 
     def _get_report_ccsp(self):
         # Return default S3 loader
-        return ReportCCSP(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportCCSP(self.report_dataframe, self.extra_params)
 
     def _get_report_ccsp_v2(self):
         # Return default S3 loader
-        return ReportCCSPv2(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportCCSPv2(self.report_dataframe, self.extra_params)
 
     def _get_report_renewal_guidance(self):
         # Return default S3 loader
-        return ReportRenewalGuidance(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportRenewalGuidance(self.report_dataframe, self.extra_params)

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -10,14 +10,15 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSP(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         # Create the workbook and worksheet
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'sku': extra_params['report_sku'],

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -16,13 +16,14 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSPv2(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'sku': extra_params['report_sku'],

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -16,13 +16,14 @@ from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup
 
 
 class ReportRenewalGuidance(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'h1_heading': {

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -10,7 +10,6 @@ from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils.dataframe import dataframe_to_rows
 
-from metrics_utility.automation_controller_billing.helpers import parse_number_of_days
 from metrics_utility.automation_controller_billing.report.base import Base
 from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup import Dedup
 
@@ -22,6 +21,7 @@ class ReportRenewalGuidance(Base):
         self.dataframe = dataframe
         self.extra_params = extra_params
 
+        self.ephemeral_days = extra_params['ephemeral_days']
         self.price_per_node = extra_params['price_per_node']
         self.report_period = extra_params['report_period']
 
@@ -62,7 +62,7 @@ class ReportRenewalGuidance(Base):
         host_metric_dataframe['days_automated'] = host_metric_dataframe['days_automated'].apply(lambda x: x if x > 0 else 0)
 
         ephemeral_usage_dataframe = None
-        if self.extra_params.get('opt_ephemeral') is not None:
+        if self.ephemeral_days:
             # Looking at the historical ephemeral usage, so we want to looks also at records that
             # were soft-deleted already.
             ephemeral_usage_dataframe = self.compute_ephemeral_intervals(
@@ -85,7 +85,7 @@ class ReportRenewalGuidance(Base):
         # Add optional sheets
         if 'managed_nodes' in self.optional_report_sheets():
             # Sheet with list of managed nodes
-            if self.extra_params.get('opt_ephemeral') is None:
+            if not self.ephemeral_days:
                 ws = self.add_sheet('Managed nodes', sheet_index, self.config['data_column_widths'])
                 self._build_data_section_host_metrics(1, ws, self.df_managed_nodes_query(host_metric_dataframe))
                 sheet_index += 1
@@ -116,21 +116,19 @@ class ReportRenewalGuidance(Base):
             if not with_deleted:
                 dataframe = dataframe[~dataframe['deleted']]
 
-            # Filter ephemeral based on number of automated days
-            ephemeral_days = parse_number_of_days(self.extra_params.get('opt_ephemeral'))
-
             # Ephemeral threshold, host's first automation must be older than ephemeral threshold
             # to be considered as ephemeral
             ephemeral_threshold = (
-                pd.to_datetime(datetime.datetime.now() - datetime.timedelta(days=ephemeral_days - 1), format='ISO8601')
+                pd.to_datetime(datetime.datetime.now() - datetime.timedelta(days=self.ephemeral_days - 1), format='ISO8601')
                 .replace(hour=0, minute=0, second=0, microsecond=0)
                 .tz_localize(None)
             )
 
+            # Filter ephemeral based on number of automated days
             if ephemeral is True:
-                return dataframe[(dataframe['days_automated'] <= ephemeral_days) & (dataframe['first_automation'] <= ephemeral_threshold)]
+                return dataframe[(dataframe['days_automated'] <= self.ephemeral_days) & (dataframe['first_automation'] <= ephemeral_threshold)]
             if ephemeral is False:
-                return dataframe[(dataframe['days_automated'] > ephemeral_days) | (dataframe['first_automation'] > ephemeral_threshold)]
+                return dataframe[(dataframe['days_automated'] > self.ephemeral_days) | (dataframe['first_automation'] > ephemeral_threshold)]
 
     def df_deleted_managed_nodes_query(self, dataframe):
         return dataframe[dataframe['deleted']]
@@ -157,9 +155,8 @@ class ReportRenewalGuidance(Base):
             - datetime.timedelta(microseconds=1)
         )
 
-        ephemeral_days = parse_number_of_days(self.extra_params.get('opt_ephemeral'))
         ephemeral_usage_intervals = []
-        intervals = self.get_intervals(start_date, end_date, ephemeral_days)
+        intervals = self.get_intervals(start_date, end_date, self.ephemeral_days)
         for window_start, window_end in intervals:
             # print(f"Processing {window_start}, {window_end}")
             filtered = host_metric_dataframe[
@@ -201,7 +198,7 @@ class ReportRenewalGuidance(Base):
 
         ccsp_report = []
 
-        if self.extra_params.get('opt_ephemeral') is None:
+        if not self.ephemeral_days:
             # Automated hosts
             ccsp_report_item = {'description': 'Automated hosts', 'quantity_consumed': self.df_managed_nodes_query(dataframe)['hostname'].nunique()}
             ccsp_report.append(ccsp_report_item)

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -422,7 +422,7 @@ class ReportRenewalGuidance(Base):
             if header_row['label'] == 'Report Period (YYYY-MM-DD, YYYY-MM-DD)':
                 # Insert dynamic report period into the specific header column
                 cell.fill = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
-                cell.value = self.extra_params['report_period_range']
+                cell.value = self.report_period
             else:
                 cell.fill = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
                 cell.value = header_row['value']

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -66,8 +66,6 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
-        handle_env_validation('build')
-
         parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=HelpText.ephemeral)
         parser.add_argument('--force', dest='force', action='store_true', help=HelpText.force)
         parser.add_argument('--month', dest='month', action='store', help=HelpText.month)
@@ -95,6 +93,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.init_logging()
+
+        handle_env_validation('build')
+
         og_month, month, next_month = handle_month(options.get('month') or None)
 
         validate_build_extra_params(HelpText, options)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -46,7 +46,6 @@ class Command(BaseCommand):
 
     def __init__(self):
         super().__init__()
-
         self.help = {
             'since': (
                 'Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m), '

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -15,13 +15,9 @@ from metrics_utility.automation_controller_billing.helpers import (
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import (
-    BadParameter,
     BadRequiredEnvVar,
     BadShipTarget,
-    DateFormatError,
     MissingRequiredEnvVar,
-    MissingRequiredParameter,
-    UnparsableParameter,
 )
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
@@ -87,7 +83,7 @@ class Command(BaseCommand):
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(logging.Formatter('%(message)s'))
         self.logger.addHandler(handler)
-        self.logger.propagate = True
+        self.logger.propagate = False
 
     def _parse_param(
         self,
@@ -99,7 +95,7 @@ class Command(BaseCommand):
             return None
         return parse_date_param(param)
 
-    def _handle(self, *args, **options):
+    def handle(self, *args, **options):
         self.init_logging()
         og_month, month, next_month = handle_month(options.get('month') or None)
 
@@ -168,24 +164,6 @@ class Command(BaseCommand):
         # Save the report to the configured destination
         report_saver_engine.save(report_spreadsheet)
         self.logger.info(f'Report generated into {ship_target}: {report_saver_engine.report_spreadsheet_destination_path}')
-
-    def handle(self, *args, **options):
-        try:
-            self._handle(*args, **options)
-        except (
-            BadShipTarget,
-            MissingRequiredEnvVar,
-            BadRequiredEnvVar,
-            MissingRequiredParameter,
-            UnparsableParameter,
-            BadParameter,
-            DateFormatError,
-        ) as e:
-            self.logger.error(str(e))
-            exit(1)
-        except Exception as e:
-            self.logger.exception(e)
-            exit(1)
 
     def _handle_ship_target(self, ship_target):
         if ship_target in ['controller_db', 'directory']:

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -128,14 +128,13 @@ class Command(BaseCommand):
             extra_params['since_date'] = opt_since.date()
             extra_params['until_date'] = opt_until.date() if opt_until else now.date()
 
-            report_period = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
-
+            extra_params['report_period'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 get_report_path(extra_params['ship_path'], extra_params['until_date']),
                 f'{extra_params["report_type"]}-{extra_params["since_date"]}--{extra_params["until_date"]}.xlsx',
             )
         else:
-            report_period = opt_month
+            extra_params['report_period'] = opt_month
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 get_report_path(extra_params['ship_path'], month),
                 f'{extra_params["report_type"]}-{opt_month}.xlsx',
@@ -161,12 +160,7 @@ class Command(BaseCommand):
                 self.logger.info(f'No billing data for month {opt_month}')
             return
 
-        report_engine = ReportFactory(
-            report_period=report_period,
-            report_dataframe=report_dataframe,
-            ship_target=ship_target,
-            extra_params=extra_params,
-        ).create()
+        report_engine = ReportFactory(report_dataframe=report_dataframe, extra_params=extra_params).create()
         report_spreadsheet = report_engine.build_spreadsheet()
 
         # Save the report to the configured destination

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -11,6 +11,7 @@ from metrics_utility.automation_controller_billing.extract.factory import Factor
 from metrics_utility.automation_controller_billing.helpers import (
     handle_month,
     parse_date_param,
+    parse_number_of_days,
 )
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
@@ -113,14 +114,14 @@ class Command(BaseCommand):
         opt_month, month, next_month = handle_month(options.get('month') or None)
         opt_since = parse_date_param(options.get('since') or None, HelpText.since) if not opt_month else None
         opt_until = parse_date_param(options.get('until') or None, HelpText.until) if not opt_month and opt_since else None
-
+        opt_ephemeral = parse_number_of_days(options.get('ephemeral') or None, HelpText.ephemeral)
         opt_force = options.get('force')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         extra_params = self._handle_extra_params(ship_target)
         extra_params['opt_since'] = opt_since
         extra_params['opt_until'] = opt_until
-        extra_params['opt_ephemeral'] = options.get('ephemeral') or None
+        extra_params['ephemeral_days'] = opt_ephemeral
         extra_params['month_since'] = month
         extra_params['month_until'] = next_month
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -8,11 +8,6 @@ from django.core.management.base import BaseCommand
 
 from metrics_utility.automation_controller_billing.dataframe_engine.factory import Factory as DataframeEngineFactory
 from metrics_utility.automation_controller_billing.extract.factory import Factory as ExtractorFactory
-from metrics_utility.automation_controller_billing.helpers import (
-    handle_month,
-    parse_date_param,
-    parse_number_of_days,
-)
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import (
@@ -26,7 +21,7 @@ from metrics_utility.management.validation import (
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
-    validate_build_extra_params,
+    validate_build_params,
 )
 from metrics_utility.metric_utils import get_optional_collectors
 
@@ -109,19 +104,18 @@ class Command(BaseCommand):
         self.init_logging()
 
         handle_env_validation('build')
-        validate_build_extra_params(HelpText, options)
+        parsed = validate_build_params(options, HelpText)
 
-        opt_month, month, next_month = handle_month(options.get('month') or None)
-        opt_since = parse_date_param(options.get('since') or None, HelpText.since) if not opt_month else None
-        opt_until = parse_date_param(options.get('until') or None, HelpText.until) if not opt_month and opt_since else None
-        opt_ephemeral = parse_number_of_days(options.get('ephemeral') or None, HelpText.ephemeral)
+        opt_month, month, next_month = parsed['month']
+        opt_since = parsed['since']
+        opt_until = parsed['until']
         opt_force = options.get('force')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         extra_params = self._handle_extra_params(ship_target)
         extra_params['opt_since'] = opt_since
         extra_params['opt_until'] = opt_until
-        extra_params['ephemeral_days'] = opt_ephemeral
+        extra_params['ephemeral_days'] = parsed['ephemeral_days']
         extra_params['month_since'] = month
         extra_params['month_until'] = next_month
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -48,16 +48,26 @@ class Command(BaseCommand):
         super().__init__()
 
         self.help = {
-            'since': """Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m),
-              a number of days ago (--since=5d), or a number of months (--since=2m).""",
-            'until': 'End date for collection including (e.g. --until=2023-12-21), a number of minutes (--until=2m), '
-            'a number of days ago (--until=5d), or a number of months (--until=2m).',
-            'time_frame_extra_params': 'Missing required parameter --month, --until, or --since. Metrics utility requires a value for at least '
-            'one of the following: month, since, until.',
-            'month': """Month the report will be generated for, with format YYYY-MM. If this params is not provided, previous month report
-             will be generated if it doesn't exists already.""",
-            'ephemeral': """Duration in months or days to determine if host is ephemeral. Months are taken as 30days duration.
-            Example: --ephemeral=3months, or --ephemeral=3days""",
+            'since': (
+                'Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m), '
+                'a number of days ago (--since=5d), or a number of months (--since=2m).'
+            ),
+            'until': (
+                'End date for collection including (e.g. --until=2023-12-21), a number of minutes (--until=2m), '
+                'a number of days ago (--until=5d), or a number of months (--until=2m).'
+            ),
+            'time_frame_extra_params': (
+                'Missing required parameter --month, --until, or --since. Metrics utility requires a value for at least '
+                'one of the following: month, since, until.'
+            ),
+            'month': (
+                'Month the report will be generated for, with format YYYY-MM. If this params is not provided, '
+                "previous month report will be generated if it doesn't exists already."
+            ),
+            'ephemeral': (
+                'Duration in months or days to determine if host is ephemeral. Months are taken as 30days duration. '
+                'Example: --ephemeral=3months, or --ephemeral=3days'
+            ),
         }
 
     def add_arguments(self, parser):

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -63,17 +63,38 @@ class HelpText:
 
 class Command(BaseCommand):
     """
-    Gather Automation Controller billing data
+    Build a XLSX report
     """
 
-    help = 'Gather Automation Controller billing data'
+    help = 'Build a XLSX report'
 
     def add_arguments(self, parser):
-        parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=HelpText.ephemeral)
-        parser.add_argument('--force', dest='force', action='store_true', help=HelpText.force)
-        parser.add_argument('--month', dest='month', action='store', help=HelpText.month)
-        parser.add_argument('--since', dest='since', action='store', help=HelpText.since)
-        parser.add_argument('--until', dest='until', action='store', help=HelpText.until)
+        report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+        allowed = ['CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE']
+        current = 'none' if report_type not in allowed else report_type
+
+        group = parser.add_argument_group(
+            'Note',
+            f'The availability of some arguments depends on METRICS_UTILITY_REPORT_TYPE. Allowed values: {", ".join(allowed)}; current: {current}',
+        )
+
+        if report_type in ['CCSP', 'CCSPv2']:
+            # since and month are mutually exclusive
+            exclusive = group.add_mutually_exclusive_group(required=False)
+            exclusive.add_argument('--month', dest='month', action='store', help=HelpText.month)
+        else:
+            exclusive = group
+
+        exclusive.add_argument('--since', dest='since', action='store', help=HelpText.since)
+
+        if report_type in ['CCSP', 'CCSPv2']:
+            group.add_argument('--until', dest='until', action='store', help=HelpText.until)
+
+        if report_type in ['RENEWAL_GUIDANCE']:
+            group.add_argument('--ephemeral', dest='ephemeral', action='store', help=HelpText.ephemeral)
+
+        group.add_argument('--force', dest='force', action='store_true', help=HelpText.force)
+
         parser.add_argument('--verbose', dest='verbose', action='store_true', help=HelpText.verbose)
 
     def init_logging(self):

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -128,13 +128,14 @@ class Command(BaseCommand):
             extra_params['since_date'] = opt_since.date()
             extra_params['until_date'] = opt_until.date() if opt_until else now.date()
 
-            extra_params['report_period_range'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
+            report_period = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
 
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 get_report_path(extra_params['ship_path'], extra_params['until_date']),
                 f'{extra_params["report_type"]}-{extra_params["since_date"]}--{extra_params["until_date"]}.xlsx',
             )
         else:
+            report_period = opt_month
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 get_report_path(extra_params['ship_path'], month),
                 f'{extra_params["report_type"]}-{opt_month}.xlsx',
@@ -161,7 +162,7 @@ class Command(BaseCommand):
             return
 
         report_engine = ReportFactory(
-            report_period=opt_month,
+            report_period=report_period,
             report_dataframe=report_dataframe,
             ship_target=ship_target,
             extra_params=extra_params,

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -104,27 +104,16 @@ class Command(BaseCommand):
         self.logger.addHandler(handler)
         self.logger.propagate = False
 
-    def _parse_param(
-        self,
-        param_name,
-        options,
-    ):
-        param = options.get(param_name)
-        if options.get('month') is not None or param is None:
-            return None
-        return parse_date_param(param)
-
     def handle(self, *args, **options):
         self.init_logging()
 
         handle_env_validation('build')
-
-        og_month, month, next_month = handle_month(options.get('month') or None)
-
         validate_build_extra_params(HelpText, options)
-        opt_month = og_month if options.get('month') else None
-        opt_until = self._parse_param('until', options)
-        opt_since = self._parse_param('since', options)
+
+        opt_month, month, next_month = handle_month(options.get('month') or None)
+        opt_since = parse_date_param(options.get('since') or None) if not opt_month
+        opt_until = parse_date_param(options.get('until') or None) if not opt_month and opt_since
+
         opt_force = options.get('force')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -37,6 +37,27 @@ def get_report_path(ship_path, date):
     return f'{ship_path}/reports/{year}/{month}'
 
 
+class HelpText:
+    since = (
+        'Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m), '
+        'a number of days ago (--since=5d), or a number of months (--since=2m).'
+    )
+    until = (
+        'End date for collection including (e.g. --until=2023-12-21), a number of minutes (--until=2m), '
+        'a number of days ago (--until=5d), or a number of months (--until=2m).'
+    )
+    month = (
+        'Month the report will be generated for, with format YYYY-MM. If this params is not provided, '
+        "previous month report will be generated if it doesn't exists already."
+    )
+    ephemeral = (
+        'Duration in months or days to determine if host is ephemeral. Months are taken as 30days duration. '
+        'Example: --ephemeral=3months, or --ephemeral=3days'
+    )
+    force = 'With this option, the existing reports will be overwritten if running this command again.'
+    verbose = 'Starts to print debug information to terminal.'
+
+
 class Command(BaseCommand):
     """
     Gather Automation Controller billing data
@@ -44,54 +65,15 @@ class Command(BaseCommand):
 
     help = 'Gather Automation Controller billing data'
 
-    def __init__(self):
-        super().__init__()
-        self.help = {
-            'since': (
-                'Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m), '
-                'a number of days ago (--since=5d), or a number of months (--since=2m).'
-            ),
-            'until': (
-                'End date for collection including (e.g. --until=2023-12-21), a number of minutes (--until=2m), '
-                'a number of days ago (--until=5d), or a number of months (--until=2m).'
-            ),
-            'time_frame_extra_params': (
-                'Missing required parameter --month, --until, or --since. Metrics utility requires a value for at least '
-                'one of the following: month, since, until.'
-            ),
-            'month': (
-                'Month the report will be generated for, with format YYYY-MM. If this params is not provided, '
-                "previous month report will be generated if it doesn't exists already."
-            ),
-            'ephemeral': (
-                'Duration in months or days to determine if host is ephemeral. Months are taken as 30days duration. '
-                'Example: --ephemeral=3months, or --ephemeral=3days'
-            ),
-        }
-
     def add_arguments(self, parser):
         handle_env_validation('build')
-        parser.add_argument('--month', dest='month', action='store', help=self.help.get('month'))
-        parser.add_argument('--since', dest='since', action='store', help=self.help.get('since'))
-        parser.add_argument(
-            '--until',
-            dest='until',
-            action='store',
-            help=self.help.get('until'),
-        )
-        parser.add_argument(
-            '--ephemeral',
-            dest='ephemeral',
-            action='store',
-            help=self.help.get('ephemeral'),
-        )
-        parser.add_argument(
-            '--force',
-            dest='force',
-            action='store_true',
-            help='With this option, the existing reports will be overwritten if running this command again.',
-        )
-        parser.add_argument('--verbose', dest='verbose', action='store_true', help='Starts to print debug information to terminal.')
+
+        parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=HelpText.ephemeral)
+        parser.add_argument('--force', dest='force', action='store_true', help=HelpText.force)
+        parser.add_argument('--month', dest='month', action='store', help=HelpText.month)
+        parser.add_argument('--since', dest='since', action='store', help=HelpText.since)
+        parser.add_argument('--until', dest='until', action='store', help=HelpText.until)
+        parser.add_argument('--verbose', dest='verbose', action='store_true', help=HelpText.verbose)
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')
@@ -115,7 +97,7 @@ class Command(BaseCommand):
         self.init_logging()
         og_month, month, next_month = handle_month(options.get('month') or None)
 
-        validate_build_extra_params(self.help, options)
+        validate_build_extra_params(HelpText, options)
         opt_month = og_month if options.get('month') else None
         opt_until = self._parse_param('until', options)
         opt_since = self._parse_param('since', options)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -111,8 +111,8 @@ class Command(BaseCommand):
         validate_build_extra_params(HelpText, options)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
-        opt_since = parse_date_param(options.get('since') or None) if not opt_month
-        opt_until = parse_date_param(options.get('until') or None) if not opt_month and opt_since
+        opt_since = parse_date_param(options.get('since') or None, HelpText.since) if not opt_month else None
+        opt_until = parse_date_param(options.get('until') or None, HelpText.until) if not opt_month and opt_since else None
 
         opt_force = options.get('force')
 

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -38,24 +38,27 @@ def get_report_path(ship_path, date):
 
 
 class HelpText:
+    month = (
+        'Month for which the report will be generated, in YYYY-MM format. '
+        'If neither --month nor --since are provided, a report for the previous month will be generated. ',
+        'Not available for renewal guidance report.',
+    )
     since = (
-        'Start date for collection including (e.g. --since=2023-12-20), a number of minutes ago (--until=2m), '
-        'a number of days ago (--since=5d), or a number of months (--since=2m).'
+        'Start date for the report as an absolute date (in YYYY-MM-DD format, e.g. --since=2024-12-31) or a relative offset '
+        '(e.g. --since=5d for five days ago, --since=5mo for five months ago, --since=5m for five minutes ago).'
     )
     until = (
-        'End date for collection including (e.g. --until=2023-12-21), a number of minutes (--until=2m), '
-        'a number of days ago (--until=5d), or a number of months (--until=2m).'
-    )
-    month = (
-        'Month the report will be generated for, with format YYYY-MM. If this params is not provided, '
-        "previous month report will be generated if it doesn't exists already."
+        'End date for the report as an absolute date (in YYYY-MM-DD format, e.g. --until=2024-12-31) or a relative offset '
+        '(e.g. --until=5d for five days ago, --until=5mo for five months ago, --until=5m for five minutes ago). '
+        'Defaults to today. Ignored without --since. Not available for renewal guidance report.'
     )
     ephemeral = (
-        'Duration in months or days to determine if host is ephemeral. Months are taken as 30days duration. '
-        'Example: --ephemeral=3months, or --ephemeral=3days'
+        'Duration in months or days used to determine if a host is considered ephemeral '
+        '(e.g. --ephemeral=3months, or --ephemeral=3days). Months are treated as 30-day periods. '
+        'Only available for renewal guidance report.'
     )
-    force = 'With this option, the existing reports will be overwritten if running this command again.'
-    verbose = 'Starts to print debug information to terminal.'
+    force = 'Overwrite existing reports when the command is re-run.'
+    verbose = 'Print debug information to console.'
 
 
 class Command(BaseCommand):

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -82,10 +82,9 @@ class Command(BaseCommand):
             # since and month are mutually exclusive
             exclusive = group.add_mutually_exclusive_group(required=False)
             exclusive.add_argument('--month', dest='month', action='store', help=HelpText.month)
+            exclusive.add_argument('--since', dest='since', action='store', help=HelpText.since)
         else:
-            exclusive = group
-
-        exclusive.add_argument('--since', dest='since', action='store', help=HelpText.since)
+            group.add_argument('--since', dest='since', action='store', help=HelpText.since, required=(report_type in ['RENEWAL_GUIDANCE']))
 
         if report_type in ['CCSP', 'CCSPv2']:
             group.add_argument('--until', dest='until', action='store', help=HelpText.until)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -30,6 +30,13 @@ from metrics_utility.management.validation import (
 from metrics_utility.metric_utils import get_optional_collectors
 
 
+def get_report_path(ship_path, date):
+    year = date.strftime('%Y')
+    month = date.strftime('%m')
+
+    return f'{ship_path}/reports/{year}/{month}'
+
+
 class Command(BaseCommand):
     """
     Gather Automation Controller billing data
@@ -124,12 +131,12 @@ class Command(BaseCommand):
             extra_params['report_period_range'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
 
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                extractor.get_report_path(extra_params['until_date']),
-                f'{extra_params["report_type"]}-{opt_since.date()}--{extra_params["until_date"]}.xlsx',
+                get_report_path(extra_params['ship_path'], extra_params['until_date']),
+                f'{extra_params["report_type"]}-{extra_params["since_date"]}--{extra_params["until_date"]}.xlsx',
             )
         else:
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                extractor.get_report_path(month),
+                get_report_path(extra_params['ship_path'], month),
                 f'{extra_params["report_type"]}-{opt_month}.xlsx',
             )
 

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -37,8 +37,6 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
-        handle_env_validation('gather')
-
         parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=HelpText.dry_run)
         parser.add_argument('--ship', dest='ship', action='store_true', help=HelpText.ship)
         parser.add_argument('--since', dest='since', action='store', help=HelpText.since)
@@ -54,6 +52,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.init_logging()
+
+        handle_env_validation('gather')
 
         handle_validate_date_param(options.get('since', None), HelpText.since, 'gather')
         handle_validate_date_param(options.get('until', None), HelpText.until, 'gather')

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -8,12 +8,8 @@ from django.utils import timezone
 
 from metrics_utility.automation_controller_billing.collector import Collector
 from metrics_utility.exceptions import (
-    BadRequiredEnvVar,
     BadShipTarget,
-    FailedToUploadPayload,
-    MissingRequiredEnvVar,
     NoAnalyticsCollected,
-    UnparsableParameter,
 )
 from metrics_utility.management.validation import (
     handle_crc_ship_target,
@@ -73,17 +69,6 @@ class Command(BaseCommand):
         self.logger.propagate = False
 
     def handle(self, *args, **options):
-        try:
-            self._handle(self, *args, **options)
-            exit(0)
-        except (BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar, FailedToUploadPayload, UnparsableParameter) as e:
-            self.logger.error(e.name)
-            exit(1)
-        except Exception as e:
-            self.logger.exception(e)
-            exit(1)
-
-    def _handle(self, *args, **options):
         self.init_logging()
 
         handle_validate_date_param(options.get('since', None), self.help.get('since'), 'gather')

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -27,6 +27,8 @@ class Command(BaseCommand):
     Gather Automation Controller billing data
     """
 
+    help = 'Gather Automation Controller billing data'
+
     def __init__(self):
         super().__init__()
         self.help = {

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -43,10 +43,13 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
-        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=HelpText.dry_run)
-        parser.add_argument('--ship', dest='ship', action='store_true', help=HelpText.ship)
         parser.add_argument('--since', dest='since', action='store', help=HelpText.since)
         parser.add_argument('--until', dest='until', action='store', help=HelpText.until)
+
+        # dry-run and ship are mutually exclusive
+        exclusive = parser.add_mutually_exclusive_group(required=False)
+        exclusive.add_argument('--dry-run', dest='dry-run', action='store_true', help=HelpText.dry_run)
+        exclusive.add_argument('--ship', dest='ship', action='store_true', help=HelpText.ship)
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -35,10 +35,8 @@ class Command(BaseCommand):
                 'or a number of months (--since=2m).'
             ),
             'until': (
-                'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
-            ),
-            'time_frame_extra_params': (
-                'Missing required parameter --until, or --since. Metrics utility requires a value for at least one of the following: since, until.'
+                'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), '
+                'or a number of months (--until=2m).'
             ),
         }
 

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -1,12 +1,10 @@
-import datetime
 import logging
 import os
 
-from dateutil import parser
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
 from metrics_utility.automation_controller_billing.collector import Collector
+from metrics_utility.automation_controller_billing.helpers import parse_date_param
 from metrics_utility.exceptions import (
     BadShipTarget,
     NoAnalyticsCollected,
@@ -64,15 +62,16 @@ class Command(BaseCommand):
 
         handle_env_validation('gather')
 
-        handle_validate_date_param(options.get('since', None), HelpText.since, 'gather')
-        handle_validate_date_param(options.get('until', None), HelpText.until, 'gather')
+        opt_since = options.get('since') or None
+        opt_until = options.get('until') or None
+        handle_validate_date_param(opt_since, HelpText.since, 'gather')
+        handle_validate_date_param(opt_until, HelpText.until, 'gather')
 
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
-        opt_since = options.get('since') or None
-        opt_until = options.get('until') or None
 
-        since, until = self._handle_interval(opt_since, opt_until)
+        since = parse_date_param(opt_since, help=HelpText.since)
+        until = parse_date_param(opt_until, help=HelpText.until)
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)
@@ -109,30 +108,3 @@ class Command(BaseCommand):
         else:
             allowed = ', '.join(['crc', 'directory', 's3'])
             raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')
-
-    def _handle_datelike(self, value, help=''):
-        if not value:
-            return None
-        # # Process ret argument
-        if value.endswith('d'):
-            days_ago = int(value[0:-1])
-            ret = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-        elif value.endswith('m'):
-            minutes_ago = int(value[0:-1])
-            ret = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
-        else:
-            ret = parser.parse(value)
-
-        # Add default utc timezone
-        if ret and ret.tzinfo is None:
-            ret = ret.replace(tzinfo=timezone.utc)
-
-        return ret
-
-    def _handle_interval(self, opt_since, opt_until):
-        # Process since argument
-        since = self._handle_datelike(opt_since, help=HelpText.since)
-
-        # Process until argument
-        until = self._handle_datelike(opt_until, help=HelpText.until)
-        return since, until

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -22,6 +22,13 @@ from metrics_utility.management.validation import (
 )
 
 
+class HelpText:
+    since = 'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
+    until = 'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
+    dry_run = 'Gather billing metrics without shipping.'
+    ship = 'Enable shipping of billing metrics to the console.redhat.com.'
+
+
 class Command(BaseCommand):
     """
     Gather Automation Controller billing data
@@ -29,36 +36,13 @@ class Command(BaseCommand):
 
     help = 'Gather Automation Controller billing data'
 
-    def __init__(self):
-        super().__init__()
-        self.help = {
-            'since': (
-                'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), '
-                'or a number of months (--since=2m).'
-            ),
-            'until': (
-                'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), '
-                'or a number of months (--until=2m).'
-            ),
-        }
-
     def add_arguments(self, parser):
         handle_env_validation('gather')
-        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help='Gather billing metrics without shipping.')
-        parser.add_argument('--ship', dest='ship', action='store_true', help='Enable shipping of billing metrics to the console.redhat.com')
 
-        parser.add_argument(
-            '--since',
-            dest='since',
-            action='store',
-            help=self.help.get('since'),
-        )
-        parser.add_argument(
-            '--until',
-            dest='until',
-            action='store',
-            help=self.help.get('until'),
-        )
+        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=HelpText.dry_run)
+        parser.add_argument('--ship', dest='ship', action='store_true', help=HelpText.ship)
+        parser.add_argument('--since', dest='since', action='store', help=HelpText.since)
+        parser.add_argument('--until', dest='until', action='store', help=HelpText.until)
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')
@@ -71,8 +55,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.init_logging()
 
-        handle_validate_date_param(options.get('since', None), self.help.get('since'), 'gather')
-        handle_validate_date_param(options.get('until', None), self.help.get('until'), 'gather')
+        handle_validate_date_param(options.get('since', None), HelpText.since, 'gather')
+        handle_validate_date_param(options.get('until', None), HelpText.until, 'gather')
 
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
@@ -138,8 +122,8 @@ class Command(BaseCommand):
 
     def _handle_interval(self, opt_since, opt_until):
         # Process since argument
-        since = self._handle_datelike(opt_since, help=self.help.get('since'))
+        since = self._handle_datelike(opt_since, help=HelpText.since)
 
         # Process until argument
-        until = self._handle_datelike(opt_until, help=self.help.get('until'))
+        until = self._handle_datelike(opt_until, help=HelpText.until)
         return since, until

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -23,10 +23,16 @@ from metrics_utility.management.validation import (
 
 
 class HelpText:
-    since = 'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
-    until = 'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
+    since = (
+        'Start date for collection (including) as an absolute date (in YYYY-MM-DD format, e.g. --since=2024-12-31) or a relative offset '
+        '(e.g. --since=5d for five days ago, --since=5mo for five months ago, --since=5m for five minutes ago).'
+    )
+    until = (
+        'End date for collection (including) as an absolute date (in YYYY-MM-DD format, e.g. --until=2024-12-31) or a relative offset '
+        '(e.g. --until=5d for five days ago, --until=5mo for five months ago, --until=5m for five minutes ago). '
+    )
     dry_run = 'Gather billing metrics without shipping.'
-    ship = 'Enable shipping of billing metrics to the console.redhat.com.'
+    ship = 'Enable shipping of billing metrics to console.redhat.com.'
 
 
 class Command(BaseCommand):

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -4,7 +4,6 @@ import os
 from django.core.management.base import BaseCommand
 
 from metrics_utility.automation_controller_billing.collector import Collector
-from metrics_utility.automation_controller_billing.helpers import parse_date_param
 from metrics_utility.exceptions import (
     BadShipTarget,
     NoAnalyticsCollected,
@@ -16,7 +15,7 @@ from metrics_utility.management.validation import (
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
-    handle_validate_date_param,
+    validate_gather_params,
 )
 
 
@@ -61,17 +60,10 @@ class Command(BaseCommand):
         self.init_logging()
 
         handle_env_validation('gather')
-
-        opt_since = options.get('since') or None
-        opt_until = options.get('until') or None
-        handle_validate_date_param(opt_since, HelpText.since, 'gather')
-        handle_validate_date_param(opt_until, HelpText.until, 'gather')
+        since, until = validate_gather_params(options, HelpText)
 
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
-
-        since = parse_date_param(opt_since, help=HelpText.since)
-        until = parse_date_param(opt_until, help=HelpText.until)
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -417,7 +417,7 @@ def validate_renewal_guidance_params(since, until, help_text):
         raise BadParameter('The --until parameter is not allowed when environment variable METRICS_UTILITY_REPORT_TYPE is RENEWAL_GUIDANCE')
 
     if since:
-        raise MissingRequiredParameter(f"""{help_text.time_frame_extra_params} \n\n{since_help} \n{until_help} \n{help_text.month}""")
+        raise MissingRequiredParameter(f"{help_text.time_frame_extra_params}\n\n{since_help}\n{until_help}\n{help_text.month}")
 
 
 def handle_validate_ephemeral_param(value, help):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -393,7 +393,8 @@ def validate_build_extra_params(HelpText, options):
     has_since = since is not None
     has_until = until is not None
 
-    validate_renewal_guidance_params(has_since, has_until, HelpText)
+    if report_type == 'RENEWAL_GUIDANCE':
+        validate_renewal_guidance_params(has_since, has_until, HelpText.since)
 
     if (has_since and has_until) and until < since:
         raise UnparsableParameter('The date for --until cannot be before the date for --since.')
@@ -402,27 +403,23 @@ def validate_build_extra_params(HelpText, options):
         raise BadParameter('The --since and --until parameters are not allowed if the --month parameter is provided.')
 
 
-def validate_renewal_guidance_params(since, until, help_text):
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
-    is_renewal = report_type.startswith('RENEWAL_GUIDANCE')
-    if not is_renewal:
-        return
+def validate_renewal_guidance_params(has_since, has_until, since_help):
+    if has_until:
+        raise BadParameter('The --until parameter is not allowed when METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE')
 
-    since_help = help_text.get('since')
-    until_help = help_text.get('until')
-    if until:
-        raise BadParameter('The --until parameter is not allowed when environment variable METRICS_UTILITY_REPORT_TYPE is RENEWAL_GUIDANCE')
-
-    if since:
-        raise MissingRequiredParameter(f"{help_text.time_frame_extra_params}\n\n{since_help}\n{until_help}\n{help_text.month}")
+    if not has_since:
+        raise MissingRequiredParameter(f'Missing --since parameter, required when METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE: {since_help}')
 
 
 def handle_validate_ephemeral_param(value, help):
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if not value:
         return
-    if not report_type.startswith('RENEWAL_GUIDANCE'):
+
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    if report_type != 'RENEWAL_GUIDANCE':
         raise BadParameter(f'METRICS_UTILITY_REPORT_TYPE {report_type} does not allow --ephemeral.')
+
     if re.match(ALLOWED_EPHEMERAL_PATTERN, value):
         return
+
     raise UnparsableParameter(help)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -373,17 +373,15 @@ def match_gather_date_param_regex(date):
     return re.match(SINCE_AND_UNTIL_GATHER_PATTERN, date)
 
 
-def validate_build_extra_params(help_text, options):
+def validate_build_extra_params(HelpText, options):
     opt_month = options.get('month') or None
-    # since = None
-    until = options.get('until', None)
+
     since = options.get('since', None)
-    since_help = help_text.get('since')
-    until_help = help_text.get('until')
-    # until = None
-    handle_validate_ephemeral_param(options.get('ephemeral', None), help_text.get('ephemeral'))
-    handle_validate_date_param(since, since_help, 'build')
-    handle_validate_date_param(until, until_help, 'build')
+    until = options.get('until', None)
+
+    handle_validate_ephemeral_param(options.get('ephemeral', None), HelpText.ephemeral)
+    handle_validate_date_param(since, HelpText.since, 'build')
+    handle_validate_date_param(until, HelpText.until, 'build')
 
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if report_type is None:
@@ -395,7 +393,7 @@ def validate_build_extra_params(help_text, options):
     has_since = since is not None
     has_until = until is not None
 
-    validate_renewal_guidance_params(has_since, has_until, help_text)
+    validate_renewal_guidance_params(has_since, has_until, HelpText)
 
     if (has_since and has_until) and until < since:
         raise UnparsableParameter('The date for --until cannot be before the date for --since.')

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -4,14 +4,13 @@ import re
 
 from dateutil import parser
 
-from metrics_utility.automation_controller_billing.helpers import (
-    ALLOWED_EPHEMERAL_PATTERN,
-    SINCE_AND_UNTIL_BUILD_PATTERN,
-    SINCE_AND_UNTIL_GATHER_PATTERN,
-    parse_date_param,
-)
+from metrics_utility.automation_controller_billing.helpers import parse_date_param
 from metrics_utility.exceptions import BadParameter, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
 
+
+ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
+SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
+SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
 
 # Constants for valid values
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,10 +1,13 @@
 import logging
 import os
+import re
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
-from metrics_utility.automation_controller_billing.helpers import parse_date_param, parse_month, parse_number_of_days
-from metrics_utility.exceptions import BadParameter, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
+from dateutil import parser
+from dateutil.relativedelta import relativedelta
+
+from metrics_utility.exceptions import BadParameter, DateFormatError, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
 
 
 # Constants for valid values
@@ -410,3 +413,84 @@ def validate_gather_params(options, HelpText):
             logger.warning('The date for --until is in the future.')
 
     return since, until
+
+
+# should also suport quarters, start/end of month ("4mo_ago_beginning" vs "1 mo ago end"), but doesn't yet
+def parse_date_param(value, help=''):
+    if not value:
+        return None
+
+    value = value.strip().lower()
+    if value.isdigit():
+        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
+
+    now = datetime.now()
+    parsed_date = None
+
+    # N days ago, start of day
+    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)(\s*_*ago)?', value)
+    if match:
+        days_ago = int(match.group(1))
+        parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # N months ago, start of day
+    match = re.fullmatch(r'(\d+)\s*_*(mo|mon|mont|month|months)(\s*_*ago)?', value)
+    if match:
+        months_ago = int(match.group(1))
+        parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # N minutes ago
+    match = re.fullmatch(r'(\d+)\s*_*(m|mi|min|minu|minut|minute|minutes)(\s*_*ago)?', value)
+    if match:
+        minutes_ago = int(match.group(1))
+        parsed_date = now - timedelta(minutes=minutes_ago)
+
+    # actual date
+    if not parsed_date:
+        parsed_date = parser.parse(value)
+
+    # Add default UTC timezone
+    if parsed_date and parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
+
+    return parsed_date
+
+
+def parse_number_of_days(value, help=''):
+    if not value:
+        return None
+
+    value = value.strip().lower()
+    if value.isdigit():
+        raise UnparsableParameter(f'Bare numbers are not valid ({help})')
+
+    # N days ago
+    match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)', value)
+    if match:
+        return int(match.group(1))
+
+    # N months ago - using 30 days per month
+    match = re.fullmatch(r'(\d+)\s*_*(m|mo|mon|mont|month|months)', value)
+    if match:
+        return int(match.group(1)) * 30
+
+    raise UnparsableParameter(f"Can't parse parameter value {value} ({help})")
+
+
+def parse_month(month):
+    """Process month argument"""
+    if month is not None:
+        try:
+            date = datetime.strptime(f'{month}', '%Y-%m')
+        except ValueError:
+            raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
+    else:
+        """Return last month if no month was passed"""
+        beginning_of_the_month = datetime.today().replace(day=1)
+        beginning_of_the_previous_month = beginning_of_the_month - relativedelta(months=1)
+        date = beginning_of_the_previous_month
+        y = date.strftime('%Y')
+        m = date.strftime('%m')
+        month = f'{y}-{m}'
+
+    return month, date, date + relativedelta(months=1)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -339,6 +339,10 @@ def handle_not_crc():
         logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": {", ".join(surplus)}')
 
 
+def now():
+    return datetime.now(tz=timezone.utc)
+
+
 def validate_build_params(options, HelpText):
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
     # report_type value validation in validate_report_type
@@ -361,7 +365,7 @@ def validate_build_params(options, HelpText):
     since = None
     if opt_since:
         since = parse_date_param(opt_since, help=HelpText.since)
-        if since > datetime.now():
+        if since > now():
             logger.warning('The date for --since is in the future.')
     elif report_type == 'RENEWAL_GUIDANCE':
         raise MissingRequiredParameter(f'Missing --since parameter, required when METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE": {HelpText.since}')
@@ -375,7 +379,7 @@ def validate_build_params(options, HelpText):
             raise BadParameter('--until is not allowed without --since.')
 
         until = parse_date_param(opt_until, help=HelpText.until)
-        if until > datetime.now():
+        if until > now():
             logger.warning('The date for --until is in the future.')
 
         if since > until:
@@ -403,13 +407,13 @@ def validate_gather_params(options, HelpText):
     since = None
     if opt_since:
         since = parse_date_param(opt_since, help=HelpText.since)
-        if since > datetime.now():
+        if since > now():
             logger.warning('The date for --since is in the future.')
 
     until = None
     if opt_until:
         until = parse_date_param(opt_until, help=HelpText.until)
-        if until > datetime.now():
+        if until > now():
             logger.warning('The date for --until is in the future.')
 
     return since, until
@@ -424,26 +428,25 @@ def parse_date_param(value, help=''):
     if value.isdigit():
         raise UnparsableParameter(f'Bare numbers are not valid ({help})')
 
-    now = datetime.now()
     parsed_date = None
 
     # N days ago, start of day
     match = re.fullmatch(r'(\d+)\s*_*(d|da|day|days)(\s*_*ago)?', value)
     if match:
         days_ago = int(match.group(1))
-        parsed_date = (now - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        parsed_date = (now() - timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N months ago, start of day
     match = re.fullmatch(r'(\d+)\s*_*(mo|mon|mont|month|months)(\s*_*ago)?', value)
     if match:
         months_ago = int(match.group(1))
-        parsed_date = (now - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
+        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # N minutes ago
     match = re.fullmatch(r'(\d+)\s*_*(m|mi|min|minu|minut|minute|minutes)(\s*_*ago)?', value)
     if match:
         minutes_ago = int(match.group(1))
-        parsed_date = now - timedelta(minutes=minutes_ago)
+        parsed_date = now() - timedelta(minutes=minutes_ago)
 
     # actual date
     if not parsed_date:

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,16 +1,11 @@
 import logging
 import os
-import re
 
-from dateutil import parser
+from datetime import datetime
 
-from metrics_utility.automation_controller_billing.helpers import parse_date_param
+from metrics_utility.automation_controller_billing.helpers import parse_date_param, parse_month, parse_number_of_days
 from metrics_utility.exceptions import BadParameter, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
 
-
-ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
-SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
-SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
 
 # Constants for valid values
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}
@@ -157,11 +152,16 @@ def validate_report_type(errors, method):
             f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
         )
+
     if method == 'build' and report_type is None:
         errors.append(
             f'Invalid METRICS_UTILITY_REPORT_TYPE is Empty. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
         )
+
+    if method == 'gather' and report_type is not None:
+        logger.warning('Ignoring METRICS_UTILITY_REPORT_TYPE used without build_report')
+
     return report_type
 
 
@@ -336,90 +336,77 @@ def handle_not_crc():
         logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": {", ".join(surplus)}')
 
 
-def handle_validate_date_param(param, help_text, command):
-    exceptions = []
+def validate_build_params(options, HelpText):
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
+    # report_type value validation in validate_report_type
 
-    if param is None:
-        return
+    opt_month = options.get('month', None) or None
+    opt_since = options.get('since', None) or None
+    opt_until = options.get('until', None) or None
+    opt_ephemeral = options.get('ephemeral', None) or None
 
-    if param.isdigit():
-        """If the value is a digit stop execution and render the failure message."""
-        exceptions.append('isdigit')
-        help_text = 'Integers are not allowed for parameters --since and --until.'
-        raise UnparsableParameter(help_text)
+    if opt_month:
+        if opt_since or opt_until:
+            raise BadParameter('The --since and --until parameters are not allowed if the --month parameter is provided.')
 
-    try:
-        """Try to parse the date, and if it fails go to next loop iteration.  Then, determine if we need to render the failure message."""
-        parser.parse(param)
-    except Exception:
-        exceptions.append(help_text)
+        if report_type == 'RENEWAL_GUIDANCE':
+            raise BadParameter('The --month parameter is not allowed when METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE"')
 
-        """Try to parse the date, and if it fails go to next loop iteration.  Then, determine if we need to render the failure message."""
-    if command == 'build':
-        match = match_build_date_param_regex(param)
-    elif command == 'gather':
-        match = match_gather_date_param_regex(param)
-    if match is None:
-        exceptions.append(help_text)
-    if len(exceptions) > 1:
-        raise UnparsableParameter(help_text)
+    # has defaults if empty
+    month = parse_month(opt_month)
 
+    since = None
+    if opt_since:
+        since = parse_date_param(opt_since, help=HelpText.since)
+        if since > datetime.now():
+            logger.warning('The date for --since is in the future.')
+    elif report_type == 'RENEWAL_GUIDANCE':
+        raise MissingRequiredParameter(f'Missing --since parameter, required when METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE": {HelpText.since}')
 
-def match_build_date_param_regex(date):
-    return re.match(SINCE_AND_UNTIL_BUILD_PATTERN, date)
+    until = None
+    if opt_until:
+        if report_type == 'RENEWAL_GUIDANCE':
+            raise BadParameter('The --until parameter is not allowed when METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE"')
 
+        if not opt_since:
+            raise BadParameter('--until is not allowed without --since.')
 
-def match_gather_date_param_regex(date):
-    return re.match(SINCE_AND_UNTIL_GATHER_PATTERN, date)
+        until = parse_date_param(opt_until, help=HelpText.until)
+        if until > datetime.now():
+            logger.warning('The date for --until is in the future.')
 
+        if since > until:
+            raise UnparsableParameter('The date for --until cannot be before the date for --since.')
 
-def validate_build_extra_params(HelpText, options):
-    opt_month = options.get('month') or None
+    ephemeral_days = None
+    if opt_ephemeral:
+        if report_type != 'RENEWAL_GUIDANCE':
+            raise BadParameter(f'METRICS_UTILITY_REPORT_TYPE="{report_type}" does not allow --ephemeral.')
 
-    since = options.get('since', None)
-    until = options.get('until', None)
+        ephemeral_days = parse_number_of_days(opt_ephemeral, help=HelpText.ephemeral)
 
-    handle_validate_ephemeral_param(options.get('ephemeral', None), HelpText.ephemeral)
-    handle_validate_date_param(since, HelpText.since, 'build')
-    handle_validate_date_param(until, HelpText.until, 'build')
-
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
-    if report_type is None:
-        return
-
-    until = parse_date_param(until)
-    since = parse_date_param(since)
-
-    has_since = since is not None
-    has_until = until is not None
-
-    if report_type == 'RENEWAL_GUIDANCE':
-        validate_renewal_guidance_params(has_since, has_until, HelpText.since)
-
-    if (has_since and has_until) and until < since:
-        raise UnparsableParameter('The date for --until cannot be before the date for --since.')
-
-    if (has_since or has_until) and opt_month is not None:
-        raise BadParameter('The --since and --until parameters are not allowed if the --month parameter is provided.')
+    return {
+        'month': month,
+        'since': since,
+        'until': until,
+        'ephemeral_days': ephemeral_days,
+    }
 
 
-def validate_renewal_guidance_params(has_since, has_until, since_help):
-    if has_until:
-        raise BadParameter('The --until parameter is not allowed when METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE')
+def validate_gather_params(options, HelpText):
+    opt_since = options.get('since', None) or None
+    opt_until = options.get('until', None) or None
 
-    if not has_since:
-        raise MissingRequiredParameter(f'Missing --since parameter, required when METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE: {since_help}')
+    since = None
+    if opt_since:
+        since = parse_date_param(opt_since, help=HelpText.since)
+        if since > datetime.now():
+            logger.warning('The date for --since is in the future.')
 
+    until = None
+    if opt_until:
+        until = parse_date_param(opt_until, help=HelpText.until)
+        if until > datetime.now():
+            logger.warning('The date for --until is in the future.')
 
-def handle_validate_ephemeral_param(value, help):
-    if not value:
-        return
-
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
-    if report_type != 'RENEWAL_GUIDANCE':
-        raise BadParameter(f'METRICS_UTILITY_REPORT_TYPE {report_type} does not allow --ephemeral.')
-
-    if re.match(ALLOWED_EPHEMERAL_PATTERN, value):
-        return
-
-    raise UnparsableParameter(help)
+    return since, until

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -1,9 +1,24 @@
+import logging
 import os
 import sys
 
 from importlib import import_module
 
 import django.core.management as management
+
+from metrics_utility.exceptions import (
+    BadParameter,
+    BadRequiredEnvVar,
+    BadShipTarget,
+    DateFormatError,
+    FailedToUploadPayload,
+    MissingRequiredEnvVar,
+    MissingRequiredParameter,
+    UnparsableParameter,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 class ManagementUtility(management.ManagementUtility):
@@ -52,9 +67,7 @@ class ManagementUtility(management.ManagementUtility):
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:
-            # from metrics_utility.management.commands.host_metric import Command
-            # Command().run_from_argv(self.argv)
-            self.fetch_command(subcommand).run_from_argv(self.argv)
+            self.run_subcommand(subcommand, self.argv)
 
     def fetch_command(self, subcommand):
         module = import_module(f'metrics_utility.management.commands.{subcommand}')
@@ -66,3 +79,22 @@ class ManagementUtility(management.ManagementUtility):
         path = os.path.join(os.path.dirname(__file__), 'management')
         commands.update({name: 'metrics_utility' for name in management.find_commands(path)})
         return commands
+
+    def run_subcommand(self, subcommand, argv):
+        try:
+            self.fetch_command(subcommand).run_from_argv(argv)
+        except (
+            BadParameter,
+            BadRequiredEnvVar,
+            BadShipTarget,
+            DateFormatError,
+            FailedToUploadPayload,
+            MissingRequiredEnvVar,
+            MissingRequiredParameter,
+            UnparsableParameter,
+        ) as e:
+            logger.error(e.name)
+            exit(1)
+        except Exception as e:
+            logger.exception(e)
+            exit(1)

--- a/metrics_utility/test/renewal_guidance/test_get_intervals.py
+++ b/metrics_utility/test/renewal_guidance/test_get_intervals.py
@@ -29,7 +29,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -92,7 +92,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-04-28,2025-05-12',
             'since_date': '2025-04-28',
@@ -228,7 +228,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-04-10,2025-05-12',
             'since_date': '2025-04-10',

--- a/metrics_utility/test/renewal_guidance/test_get_intervals.py
+++ b/metrics_utility/test/renewal_guidance/test_get_intervals.py
@@ -29,7 +29,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7days',
+            'ephemeral_days': 7,
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -92,7 +92,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7days',
+            'ephemeral_days': 7,
             'price_per_node': 0.1,
             'report_period': '2025-04-28,2025-05-12',
             'since_date': '2025-04-28',
@@ -106,9 +106,8 @@ class TestGetIntervals:
 
         start_date = dt_actual.datetime(2025, 4, 28, 0, 0, 0)
         end_date = dt_actual.datetime(2025, 5, 12, 23, 59, 59, 999999)
-        ephemeral_days = 7
 
-        intervals = instance.get_intervals(start_date, end_date, ephemeral_days)
+        intervals = instance.get_intervals(start_date, end_date, extra_params['ephemeral_days'])
 
         assert len(intervals) == 9
 
@@ -228,7 +227,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7days',
+            'ephemeral_days': 7,
             'price_per_node': 0.1,
             'report_period': '2025-04-10,2025-05-12',
             'since_date': '2025-04-10',
@@ -242,9 +241,8 @@ class TestGetIntervals:
 
         start_date = dt_actual.datetime(2025, 4, 10, 0, 0, 0)
         end_date = dt_actual.datetime(2025, 5, 12, 23, 59, 59, 999999)
-        ephemeral_days = 7
 
-        intervals = production_instance.get_intervals(start_date, end_date, ephemeral_days)
+        intervals = production_instance.get_intervals(start_date, end_date, extra_params['ephemeral_days'])
 
         assert len(intervals) == 27
 

--- a/metrics_utility/test/renewal_guidance/test_get_intervals.py
+++ b/metrics_utility/test/renewal_guidance/test_get_intervals.py
@@ -31,14 +31,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-01-01,2025-06-03',
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
 
         return ReportRenewalGuidance(
             dataframe=[mock_df],
-            report_period='2025-01-01,2025-06-03',
             extra_params=extra_params,
         )
 
@@ -95,14 +94,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-04-28,2025-05-12',
+            'report_period': '2025-04-28,2025-05-12',
             'since_date': '2025-04-28',
             'until_date': '2025-05-12',
         }
 
         instance = ReportRenewalGuidance(
             dataframe=[realistic_df],
-            report_period='2025-04-28,2025-05-12',
             extra_params=extra_params,
         )
 
@@ -232,14 +230,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-04-10,2025-05-12',
+            'report_period': '2025-04-10,2025-05-12',
             'since_date': '2025-04-10',
             'until_date': '2025-05-12',
         }
 
         production_instance = ReportRenewalGuidance(
             dataframe=[production_df],
-            report_period='2025-04-10,2025-05-12',
             extra_params=extra_params,
         )
 

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -25,17 +25,15 @@ def setup_report_renewal_guidance_instance(fixed_now):
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
         test_ephemeral_days = 30
-        report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
-            'report_period_range': report_period_range,
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
 
         yield {
-            'report_period': report_period_range,
             'extra_params': test_extra_params,
         }
 
@@ -51,7 +49,6 @@ def test_renewal_guidance_queries_with_mocked_data(setup_report_renewal_guidance
 
     report_instance = ReportRenewalGuidance(
         dataframe=[processed_df],
-        report_period=report_instance_params['report_period'],
         extra_params=report_instance_params['extra_params'],
     )
 
@@ -103,11 +100,10 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
         test_ephemeral_days = 30
-        report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
-            'report_period_range': report_period_range,
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
@@ -126,7 +122,6 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
 
         report_renewal_guidance_instance_empty = ReportRenewalGuidance(
             dataframe=[empty_df_with_cols],
-            report_period=report_period_range,
             extra_params=test_extra_params,
         )
 

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -26,7 +26,7 @@ def setup_report_renewal_guidance_instance(fixed_now):
 
         test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days} days',
+            'opt_ephemeral': f'{test_ephemeral_days}days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -101,7 +101,7 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
 
         test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days} days',
+            'opt_ephemeral': f'{test_ephemeral_days}days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -24,9 +24,8 @@ def setup_report_renewal_guidance_instance(fixed_now):
         mock_datetime_module.timezone = MagicMock(spec=dt_actual.timezone)
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
-        test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days}days',
+            'ephemeral_days': 30,
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -99,9 +98,8 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
         mock_datetime_module.timezone = MagicMock(spec=dt_actual.timezone)
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
-        test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days}days',
+            'ephemeral_days': 30,
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -64,15 +64,14 @@ def run_build_int(env, options):
     from metrics_utility.management.commands.build_report import Command
 
     with temporary_env(env):
-        Command()._handle(**options)
+        Command().handle(**options)
 
 
 def run_gather_int(env, options):
     from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
 
     with temporary_env(env):
-        # .handle does exit(0), breaking tests
-        Command()._handle(**options)
+        Command().handle(**options)
 
 
 def generate_renewal_guidance_dataframe(is_empty=False, current_datetime=None):


### PR DESCRIPTION
This is a collection of semi-related commits, some work in progress, some ready, some suggestions, some fixes, some ideas, vaguely related to AAP-43196 and tasks under it - environmental variable and command line argument validation.

Currently contains a mix of:
* follow-ups to the epic, around making `--help` responsive to report type, moving exception handling to a base class
* dead/duplicate code cleanups / refactorings in related code, simplify logic around extra_params values
* obsolete help suggestions (which *might* still have bits that we'd want to add)
* extending the formats accepted for relative dates and intervals
* fixing up more edge cases with param checking
* test cleanups where we're skipping required params or providing extraneous params

---

The PR is never meant to be merged as a whole, I'll be pulling out bits and pieces that make sense together into individual PRs over time.

