### PR TITLE
 AAP-45503- Better Error Handling for enviroment variables

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
+import sys
+
+from metrics_utility.exceptions import MissingRequiredEnvVar
+
+
 if __name__ == '__main__':
     from metrics_utility import manage
 
-    manage()
+    try:
+        manage()
+    except MissingRequiredEnvVar as exc:
+        print(f'\nEnvironment Variable Validation Error: \n{exc}\n')
+        sys.exit(1)

--- a/manage.py
+++ b/manage.py
@@ -1,16 +1,7 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
-import sys
-
-from metrics_utility.exceptions import MissingRequiredEnvVar
-
-
 if __name__ == '__main__':
     from metrics_utility import manage
 
-    try:
-        manage()
-    except MissingRequiredEnvVar as exc:
-        print(f'\nEnvironment Variable Validation Error: \n{exc}\n')
-        sys.exit(1)
+    manage()

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
-        handle_env_validation()
+        handle_env_validation('build')
         parser.add_argument(
             '--month',
             dest='month',

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -14,7 +14,13 @@ from metrics_utility.automation_controller_billing.helpers import parse_date_par
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
-from metrics_utility.management.validation import handle_directory_ship_target, handle_not_crc, handle_not_s3, handle_s3_ship_target
+from metrics_utility.management.validation import (
+    handle_directory_ship_target,
+    handle_env_validation,
+    handle_not_crc,
+    handle_not_s3,
+    handle_s3_ship_target,
+)
 from metrics_utility.metric_utils import get_optional_collectors
 
 
@@ -26,6 +32,7 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
+        handle_env_validation()
         parser.add_argument(
             '--month',
             dest='month',

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -18,6 +18,7 @@ from metrics_utility.exceptions import (
 from metrics_utility.management.validation import (
     handle_crc_ship_target,
     handle_directory_ship_target,
+    handle_env_validation,
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
@@ -36,6 +37,7 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
 
     def add_arguments(self, parser):
+        handle_env_validation('gather')
         parser.add_argument('--dry-run', dest='dry-run', action='store_true', help='Gather billing metrics without shipping.')
         parser.add_argument('--ship', dest='ship', action='store_true', help='Enable shipping of billing metrics to the console.redhat.com')
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -32,7 +32,8 @@ VALID_SHEETS = {
     },
 }
 VALID_COLLECTORS = {'main_host', 'main_jobevent', 'main_indirectmanagednodeaudit'}
-VALID_SHIP_TARGET = {'directory', 's3', 'crc'}
+VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
+VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
 
 
 logger = logging.getLogger(__name__)
@@ -216,7 +217,7 @@ def validate_collectors(errors):
             errors.append(f'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS: {", ".join(invalid)}. Valid values: {", ".join(VALID_COLLECTORS)}')
 
 
-def validate_ship_target(errors):
+def validate_ship_target(errors, ship_target_type):
     """
     Validates the 'METRICS_UTILITY_SHIP_TARGET' environment variable against a set of valid ship targets.
 
@@ -234,8 +235,8 @@ def validate_ship_target(errors):
         - Error messages include the invalid ship target and the list of valid values.
     """
     ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
-    if ship_target and ship_target not in VALID_SHIP_TARGET:
-        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(VALID_SHIP_TARGET)}')
+    if ship_target and ship_target not in ship_target_type:
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(ship_target_type)}')
     return ship_target
 
 
@@ -257,7 +258,7 @@ def validate_ship_path(errors, ship_target):
             errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
 
 
-def handle_env_validation():
+def handle_env_validation(method: str):
     """
     Validates required environment variables and configuration for the application.
 
@@ -286,7 +287,10 @@ def handle_env_validation():
     report_type = validate_report_type(errors)
     validate_ccsp_report_sheets(errors, report_type)
     validate_collectors(errors)
-    ship_target = validate_ship_target(errors)
+    if method == 'gather':
+        ship_target = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
+    else:
+        ship_target = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
     validate_ship_path(errors, ship_target)
     if errors:
         raise MissingRequiredEnvVar('\n'.join(errors))

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -4,6 +4,37 @@ import os
 from metrics_utility.exceptions import MissingRequiredEnvVar
 
 
+# Constants for valid values
+VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}
+VALID_SHEETS = {
+    'CCSP': {
+        'ccsp_summary',
+        'managed_nodes',
+        'indirectly_managed_nodes',
+        'inventory_scope',
+        'usage_by_collections',
+        'usage_by_roles',
+        'usage_by_modules',
+        'usage_by_organizations',
+    },
+    'CCSPv2': {
+        'ccsp_summary',
+        'jobs',
+        'managed_nodes',
+        'indirectly_managed_nodes',
+        'inventory_scope',
+        'usage_by_organizations',
+        'usage_by_collections',
+        'usage_by_roles',
+        'usage_by_modules',
+        'managed_nodes_by_organization',
+        'data_collection_status',
+    },
+}
+VALID_COLLECTORS = {'main_host', 'main_jobevent', 'main_indirectmanagednodeaudit'}
+VALID_SHIP_TARGET = {'directory', 's3', 'crc'}
+
+
 logger = logging.getLogger(__name__)
 
 ship_path_description = 'place for collected data and built reports'
@@ -96,6 +127,169 @@ def handle_crc_ship_target():
         logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
 
     return billing_provider_params
+
+
+def validate_report_type(errors):
+    """
+    Validates the 'METRICS_UTILITY_REPORT_TYPE' environment variable against a set of valid report types.
+
+    If the environment variable is set and its value is not in the list of valid report types,
+    an error message is appended to the provided errors list.
+
+    Args:
+        errors (list): A list to which error messages will be appended if validation fails.
+
+    Returns:
+        str or None: The value of the 'METRICS_UTILITY_REPORT_TYPE' environment variable if set, otherwise None.
+    """
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    if report_type and report_type not in VALID_REPORT_TYPES:
+        errors.append(
+            f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
+            f'Please note these values are case sensitive'
+        )
+    return report_type
+
+
+def validate_ccsp_report_sheets(errors, report_type):
+    """
+    Validates the optional CCSP report sheets specified in the environment variable
+    'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' for a given report type.
+
+    Args:
+        errors (list): A list to which error messages will be appended if invalid sheets are found.
+        report_type (str): The type of report for which to validate the optional sheets.
+
+    Side Effects:
+        Appends error messages to the 'errors' list if any specified sheets are not valid for the given report type.
+
+    Environment Variables:
+        METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS: A comma-separated string of optional sheet names to validate.
+
+    Notes:
+        - If 'ccsp_sheets' is not set or 'report_type' is None, no validation is performed.
+        - The set of valid sheets for each report type is defined in the global 'VALID_SHEETS' dictionary.
+    """
+    ccsp_sheets = os.getenv(
+        'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS',
+        'ccsp_summary,managed_nodes,usage_by_organizations,usage_by_collections,usage_by_roles,usage_by_modules',
+    ).split(',')
+    if ccsp_sheets and report_type:
+        ccsp_sheets_set = set(ccsp_sheets)
+        if report_type in VALID_SHEETS:
+            invalid = ccsp_sheets_set - VALID_SHEETS[report_type]
+            if invalid:
+                errors.append(
+                    f'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS for '
+                    f'{report_type}: {", ".join(invalid)}. Valid values: '
+                    f'{", ".join(VALID_SHEETS[report_type])}'
+                )
+
+
+def validate_collectors(errors):
+    """
+    Validates the list of optional collectors specified in the
+    METRICS_UTILITY_OPTIONAL_COLLECTORS environment variable against a set
+    of valid collectors.
+
+    If any invalid collectors are found, an error message is appended to the
+    provided errors list.
+
+    Args:
+        errors (list): A list to which error messages will be appended if
+            invalid collectors are found.
+
+    Environment Variables:
+        METRICS_UTILITY_OPTIONAL_COLLECTORS (str, optional): Comma-separated
+            list of collector names. Defaults to 'main_jobevent' if not set.
+
+    Notes:
+        - The set of valid collectors is defined by the global variable
+          VALID_COLLECTORS.
+        - Error messages include the invalid collector names and the list of
+          valid values.
+    """
+    collectors = os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
+    if collectors:
+        invalid = set(collectors) - VALID_COLLECTORS
+        if invalid:
+            errors.append(f'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS: {", ".join(invalid)}. Valid values: {", ".join(VALID_COLLECTORS)}')
+
+
+def validate_ship_target(errors):
+    """
+    Validates the 'METRICS_UTILITY_SHIP_TARGET' environment variable against a set of valid ship targets.
+
+    If the environment variable is set and its value is not in the list of valid ship targets,
+    an error message is appended to the provided errors list.
+
+    Args:
+        errors (list): A list to which error messages will be appended if validation fails.
+
+    Returns:
+        str or None: The value of the 'METRICS_UTILITY_SHIP_TARGET' environment variable if set, otherwise None.
+
+    Notes:
+        - The set of valid ship targets is defined by the global variable VALID_SHIP_TARGET.
+        - Error messages include the invalid ship target and the list of valid values.
+    """
+    ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
+    if ship_target and ship_target not in VALID_SHIP_TARGET:
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(VALID_SHIP_TARGET)}')
+    return ship_target
+
+
+def validate_ship_path(errors, ship_target):
+    """
+    Validates the ship path environment variable based on the ship target.
+
+    Args:
+        errors (list): A list to which error messages will be appended if validation fails.
+        ship_target (str): The value of the METRICS_UTILITY_SHIP_TARGET environment variable.
+
+    Notes:
+        - For 'directory' ship target, checks if METRICS_UTILITY_SHIP_PATH is an existing directory.
+        - Appends an error message to 'errors' if the directory does not exist.
+    """
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    if ship_target == 'directory' and ship_target:
+        if not os.path.isdir(ship_path):
+            errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
+
+
+def handle_env_validation():
+    """
+    Validates required environment variables and configuration for the application.
+
+    This function performs a series of validation checks on environment variables and configuration
+    settings required for the application to run correctly. It collects any validation errors and
+    raises a `MissingRequiredEnvVar` exception if any issues are found.
+
+    Validation steps include:
+    - Validating the report type.
+    - Validating CCSP report sheets based on the report type.
+    - Validating collectors.
+    - Validating the ship target.
+    - Validating the ship path based on the ship target.
+
+    Notes:
+        - The function accumulates all errors before raising an exception, providing a comprehensive
+          error message.
+        - The specific validation functions (`validate_report_type`, `validate_ccsp_report_sheets`,
+          `validate_collectors`, `validate_ship_target`, `validate_ship_path`) are expected to
+          append error messages to the provided `errors` list.
+        - Raises:
+            MissingRequiredEnvVar: If any required environment variable or configuration is missing
+            or invalid.
+    """
+    errors = []
+    report_type = validate_report_type(errors)
+    validate_ccsp_report_sheets(errors, report_type)
+    validate_collectors(errors)
+    ship_target = validate_ship_target(errors)
+    validate_ship_path(errors, ship_target)
+    if errors:
+        raise MissingRequiredEnvVar('\n'.join(errors))
 
 
 def handle_not_crc():

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -158,11 +158,11 @@ def validate_report_type(errors, method):
             f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
         )
-        if method == 'build' and report_type is None:
-            errors.append(
-                f'Invalid METRICS_UTILITY_REPORT_TYPE is Empty. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
-                f'Please note these values are case sensitive'
-            )
+    if method == 'build' and report_type is None:
+        errors.append(
+            f'Invalid METRICS_UTILITY_REPORT_TYPE is Empty. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
+            f'Please note these values are case sensitive'
+        )
     return report_type
 
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -32,8 +32,8 @@ VALID_SHEETS = {
     },
 }
 VALID_COLLECTORS = {'main_host', 'main_jobevent', 'main_indirectmanagednodeaudit'}
-VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
-VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
+VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
+VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc', 'controller_db'}
 
 
 logger = logging.getLogger(__name__)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -270,8 +270,12 @@ def handle_env_validation(method: str):
     - Validating the report type.
     - Validating CCSP report sheets based on the report type.
     - Validating collectors.
-    - Validating the ship target.
+    - Validating the ship target (uses the `method` argument to determine which set of valid targets to check).
     - Validating the ship path based on the ship target.
+
+    Args:
+        method (str): Determines which set of valid ship targets to use for validation.
+            Should be either 'gather' or another supported method.
 
     Notes:
         - The function accumulates all errors before raising an exception, providing a comprehensive
@@ -279,6 +283,7 @@ def handle_env_validation(method: str):
         - The specific validation functions (`validate_report_type`, `validate_ccsp_report_sheets`,
           `validate_collectors`, `validate_ship_target`, `validate_ship_path`) are expected to
           append error messages to the provided `errors` list.
+        - The `method` parameter controls which ship target validation set is used.
         - Raises:
             MissingRequiredEnvVar: If any required environment variable or configuration is missing
             or invalid.

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -33,7 +33,7 @@ VALID_SHEETS = {
 }
 VALID_COLLECTORS = {'main_host', 'main_jobevent', 'main_indirectmanagednodeaudit'}
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
-VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc', 'controller_db'}
+VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
 
 
 logger = logging.getLogger(__name__)
@@ -130,7 +130,7 @@ def handle_crc_ship_target():
     return billing_provider_params
 
 
-def validate_report_type(errors):
+def validate_report_type(errors, method):
     """
     Validates the 'METRICS_UTILITY_REPORT_TYPE' environment variable against a set of valid report types.
 
@@ -149,6 +149,11 @@ def validate_report_type(errors):
             f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
         )
+        if method == 'build' and report_type is None:
+            errors.append(
+                f'Invalid METRICS_UTILITY_REPORT_TYPE is Empty. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
+                f'Please note these values are case sensitive'
+            )
     return report_type
 
 
@@ -235,12 +240,14 @@ def validate_ship_target(errors, ship_target_type):
         - Error messages include the invalid ship target and the list of valid values.
     """
     ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
+    if ship_target is None:
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET is Empty. Valid values: {", ".join(ship_target_type)}')
     if ship_target and ship_target not in ship_target_type:
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(ship_target_type)}')
     return ship_target
 
 
-def validate_ship_path(errors, ship_target):
+def validate_ship_path(errors, ship_target, method):
     """
     Validates the ship path environment variable based on the ship target.
 
@@ -253,9 +260,14 @@ def validate_ship_path(errors, ship_target):
         - Appends an error message to 'errors' if the directory does not exist.
     """
     ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
-    if ship_target == 'directory' and ship_target:
+    dir_paths = VALID_SHIP_TARGET_BUILD
+    if 's3' in dir_paths:
+        dir_paths.remove('s3')
+    if ship_target and ship_target in dir_paths and method == 'build':
         if not os.path.isdir(ship_path):
             errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
+    if method == 'gather' and ship_target == 'directory':
+        logger.info('No directory set under METRICS_UTILITY_SHIP_PATH. A directory will be created')
 
 
 def handle_env_validation(method: str):
@@ -289,14 +301,14 @@ def handle_env_validation(method: str):
             or invalid.
     """
     errors = []
-    report_type = validate_report_type(errors)
-    validate_ccsp_report_sheets(errors, report_type)
+    report_type = validate_report_type(errors, method)
     validate_collectors(errors)
-    if method == 'gather':
-        ship_target = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
-    else:
+    if method == 'build':
+        validate_ccsp_report_sheets(errors, report_type)
         ship_target = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
-    validate_ship_path(errors, ship_target)
+    else:
+        ship_target = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
+    validate_ship_path(errors, ship_target, method)
     if errors:
         raise MissingRequiredEnvVar('\n'.join(errors))
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -259,15 +259,16 @@ def validate_ship_path(errors, ship_target, method):
         - For 'directory' ship target, checks if METRICS_UTILITY_SHIP_PATH is an existing directory.
         - Appends an error message to 'errors' if the directory does not exist.
     """
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    no_path = 'No Path Provided'
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', no_path)
     dir_paths = VALID_SHIP_TARGET_BUILD
     if 's3' in dir_paths:
         dir_paths.remove('s3')
     if ship_target and ship_target in dir_paths and method == 'build':
         if not os.path.isdir(ship_path):
             errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
-    if method == 'gather' and ship_target == 'directory':
-        logger.info('No directory set under METRICS_UTILITY_SHIP_PATH. A directory will be created')
+    if ship_path == no_path and method == 'gather' and ship_target == 'directory':
+        logger.info('No path set under METRICS_UTILITY_SHIP_PATH. A directory will be created')
 
 
 def handle_env_validation(method: str):

--- a/metrics_utility/test/ccspv_reports/test_build_report_unit.py
+++ b/metrics_utility/test/ccspv_reports/test_build_report_unit.py
@@ -14,7 +14,7 @@ def command_instance():
 def test_add_arguments_calls_env_validation(monkeypatch, command_instance):
     called = {}
 
-    def fake_handle_env_validation():
+    def fake_handle_env_validation(build):
         called['called'] = True
 
     monkeypatch.setattr(

--- a/metrics_utility/test/ccspv_reports/test_build_report_unit.py
+++ b/metrics_utility/test/ccspv_reports/test_build_report_unit.py
@@ -1,0 +1,90 @@
+from unittest import mock
+
+import pytest
+
+from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
+from metrics_utility.management.commands.build_report import Command
+
+
+@pytest.fixture
+def command_instance():
+    return Command()
+
+
+def test_add_arguments_calls_env_validation(monkeypatch, command_instance):
+    called = {}
+
+    def fake_handle_env_validation():
+        called['called'] = True
+
+    monkeypatch.setattr(
+        'metrics_utility.management.commands.build_report.handle_env_validation',
+        fake_handle_env_validation,
+    )
+    parser = mock.Mock()
+    command_instance.add_arguments(parser)
+    assert called['called']
+
+
+def test_handle_ship_target_directory(monkeypatch, command_instance):
+    monkeypatch.setattr('metrics_utility.management.commands.build_report.handle_directory_ship_target', lambda: {'ship_path': 'directory'})
+    assert command_instance._handle_ship_target('directory') == {'ship_path': 'directory'}
+
+
+def test_handle_ship_target_s3(monkeypatch, command_instance):
+    monkeypatch.setattr('metrics_utility.management.commands.build_report.handle_s3_ship_target', lambda: {'ship_path': 's3'})
+    assert command_instance._handle_ship_target('s3') == {'ship_path': 's3'}
+
+
+def test_handle_ship_target_invalid(command_instance):
+    with pytest.raises(BadShipTarget):
+        command_instance._handle_ship_target('invalid_target')
+
+
+def test_handle_extra_params_missing_ship_path(monkeypatch, command_instance):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
+    with pytest.raises(MissingRequiredEnvVar):
+        command_instance._handle_extra_params('directory')
+
+
+def test_handle_extra_params_missing_report_type(monkeypatch, command_instance):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', 'directory')
+    monkeypatch.delenv('METRICS_UTILITY_REPORT_TYPE', raising=False)
+    with pytest.raises(MissingRequiredEnvVar):
+        command_instance._handle_extra_params('directory')
+
+
+def test_handle_extra_params_bad_report_type(monkeypatch, command_instance):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', 'directory')
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'BADTYPE')
+    with pytest.raises(BadRequiredEnvVar):
+        command_instance._handle_extra_params('directory')
+
+
+def test_handle_extra_params_all_valid(monkeypatch, command_instance):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', 'directory')
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    params = command_instance._handle_extra_params('directory')
+    assert params['ship_path'] == 'directory'
+    assert params['report_type'] == 'CCSP'
+
+
+def test_handle_month_with_arg(command_instance):
+    month, date, next_month = command_instance._handle_month('2024-05')
+    assert month == '2024-05'
+    assert date.month == 5
+    assert next_month.month == 6
+
+
+def test_handle_month_without_arg(command_instance):
+    month, date, next_month = command_instance._handle_month(None)
+    assert isinstance(month, str)
+    assert date.day == 1
+    assert (next_month - date).days in (28, 29, 30, 31)
+
+
+def test_init_logging(command_instance):
+    command_instance.init_logging()
+    assert hasattr(command_instance, 'logger')
+    assert command_instance.logger.name == 'awx.main.analytics'

--- a/metrics_utility/test/ccspv_reports/test_build_report_unit.py
+++ b/metrics_utility/test/ccspv_reports/test_build_report_unit.py
@@ -70,20 +70,6 @@ def test_handle_extra_params_all_valid(monkeypatch, command_instance):
     assert params['report_type'] == 'CCSP'
 
 
-def test_handle_month_with_arg(command_instance):
-    month, date, next_month = command_instance._handle_month('2024-05')
-    assert month == '2024-05'
-    assert date.month == 5
-    assert next_month.month == 6
-
-
-def test_handle_month_without_arg(command_instance):
-    month, date, next_month = command_instance._handle_month(None)
-    assert isinstance(month, str)
-    assert date.day == 1
-    assert (next_month - date).days in (28, 29, 30, 31)
-
-
 def test_init_logging(command_instance):
     command_instance.init_logging()
     assert hasattr(command_instance, 'logger')

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -1,0 +1,149 @@
+import tempfile
+
+import pytest
+
+from metrics_utility.exceptions import MissingRequiredEnvVar
+from metrics_utility.management.validation import (
+    handle_env_validation,
+    validate_ccsp_report_sheets,
+    validate_collectors,
+    validate_report_type,
+    validate_ship_path,
+    validate_ship_target,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    # Clear relevant env vars before each test
+    keys = [
+        'METRICS_UTILITY_REPORT_TYPE',
+        'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS',
+        'METRICS_UTILITY_OPTIONAL_COLLECTORS',
+        'METRICS_UTILITY_SHIP_PATH',
+        'METRICS_UTILITY_SHIP_TARGET',
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+def test_validate_report_type_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    errors = []
+    result = validate_report_type(errors)
+    assert result == 'CCSP'
+    assert not errors
+
+
+def test_validate_report_type_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
+    errors = []
+    result = validate_report_type(errors)
+    assert result == 'INVALID'
+    assert errors
+    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in errors[0]
+
+
+def test_validate_ccsp_report_sheets_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'ccsp_summary,managed_nodes')
+    errors = []
+    validate_ccsp_report_sheets(errors, 'CCSP')
+    assert not errors
+
+
+def test_validate_ccsp_report_sheets_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'ccsp_summary,invalid_sheet')
+    errors = []
+    validate_ccsp_report_sheets(errors, 'CCSP')
+    assert errors
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in errors[0]
+
+
+def test_validate_collectors_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_host')
+    errors = []
+    validate_collectors(errors)
+    assert not errors
+
+
+def test_validate_collectors_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid_collector')
+    errors = []
+    validate_collectors(errors)
+    assert errors
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in errors[0]
+
+
+def test_validate_ship_target_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
+    errors = []
+    result = validate_ship_target(errors)
+    assert result == 'directory'
+    assert not errors
+
+
+def test_validate_ship_target_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
+    errors = []
+    result = validate_ship_target(errors)
+    assert result == 'invalid'
+    assert errors
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]
+
+
+def test_validate_ship_path_valid(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)
+        errors = []
+        validate_ship_path(errors, 'directory')
+        assert not errors
+
+
+def test_validate_ship_path_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    errors = []
+    validate_ship_path(errors, 'directory')
+    assert errors
+    assert 'Invalid METRICS_UTILITY_SHIP_PATH' in errors[0]
+
+
+def test_handle_env_validation_all_valid(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+        monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'ccsp_summary')
+        monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_host')
+        monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
+        monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)
+        # Should not raise
+        handle_env_validation()
+
+
+def test_handle_env_validation_raises(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_env_validation()
+    msg = str(excinfo.value)
+    print(f'full message: {msg}')
+    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in msg
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
+
+
+def test_handle_env_validation_raises_valid_report_type(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_env_validation()
+    msg = str(excinfo.value)
+    print(f'full message: {msg}')
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in msg
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -28,18 +28,35 @@ def clear_env(monkeypatch):
     yield
 
 
-def test_validate_report_type_valid(monkeypatch):
+def test_validate_report_type_build_valid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
     errors = []
-    result = validate_report_type(errors)
+    result = validate_report_type(errors, 'build')
     assert result == 'CCSP'
     assert not errors
 
 
-def test_validate_report_type_invalid(monkeypatch):
+def test_validate_report_type_gather_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    errors = []
+    result = validate_report_type(errors, 'gather')
+    assert result == 'CCSP'
+    assert not errors
+
+
+def test_validate_report_type_build_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
     errors = []
-    result = validate_report_type(errors)
+    result = validate_report_type(errors, 'build')
+    assert result == 'INVALID'
+    assert errors
+    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in errors[0]
+
+
+def test_validate_report_type_gather_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
+    errors = []
+    result = validate_report_type(errors, 'gather')
     assert result == 'INVALID'
     assert errors
     assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in errors[0]
@@ -77,7 +94,7 @@ def test_validate_collectors_invalid(monkeypatch):
 
 def test_validate_ship_target_valid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
-    VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
+    VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
     errors = []
     result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
     assert result == 'directory'
@@ -86,7 +103,7 @@ def test_validate_ship_target_valid(monkeypatch):
 
 def test_validate_ship_target_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
-    VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
+    VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
     errors = []
     result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
     assert result == 'invalid'
@@ -113,23 +130,38 @@ def test_validate_ship_target_gather_invalid(monkeypatch):
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]
 
 
-def test_validate_ship_path_valid(monkeypatch):
+def test_validate_ship_path_build_valid(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
         monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)
         errors = []
-        validate_ship_path(errors, 'directory')
+        validate_ship_path(errors, 'directory', 'build')
         assert not errors
 
 
-def test_validate_ship_path_invalid(monkeypatch):
+def test_validate_ship_path_gather_valid(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)
+        errors = []
+        validate_ship_path(errors, 'directory', 'gather')
+        assert not errors
+
+
+def test_validate_ship_path_build_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
     errors = []
-    validate_ship_path(errors, 'directory')
+    validate_ship_path(errors, 'directory', 'build')
     assert errors
     assert 'Invalid METRICS_UTILITY_SHIP_PATH' in errors[0]
 
 
-def test_handle_env_validation_all_valid(monkeypatch):
+def test_validate_ship_path_gather_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    errors = []
+    validate_ship_path(errors, 'directory', 'gather')
+    assert not errors
+
+
+def test_handle_env_validation_all_build_valid(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
         monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
         monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'ccsp_summary')
@@ -140,7 +172,7 @@ def test_handle_env_validation_all_valid(monkeypatch):
         handle_env_validation('build')
 
 
-def test_handle_env_validation_raises(monkeypatch):
+def test_handle_env_validation_gather_raises1(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
@@ -155,22 +187,21 @@ def test_handle_env_validation_raises(monkeypatch):
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
 
 
-def test_handle_env_validation_raises_valid_report_type(monkeypatch):
+def test_handle_env_validation_raises_valid_build_report_type(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
-        handle_env_validation('gather')
+        handle_env_validation('build')
     msg = str(excinfo.value)
-    print(f'full message: {msg}')
     assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in msg
     assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
 
 
-def test_handle_env_validation_build_raises(monkeypatch):
+def test_handle_env_validation_gather_raises2(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
     monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
@@ -179,8 +210,6 @@ def test_handle_env_validation_build_raises(monkeypatch):
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
         handle_env_validation('gather')
     msg = str(excinfo.value)
-    print(f'full message: {msg}')
-    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in msg
     assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
 
@@ -192,9 +221,7 @@ def test_handle_env_validation_raises_valid_buid_report_type(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
-        handle_env_validation('gather')
+        handle_env_validation('build')
     msg = str(excinfo.value)
-    print(f'full message: {msg}')
-    assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in msg
     assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -138,6 +138,19 @@ def test_validate_ship_path_build_valid(monkeypatch):
         assert not errors
 
 
+def test_validate_ship_path_build_empty_build_valid(monkeypatch):
+    errors = []
+    validate_ship_path(errors, 'directory', 'build')
+    assert errors
+    assert 'Invalid METRICS_UTILITY_SHIP_PATH' in errors[0]
+
+
+def test_validate_ship_path_build_empty_gather_valid(monkeypatch):
+    errors = []
+    validate_ship_path(errors, 'directory', 'gather')
+    assert not errors
+
+
 def test_validate_ship_path_gather_valid(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
         monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -77,16 +77,37 @@ def test_validate_collectors_invalid(monkeypatch):
 
 def test_validate_ship_target_valid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
+    VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
     errors = []
-    result = validate_ship_target(errors)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
     assert result == 'directory'
     assert not errors
 
 
 def test_validate_ship_target_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
+    VALID_SHIP_TARGET_BUILD = {'directory', 's3'}
     errors = []
-    result = validate_ship_target(errors)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
+    assert result == 'invalid'
+    assert errors
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]
+
+
+def test_validate_ship_target_gather_valid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
+    VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
+    errors = []
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
+    assert result == 'directory'
+    assert not errors
+
+
+def test_validate_ship_target_gather_invalid(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
+    VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
+    errors = []
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
     assert result == 'invalid'
     assert errors
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]
@@ -116,7 +137,7 @@ def test_handle_env_validation_all_valid(monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
         monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', tmpdir)
         # Should not raise
-        handle_env_validation()
+        handle_env_validation('build')
 
 
 def test_handle_env_validation_raises(monkeypatch):
@@ -126,7 +147,7 @@ def test_handle_env_validation_raises(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
-        handle_env_validation()
+        handle_env_validation('gather')
     msg = str(excinfo.value)
     print(f'full message: {msg}')
     assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in msg
@@ -141,7 +162,37 @@ def test_handle_env_validation_raises_valid_report_type(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
-        handle_env_validation()
+        handle_env_validation('gather')
+    msg = str(excinfo.value)
+    print(f'full message: {msg}')
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in msg
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
+
+
+def test_handle_env_validation_build_raises(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_env_validation('gather')
+    msg = str(excinfo.value)
+    print(f'full message: {msg}')
+    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in msg
+    assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
+    assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
+
+
+def test_handle_env_validation_raises_valid_buid_report_type(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS', 'egg,fried')
+    monkeypatch.setenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'invalid,page')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid_path')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/non/existing/dir')
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_env_validation('gather')
     msg = str(excinfo.value)
     print(f'full message: {msg}')
     assert 'Invalid METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS' in msg


### PR DESCRIPTION
[[AAP-45503]](https://issues.redhat.com/browse/AAP-45503)

## Description

Better Error Handling for enviroment variables


- What is being changed?
Added in validate location for verifying all variables so this can be done cleanly in one place

- Why is this change needed?
At the moment environment variable are verified or not even verified once they are run causing exceptions to be thrown without the full details. this way the environment variables will be checked at first run and show a error and helper. This allows multiple issues to be caught at first run instead of individually. 

- How does this change address the issue?
Resolves the issue and gives more structure going forward. 

##  Changes 

- Added handle_env_validation to Build Report [metrics_utility/management/commands/build_report.py](https://github.com/ansible/metrics-utility/pull/135/files#diff-216a16965cc1fe989bdf35aef44e5ecd26f303ce3dd23812ff00862c8bc662a3)
- Added handle_env_validation to Gather Method [metrics_utility/management/commands/gather_automation_controller_billing_data.py](https://github.com/ansible/metrics-utility/pull/137/files#diff-bb98f7ff0b0f4e4c66ebfeb4296c00cf73d8e86eafcb1fd12ba5c7eca4aeb2a7)files#diff-216a16965cc1fe989bdf35aef44e5ecd26f303ce3dd23812ff00862c8bc662a3)
- Addition to Validation.py of the handle_env_validation method and constants of valid values [metrics_utility/management/validation.py](https://github.com/ansible/metrics-utility/pull/135/files#diff-74815671e759671fde1bdd5f0276ffd27e215e903eb3dc74b3f3dc1da16c3380)
- Added basic unit tests for code coverage for [metrics_utility/test/ccspv_reports/test_build_report_unit.py](https://github.com/ansible/metrics-utility/pull/135/files#diff-2df7e5d5f20f0d957ef9210f8a4e96a8e045444087bd770b2e3217e1ec00b3ab)
- Added unit tests for [test_validation.py](https://github.com/ansible/metrics-utility/pull/135/files#diff-18504e9f84b6305d6410e1e8b1cc3f822e8ea643a0b8160566c0ce40f85a430c)

Closed previous PR due to unsigned commits https://github.com/ansible/metrics-utility/pull/135 