### PR TITLE
Commands: move handle_env* *after* init_logging

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -102,6 +102,7 @@ class Command(BaseCommand):
     def _handle(self, *args, **options):
         self.init_logging()
 
+        handle_env_validation('build')
         validate_build_extra_params(self.help_texts, options)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
@@ -171,7 +172,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            handle_env_validation('build')
             self._handle(*args, **options)
         except (
             BadShipTarget,

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -101,8 +101,8 @@ class Command(BaseCommand):
 
     def _handle(self, *args, **options):
         self.init_logging()
-
         handle_env_validation('build')
+
         validate_build_extra_params(self.help_texts, options)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -71,7 +71,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            handle_env_validation('gather')
             self._handle(self, *args, **options)
             exit(0)
         except (BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar, FailedToUploadPayload, UnparsableParameter) as e:
@@ -83,6 +82,7 @@ class Command(BaseCommand):
 
     def _handle(self, *args, **options):
         self.init_logging()
+        handle_env_validation('gather')
 
         handle_validate_date_param(options.get('since', None), self.help_texts.get('since'), 'gather')
         handle_validate_date_param(options.get('until', None), self.help_texts.get('until'), 'gather')

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar
@@ -13,7 +15,12 @@ unset = {
 }
 
 
-def expect_build_error(env, klass):
+# workaround, until we merge env var handling between _handle_* and handle_env_validation
+# this test was written in a world without handle_env_validation, mocking it out
+@patch('metrics_utility.management.commands.build_report.handle_env_validation')
+def expect_build_error(env, klass, mocked):
+    mocked.return_value = None
+
     with pytest.raises(klass) as e:
         run_build_int(
             {**unset, **env},
@@ -24,7 +31,10 @@ def expect_build_error(env, klass):
     return e.value
 
 
-def expect_gather_error(env, klass):
+@patch('metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation')
+def expect_gather_error(env, klass, mocked):
+    mocked.return_value = None
+
     with pytest.raises(klass) as e:
         run_gather_int(
             {**unset, **env},
@@ -38,6 +48,7 @@ def expect_gather_error(env, klass):
 def test_build_bad_target():
     e = expect_build_error(
         {
+            'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
             'METRICS_UTILITY_SHIP_TARGET': 'crc',
         },
         BadShipTarget,


### PR DESCRIPTION
Follows #141, issue AAP-47719
Issue: AAP-47951

Moving `handle_env_validation` inside `handle()` fixed `--help` breaking,
but introduced

```
   File "/home/himdel/metrics/metrics-utility/metrics_utility/management/commands/build_report.py", line 206, in handle
    self.logger.error(str(e))
    ^^^^^^^^^^^
AttributeError: 'Command' object has no attribute 'logger'
```

when running without `--help` (and when not all env variables were valid/provided)

(And updating the S3 env validation test to cope with `handle_env_validation` being a part of `handle()` now.)