### PR TITLE
build_report: default month to last month

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -111,10 +111,10 @@ class Command(BaseCommand):
 
     def _handle(self, *args, **options):
         self.init_logging()
-        og_month, month, next_month = handle_month(options.get('month') or None)
 
         validate_build_extra_params(self.help_texts, options)
-        opt_month = og_month if options.get('month') else None
+
+        opt_month, month, next_month = handle_month(options.get('month') or None)
         opt_until = self._parse_param('until', options)
         opt_since = self._parse_param('since', options)
         opt_force = options.get('force')

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -99,24 +99,14 @@ class Command(BaseCommand):
         self.logger.addHandler(handler)
         self.logger.propagate = False
 
-    def _parse_param(
-        self,
-        param_name,
-        options,
-    ):
-        param = options.get(param_name)
-        if options.get('month') is not None or param is None:
-            return None
-        return parse_date_param(param)
-
     def _handle(self, *args, **options):
         self.init_logging()
 
         validate_build_extra_params(self.help_texts, options)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
-        opt_until = self._parse_param('until', options)
-        opt_since = self._parse_param('since', options)
+        opt_since = parse_date_param(options.get('since'))
+        opt_until = parse_date_param(options.get('until'))
         opt_force = options.get('force')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)


### PR DESCRIPTION
Follows #128, #142 
Issue: AAP-47953

Set `opt_month` even when `options['month']` was empty - the default for `--month` is the last month.
(The value gets ignored when `--since` is used, but used otherwise.)

Fixes:

```
$ METRICS_UTILITY_REPORT_TYPE=CCSPv2 METRICS_UTILITY_SHIP_TARGET=directory METRICS_UTILITY_SHIP_PATH="./metrics_utility/test/test_data/" uv run ./manage.py build_report 
Automation Controller modules not found in /awx_devel (AWX_PATH). Using mock and continuing.
No billing data for month None
```

(expected `No billing data for month 2025-05`)

(Also affects the filename of the report if there are data, and the reported report period.)