### PR TITLE
Deduplication poc

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -7,6 +7,9 @@ from metrics_utility.automation_controller_billing.dataframe_engine.base import 
 from metrics_utility.debug_utils import print_data, print_debug
 
 
+# TODO how from metrics_utility.automation_controller_billing.dedup.ccsp import DedupCCSP
+
+
 logger = logging.getLogger(__name__)
 
 #######################################

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+from metrics_utility.automation_controller_billing.dedup.ccsp import DedupCCSP
 from metrics_utility.automation_controller_billing.helpers import merge_json_sets
 from metrics_utility.debug_utils import print_data, print_debug
 
@@ -37,14 +38,8 @@ class DataframeInventoryScope(Base):
                 billing_data['organization_name'] = billing_data.organization_name.fillna('No organization name')
                 billing_data['install_uuid'] = data['config']['install_uuid']
 
-                # Store the original host name for mapping purposes
-                billing_data['original_host_name'] = billing_data['host_name']
-                if 'ansible_host_variable' in billing_data.columns:
-                    # Replace missing ansible_host_variable with host name
-                    billing_data['ansible_host_variable'] = billing_data.ansible_host_variable.fillna(billing_data['host_name'])
-                    # And use the new ansible_host_variable instead of host_name, since
-                    # what is in ansible_host_variable should be the actual host we count
-                    billing_data['host_name'] = billing_data['ansible_host_variable']
+                # apply deduplication step, creates original_host_name
+                DedupCCSP.do(billing_data)
 
                 billing_data['last_automation'] = pd.to_datetime(billing_data['last_automation'], format='ISO8601').dt.tz_localize(None)
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+from metrics_utility.automation_controller_billing.dedup.ccsp import DedupCCSP
 from metrics_utility.automation_controller_billing.helpers import merge_arrays, merge_json_sets, parse_json_array
 from metrics_utility.debug_utils import print_data, print_debug
 from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
@@ -45,14 +46,8 @@ class DataframeJobhostSummaryUsage(Base):
                 billing_data['organization_name'] = billing_data.organization_name.fillna('No organization name')
                 billing_data['install_uuid'] = data['config']['install_uuid']
 
-                # Store the original host name for mapping purposes
-                billing_data['original_host_name'] = billing_data['host_name']
-                if 'ansible_host_variable' in billing_data.columns:
-                    # Replace missing ansible_host_variable with host name
-                    billing_data['ansible_host_variable'] = billing_data.ansible_host_variable.fillna(billing_data['host_name'])
-                    # And use the new ansible_host_variable instead of host_name, since
-                    # what is in ansible_host_variable should be the actual host we count
-                    billing_data['host_name'] = billing_data['ansible_host_variable']
+                # apply deduplication step, creates original_host_name
+                DedupCCSP.do(billing_data)
 
                 # Summarize all task counts into 1 col
                 def sum_columns(row):

--- a/metrics_utility/automation_controller_billing/dedup/ccsp.py
+++ b/metrics_utility/automation_controller_billing/dedup/ccsp.py
@@ -1,0 +1,9 @@
+# TODO
+class DedupCCSP:
+    def __init__(self, dataframes, extra_params):
+        self.dataframes = dataframes
+        self.extra_params = extra_params
+
+    def run_deduplication(self):
+        # FIXME - ccsp: jobhost, content, inventory ; ccspv2: jobhost, content, inventory, collection status
+        return self.dataframes[0].copy()

--- a/metrics_utility/automation_controller_billing/dedup/ccsp.py
+++ b/metrics_utility/automation_controller_billing/dedup/ccsp.py
@@ -1,4 +1,3 @@
-# TODO
 class DedupCCSP:
     def __init__(self, dataframes, extra_params):
         self.dataframes = dataframes
@@ -7,3 +6,14 @@ class DedupCCSP:
     def run_deduplication(self):
         # FIXME - ccsp: jobhost, content, inventory ; ccspv2: jobhost, content, inventory, collection status
         return self.dataframes[0].copy()
+
+    @staticmethod
+    def do(df):
+        # Store the original host name for mapping purposes
+        df['original_host_name'] = df['host_name']
+        if 'ansible_host_variable' in df.columns:
+            # Replace missing ansible_host_variable with host name
+            df['ansible_host_variable'] = df.ansible_host_variable.fillna(df['host_name'])
+            # And use the new ansible_host_variable instead of host_name, since
+            # what is in ansible_host_variable should be the actual host we count
+            df['host_name'] = df['ansible_host_variable']

--- a/metrics_utility/automation_controller_billing/dedup/factory.py
+++ b/metrics_utility/automation_controller_billing/dedup/factory.py
@@ -1,0 +1,33 @@
+from metrics_utility.automation_controller_billing.dedup.ccsp import DedupCCSP
+from metrics_utility.automation_controller_billing.dedup.renewal_guidance import DedupRenewal
+from metrics_utility.exceptions import NotSupportedFactory
+
+
+class Factory:
+    def __init__(self, dataframes, extra_params):
+        self.dataframes = dataframes
+        self.extra_params = extra_params
+
+    def create(self):
+        deduplicator = self.extra_params['deduplicator']
+        report_type = self.extra_params['report_type']
+
+        kwargs = {
+            'dataframes': self.dataframes,
+            'extra_params': self.extra_params,
+        }
+
+        if deduplicator is None:
+            if report_type in {'CCSP', 'CCSPv2'}:
+                return DedupCCSP(**kwargs)
+            if report_type in {'RENEWAL_GUIDANCE'}:
+                return DedupRenewal(**kwargs)
+
+            raise NotSupportedFactory(f'Unknown report type: {report_type}')
+
+        if deduplicator == 'ccsp':
+            return DedupCCSP(**kwargs)
+        if deduplicator == 'renewal':
+            return DedupRenewal(**kwargs)
+
+        raise NotSupportedFactory(f'Factory for {deduplicator} not supported')

--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -1,9 +1,9 @@
 import pandas as pd
 
 
-class Dedup:
-    def __init__(self, dataframe, extra_params):
-        self.dataframe = dataframe
+class DedupRenewal:
+    def __init__(self, dataframes, extra_params):
+        self.dataframe = dataframes[0]
         self.extra_params = extra_params
 
     def run_deduplication(self):
@@ -67,6 +67,7 @@ class Dedup:
                 }
             )
 
+        # FIXME: dataframes obj
         return pd.DataFrame(deduped_list)
 
     def stringify(self, value):

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -10,9 +10,9 @@ from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils.dataframe import dataframe_to_rows
 
+from metrics_utility.automation_controller_billing.dedup.factory import Factory as DedupFactory
 from metrics_utility.automation_controller_billing.helpers import parse_number_of_days
 from metrics_utility.automation_controller_billing.report.base import Base
-from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup import Dedup
 
 
 class ReportRenewalGuidance(Base):
@@ -55,7 +55,7 @@ class ReportRenewalGuidance(Base):
         host_metric_dataframe['last_deleted'] = pd.to_datetime(host_metric_dataframe['last_deleted'], format='ISO8601').dt.tz_localize(None)
 
         # Run the host deduplication first
-        host_metric_dataframe = Dedup(host_metric_dataframe, extra_params=self.extra_params).run_deduplication()
+        host_metric_dataframe = DedupFactory(dataframes=(host_metric_dataframe,), extra_params=self.extra_params).create().run_deduplication()
 
         host_metric_dataframe['days_automated'] = (host_metric_dataframe['last_automation'] - host_metric_dataframe['first_automation']).dt.days
         host_metric_dataframe['days_automated'] = host_metric_dataframe['days_automated'].apply(lambda x: x if x > 0 else 0)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 
+from argparse import RawDescriptionHelpFormatter
 from datetime import timezone
 
 from django.core.management.base import BaseCommand
@@ -67,6 +68,25 @@ class Command(BaseCommand):
                 'Example: --ephemeral=3months, or --ephemeral=3days'
             ),
         }
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        return super().create_parser(
+            prog_name,
+            subcommand,
+            # ensure newlines are preserved in descriptions and epilog
+            formatter_class=RawDescriptionHelpFormatter,
+            epilog='\n'.join(
+                [
+                    'ENVIRONMENT',
+                    "    METRICS_UTILITY_REPORT_TYPE (required, case sensitive): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'",
+                    "        determines which kind of report we're generating",
+                    '',
+                    "    METRICS_UTILITY_DEDUPLICATOR (optional): one of 'ccsp', 'renewal', 'experimental'",
+                    "        choice of deduplication algorithm, defaults to 'ccsp' or 'renewal' based on the chosen report type",
+                ]
+            ),
+            **kwargs,
+        )
 
     def add_arguments(self, parser):
         parser.add_argument('--month', dest='month', action='store', help=self.help_texts.get('month'))

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -137,6 +137,7 @@ class Command(BaseCommand):
         extra_params['opt_ephemeral'] = options.get('ephemeral') or None
         extra_params['month_since'] = month
         extra_params['month_until'] = next_month
+        extra_params['deduplicator'] = os.getenv('METRICS_UTILITY_DEDUPLICATOR', None) or None
 
         extractor = ExtractorFactory(ship_target, extra_params).create()
 

--- a/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
+++ b/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
@@ -8,7 +8,7 @@ import pytest
 
 from openpyxl import Workbook as ActualOpenpyxlWorkbook
 
-from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup import Dedup as ActualDedup
+from metrics_utility.automation_controller_billing.dedup.renewal_guidance import DedupRenewal
 from metrics_utility.automation_controller_billing.report.report_renewal_guidance import ReportRenewalGuidance
 
 
@@ -28,7 +28,7 @@ def setup_build_spreadsheet_mocks(fixed_now):
 
     mock_cell = MagicMock()
 
-    mock_dedup_instance = MagicMock(spec=ActualDedup)
+    mock_dedup_instance = MagicMock(spec=DedupRenewal)
     mock_dedup_class = MagicMock(return_value=mock_dedup_instance)
 
     mock_time_module = MagicMock()
@@ -61,7 +61,7 @@ def setup_build_spreadsheet_mocks(fixed_now):
 def setup_report_renewal_guidance_instance(fixed_now, setup_build_spreadsheet_mocks, setup_processed_dataframe):
     patch_target_datetime = 'metrics_utility.automation_controller_billing.report.report_renewal_guidance.datetime'
     patch_target_workbook = 'metrics_utility.automation_controller_billing.report.report_renewal_guidance.Workbook'
-    patch_target_dedup_class = 'metrics_utility.automation_controller_billing.report.report_renewal_guidance.Dedup'
+    patch_target_dedup_class = 'metrics_utility.automation_controller_billing.dedup.factory.DedupRenewal'
     patch_target_time = 'metrics_utility.automation_controller_billing.report.report_renewal_guidance.time'
     patch_target_dataframe_to_rows = 'metrics_utility.automation_controller_billing.report.report_renewal_guidance.dataframe_to_rows'
 
@@ -81,6 +81,8 @@ def setup_report_renewal_guidance_instance(fixed_now, setup_build_spreadsheet_mo
         test_ephemeral_days = 30
         report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
+            'report_type': 'RENEWAL_GUIDANCE',
+            'deduplicator': None,
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
             'report_period_range': report_period_range,
@@ -139,7 +141,7 @@ def test_build_spreadsheet_with_ephemeral_data(
     mocks['dedup_class_mock'].assert_called_once()
     mocks['dedup_instance_mock'].run_deduplication.assert_called_once()
 
-    dedup_call_df = mocks['dedup_class_mock'].call_args[0][0]
+    dedup_call_df = mocks['dedup_class_mock'].call_args[1]['dataframes'][0]
     expected_df_before_dedup = processed_df.copy()
     expected_df_before_dedup['first_automation'] = expected_df_before_dedup['first_automation'].dt.tz_localize(None)
     expected_df_before_dedup['last_automation'] = expected_df_before_dedup['last_automation'].dt.tz_localize(None)
@@ -223,7 +225,7 @@ def test_build_spreadsheet_without_ephemeral_data(
     mocks['dedup_class_mock'].assert_called_once()
     mocks['dedup_instance_mock'].run_deduplication.assert_called_once()
 
-    dedup_call_df = mocks['dedup_class_mock'].call_args[0][0]
+    dedup_call_df = mocks['dedup_class_mock'].call_args[1]['dataframes'][0]
     expected_df_before_dedup = processed_df.copy()
     expected_df_before_dedup['first_automation'] = expected_df_before_dedup['first_automation'].dt.tz_localize(None)
     expected_df_before_dedup['last_automation'] = expected_df_before_dedup['last_automation'].dt.tz_localize(None)


### PR DESCRIPTION
wip
jiras AAP-47867, AAP-38205, AAP-46674, AAP-47875, AAP-47907, to various extents

should now be able to switch dedup algo based on env var
TODO env var validation

does mention the env var in --help

should run renewal with renewal dedup without change
TODO wire ccsp

TODO make sure test renewal ext exists
TODO validate fields to see if both existing can be shared, or need to blow up

(wip, this PR will be ready when only missing new algo, tests)