### PR TITLE
`report_period` - move inside `extra_params`, merge with `report_period_range`

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
@@ -12,26 +12,26 @@ class Factory:
         self.month = month
         self.extra_params = extra_params
 
-        self.report_type = extra_params['report_type']
-
     def create(self):
-        if self.report_type == 'CCSP':
+        report_type = self.extra_params['report_type']
+
+        if report_type == 'CCSP':
             return (
                 self._get_dataframe_jobhost_summary_usage().build_dataframe(),
                 self._get_dataframe_content_usage().build_dataframe(),
                 self._get_dataframe_inventory_scope().build_dataframe(),
             )
-        elif self.report_type == 'CCSPv2':
+        elif report_type == 'CCSPv2':
             return (
                 self._get_dataframe_jobhost_summary_usage().build_dataframe(),
                 self._get_dataframe_content_usage().build_dataframe(),
                 self._get_dataframe_inventory_scope().build_dataframe(),
                 self._get_dataframe_collection_status().build_dataframe(),
             )
-        elif self.report_type == 'RENEWAL_GUIDANCE':
+        elif report_type == 'RENEWAL_GUIDANCE':
             return (self._get_db_dataframe_host_metric_usage().build_dataframe(),)
         else:
-            raise NotSupportedFactory(f'Factory for {self.report_type} not supported')
+            raise NotSupportedFactory(f'Factory for {report_type} not supported')
 
     def _get_dataframe_collection_status(self):
         return DataframeCollectionStatus(extractor=self.extractor, month=self.month, extra_params=self.extra_params)

--- a/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/factory.py
@@ -31,7 +31,7 @@ class Factory:
         elif self.report_type == 'RENEWAL_GUIDANCE':
             return (self._get_db_dataframe_host_metric_usage().build_dataframe(),)
         else:
-            raise NotSupportedFactory(f'Factory for {self.ship_target} not supported')
+            raise NotSupportedFactory(f'Factory for {self.report_type} not supported')
 
     def _get_dataframe_collection_status(self):
         return DataframeCollectionStatus(extractor=self.extractor, month=self.month, extra_params=self.extra_params)

--- a/metrics_utility/automation_controller_billing/report/factory.py
+++ b/metrics_utility/automation_controller_billing/report/factory.py
@@ -4,16 +4,11 @@ from metrics_utility.automation_controller_billing.report.report_renewal_guidanc
 
 
 class Factory:
-    def __init__(self, report_period, report_dataframe, extra_params):
-        if extra_params.get('report_period_range') is not None:
-            self.report_period = extra_params.get('report_period_range')
-        else:
-            self.report_period = report_period
-
+    def __init__(self, report_dataframe, extra_params):
         self.report_dataframe = report_dataframe
+        self.extra_params = extra_params
 
         self.report_type = extra_params['report_type']
-        self.extra_params = extra_params
 
     def create(self):
         if self.report_type == 'CCSP':
@@ -25,12 +20,12 @@ class Factory:
 
     def _get_report_ccsp(self):
         # Return default S3 loader
-        return ReportCCSP(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportCCSP(self.report_dataframe, self.extra_params)
 
     def _get_report_ccsp_v2(self):
         # Return default S3 loader
-        return ReportCCSPv2(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportCCSPv2(self.report_dataframe, self.extra_params)
 
     def _get_report_renewal_guidance(self):
         # Return default S3 loader
-        return ReportRenewalGuidance(self.report_dataframe, self.report_period, self.extra_params)
+        return ReportRenewalGuidance(self.report_dataframe, self.extra_params)

--- a/metrics_utility/automation_controller_billing/report/factory.py
+++ b/metrics_utility/automation_controller_billing/report/factory.py
@@ -4,15 +4,13 @@ from metrics_utility.automation_controller_billing.report.report_renewal_guidanc
 
 
 class Factory:
-    def __init__(self, report_period, report_dataframe, ship_target, extra_params):
+    def __init__(self, report_period, report_dataframe, extra_params):
         if extra_params.get('report_period_range') is not None:
             self.report_period = extra_params.get('report_period_range')
         else:
             self.report_period = report_period
 
         self.report_dataframe = report_dataframe
-
-        self.ship_target = ship_target
 
         self.report_type = extra_params['report_type']
         self.extra_params = extra_params

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -10,14 +10,15 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSP(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         # Create the workbook and worksheet
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'sku': extra_params['report_sku'],

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -16,13 +16,14 @@ from metrics_utility.metric_utils import DIRECT, INDIRECT
 
 
 class ReportCCSPv2(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'sku': extra_params['report_sku'],

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -16,13 +16,14 @@ from metrics_utility.automation_controller_billing.report.renewal_guidance.dedup
 
 
 class ReportRenewalGuidance(Base):
-    def __init__(self, dataframe, report_period, extra_params):
+    def __init__(self, dataframe, extra_params):
         self.wb = Workbook()
 
         self.dataframe = dataframe
-        self.report_period = report_period
         self.extra_params = extra_params
+
         self.price_per_node = extra_params['price_per_node']
+        self.report_period = extra_params['report_period']
 
         self.config = {
             'h1_heading': {
@@ -422,7 +423,7 @@ class ReportRenewalGuidance(Base):
             if header_row['label'] == 'Report Period (YYYY-MM-DD, YYYY-MM-DD)':
                 # Insert dynamic report period into the specific header column
                 cell.fill = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
-                cell.value = self.extra_params['report_period_range']
+                cell.value = self.report_period
             else:
                 cell.fill = PatternFill('solid', fgColor=self.GREEN_COLOR_HEX)
                 cell.value = header_row['value']

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -161,7 +161,6 @@ class Command(BaseCommand):
         report_engine = ReportFactory(
             report_period=opt_month,
             report_dataframe=report_dataframe,
-            ship_target=ship_target,
             extra_params=extra_params,
         ).create()
         report_spreadsheet = report_engine.build_spreadsheet()

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -126,13 +126,13 @@ class Command(BaseCommand):
             extra_params['since_date'] = opt_since.date()
             extra_params['until_date'] = opt_until.date() if opt_until else now.date()
 
-            extra_params['report_period_range'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
-
+            extra_params['report_period'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 extractor.get_report_path(extra_params['until_date']),
                 f'{extra_params["report_type"]}-{opt_since.date()}--{extra_params["until_date"]}.xlsx',
             )
         else:
+            extra_params['report_period'] = opt_month
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
                 extractor.get_report_path(month),
                 f'{extra_params["report_type"]}-{opt_month}.xlsx',
@@ -158,11 +158,7 @@ class Command(BaseCommand):
                 self.logger.info(f'No billing data for month {opt_month}')
             return
 
-        report_engine = ReportFactory(
-            report_period=opt_month,
-            report_dataframe=report_dataframe,
-            extra_params=extra_params,
-        ).create()
+        report_engine = ReportFactory(report_dataframe=report_dataframe, extra_params=extra_params).create()
         report_spreadsheet = report_engine.build_spreadsheet()
 
         # Save the report to the configured destination

--- a/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
+++ b/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
@@ -79,18 +79,16 @@ def setup_report_renewal_guidance_instance(fixed_now, setup_build_spreadsheet_mo
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
         test_ephemeral_days = 30
-        report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
-            'report_period_range': report_period_range,
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
 
         report_instance = ReportRenewalGuidance(
             dataframe=[setup_processed_dataframe],
-            report_period=report_period_range,
             extra_params=test_extra_params,
         )
 
@@ -203,7 +201,6 @@ def test_build_spreadsheet_without_ephemeral_data(
 
     report_instance = ReportRenewalGuidance(
         dataframe=[processed_df],
-        report_period=modified_extra_params['report_period_range'],
         extra_params=modified_extra_params,
     )
 

--- a/metrics_utility/test/renewal_guidance/test_get_intervals.py
+++ b/metrics_utility/test/renewal_guidance/test_get_intervals.py
@@ -31,14 +31,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-01-01,2025-06-03',
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
 
         return ReportRenewalGuidance(
             dataframe=[mock_df],
-            report_period='2025-01-01,2025-06-03',
             extra_params=extra_params,
         )
 
@@ -95,14 +94,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-04-28,2025-05-12',
+            'report_period': '2025-04-28,2025-05-12',
             'since_date': '2025-04-28',
             'until_date': '2025-05-12',
         }
 
         instance = ReportRenewalGuidance(
             dataframe=[realistic_df],
-            report_period='2025-04-28,2025-05-12',
             extra_params=extra_params,
         )
 
@@ -232,14 +230,13 @@ class TestGetIntervals:
         extra_params = {
             'opt_ephemeral': '7 days',
             'price_per_node': 0.1,
-            'report_period_range': '2025-04-10,2025-05-12',
+            'report_period': '2025-04-10,2025-05-12',
             'since_date': '2025-04-10',
             'until_date': '2025-05-12',
         }
 
         production_instance = ReportRenewalGuidance(
             dataframe=[production_df],
-            report_period='2025-04-10,2025-05-12',
             extra_params=extra_params,
         )
 

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -25,17 +25,15 @@ def setup_report_renewal_guidance_instance(fixed_now):
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
         test_ephemeral_days = 30
-        report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
-            'report_period_range': report_period_range,
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
 
         yield {
-            'report_period': report_period_range,
             'extra_params': test_extra_params,
         }
 
@@ -51,7 +49,6 @@ def test_renewal_guidance_queries_with_mocked_data(setup_report_renewal_guidance
 
     report_instance = ReportRenewalGuidance(
         dataframe=[processed_df],
-        report_period=report_instance_params['report_period'],
         extra_params=report_instance_params['extra_params'],
     )
 
@@ -103,11 +100,10 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
 
         test_ephemeral_days = 30
-        report_period_range = '2025-01-01,2025-06-03'
         test_extra_params = {
             'opt_ephemeral': f'{test_ephemeral_days} days',
             'price_per_node': 0.1,
-            'report_period_range': report_period_range,
+            'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
             'until_date': '2025-06-03',
         }
@@ -126,7 +122,6 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
 
         report_renewal_guidance_instance_empty = ReportRenewalGuidance(
             dataframe=[empty_df_with_cols],
-            report_period=report_period_range,
             extra_params=test_extra_params,
         )
 


### PR DESCRIPTION
`report_period` was always set to `opt_month`,
but `ReportFactory` would overwrite it with `report_period_range` when present (when `--since`),
and renewal guidance would ignore it and only use `report_period_range` (and `KeyError` for `--month`)

=> always use `report_period` now, set it to `opt_month` for `--month`, and to original `report_period_range` value in the `--since` branch

And move `report_period` inside `extra_params`, like `report_period_range` was:

`ReportFactory`: `remove report_period` & `ship_target` params
  `ship_target` is unused
  `report_period` moves inside `extra_params`

`Report*`: remove `report_period` constructor param, load from `extra_params`

`build_report`: set `extra_params['report_period']`, don't pass `report_period` & `ship_target`

tests - remove `report_period` param, rename `report_period_range` extra param to `report_period`

And fix a `ship_target` typo in dataframe engine factory - should be `report_type`

(pulling out cleanups from #136; this should behave exactly the same as before)