### PR TITLE
Unify exception handling between commands

### DIFF
--- a/metrics_utility/exceptions.py
+++ b/metrics_utility/exceptions.py
@@ -1,48 +1,43 @@
-class BadShipTarget(Exception):
+class MetricsException(Exception):
     def __init__(self, message):
         self.name = message
 
 
-class MissingRequiredEnvVar(Exception):
-    def __init__(self, message):
-        self.name = message
+class BadParameter(MetricsException):
+    pass
 
 
-class BadRequiredEnvVar(Exception):
-    def __init__(self, message):
-        self.name = message
+class BadRequiredEnvVar(MetricsException):
+    pass
 
 
-class FailedToUploadPayload(Exception):
-    def __init__(self, message):
-        self.name = message
+class BadShipTarget(MetricsException):
+    pass
 
 
-class NoAnalyticsCollected(Exception):
-    def __init__(self, message):
-        self.name = message
+class DateFormatError(MetricsException):
+    pass
 
 
-class UnparsableParameter(Exception):
-    def __init__(self, message):
-        self.name = message
+class FailedToUploadPayload(MetricsException):
+    pass
 
 
-class NotSupportedFactory(Exception):
-    def __init__(self, message):
-        self.name = message
+class MissingRequiredEnvVar(MetricsException):
+    pass
 
 
-class MissingRequiredParameter(Exception):
-    def __init__(self, message):
-        self.name = message
+class MissingRequiredParameter(MetricsException):
+    pass
 
 
-class BadParameter(Exception):
-    def __init__(self, message):
-        self.name = message
+class NoAnalyticsCollected(MetricsException):
+    pass
 
 
-class DateFormatError(Exception):
-    def __init__(self, message):
-        self.name = message
+class NotSupportedFactory(MetricsException):
+    pass
+
+
+class UnparsableParameter(MetricsException):
+    pass

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -15,13 +15,9 @@ from metrics_utility.automation_controller_billing.helpers import (
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import (
-    BadParameter,
     BadRequiredEnvVar,
     BadShipTarget,
-    DateFormatError,
     MissingRequiredEnvVar,
-    MissingRequiredParameter,
-    UnparsableParameter,
 )
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
@@ -99,7 +95,7 @@ class Command(BaseCommand):
         self.logger.addHandler(handler)
         self.logger.propagate = False
 
-    def _handle(self, *args, **options):
+    def handle(self, *args, **options):
         self.init_logging()
         handle_env_validation('build')
 
@@ -169,24 +165,6 @@ class Command(BaseCommand):
         # Save the report to the configured destination
         report_saver_engine.save(report_spreadsheet)
         self.logger.info(f'Report generated into {ship_target}: {report_saver_engine.report_spreadsheet_destination_path}')
-
-    def handle(self, *args, **options):
-        try:
-            self._handle(*args, **options)
-        except (
-            BadShipTarget,
-            MissingRequiredEnvVar,
-            BadRequiredEnvVar,
-            MissingRequiredParameter,
-            UnparsableParameter,
-            BadParameter,
-            DateFormatError,
-        ) as e:
-            self.logger.error(str(e))
-            exit(1)
-        except Exception as e:
-            self.logger.exception(e)
-            exit(1)
 
     def _handle_ship_target(self, ship_target):
         if ship_target in ['controller_db', 'directory']:

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -8,12 +8,8 @@ from django.utils import timezone
 
 from metrics_utility.automation_controller_billing.collector import Collector
 from metrics_utility.exceptions import (
-    BadRequiredEnvVar,
     BadShipTarget,
-    FailedToUploadPayload,
-    MissingRequiredEnvVar,
     NoAnalyticsCollected,
-    UnparsableParameter,
 )
 from metrics_utility.management.validation import (
     handle_crc_ship_target,
@@ -70,17 +66,6 @@ class Command(BaseCommand):
         self.logger.propagate = False
 
     def handle(self, *args, **options):
-        try:
-            self._handle(self, *args, **options)
-            exit(0)
-        except (BadShipTarget, MissingRequiredEnvVar, BadRequiredEnvVar, FailedToUploadPayload, UnparsableParameter) as e:
-            self.logger.error(e.name)
-            exit(1)
-        except Exception as e:
-            self.logger.exception(e)
-            exit(1)
-
-    def _handle(self, *args, **options):
         self.init_logging()
         handle_env_validation('gather')
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -1,9 +1,15 @@
+import logging
 import os
 import sys
 
 from importlib import import_module
 
 import django.core.management as management
+
+from metrics_utility.exceptions import MetricsException
+
+
+logger = logging.getLogger(__name__)
 
 
 class ManagementUtility(management.ManagementUtility):
@@ -52,9 +58,7 @@ class ManagementUtility(management.ManagementUtility):
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:
-            # from metrics_utility.management.commands.host_metric import Command
-            # Command().run_from_argv(self.argv)
-            self.fetch_command(subcommand).run_from_argv(self.argv)
+            self.run_subcommand(subcommand, self.argv)
 
     def fetch_command(self, subcommand):
         module = import_module(f'metrics_utility.management.commands.{subcommand}')
@@ -66,3 +70,13 @@ class ManagementUtility(management.ManagementUtility):
         path = os.path.join(os.path.dirname(__file__), 'management')
         commands.update({name: 'metrics_utility' for name in management.find_commands(path)})
         return commands
+
+    def run_subcommand(self, subcommand, argv):
+        try:
+            self.fetch_command(subcommand).run_from_argv(argv)
+        except MetricsException as e:
+            logger.error(e.name)
+            exit(1)
+        except Exception as e:
+            logger.exception(e)
+            exit(1)

--- a/metrics_utility/test/management/commands/test_build_report_unit.py
+++ b/metrics_utility/test/management/commands/test_build_report_unit.py
@@ -7,6 +7,7 @@ from metrics_utility.exceptions import (
     BadRequiredEnvVar,
     BadShipTarget,
     DateFormatError,
+    MetricsException,
     MissingRequiredEnvVar,
     MissingRequiredParameter,
     UnparsableParameter,
@@ -91,23 +92,6 @@ def test_init_logging(command_instance):
     assert command_instance.logger.name == 'awx.main.analytics'
 
 
-def test_handle_success(monkeypatch, command_instance):
-    # Patch handle_env_validation and _handle to simulate success
-    monkeypatch.setattr(
-        'metrics_utility.management.commands.build_report.handle_env_validation',
-        lambda x: None,
-    )
-    monkeypatch.setattr(command_instance, '_handle', lambda *a, **k: None)
-    # Patch logger to capture logs
-    command_instance.logger = type(
-        'Logger',
-        (),
-        {'error': lambda self, msg: None, 'exception': lambda self, msg: None},
-    )()
-    # Should not raise
-    command_instance.handle()
-
-
 @pytest.mark.parametrize(
     'exc',
     [
@@ -126,26 +110,8 @@ def test_handle_known_exceptions(monkeypatch, command_instance, exc):
         lambda x: None,
     )
 
-    def raise_exc(*a, **k):
-        raise exc
-
-    monkeypatch.setattr(command_instance, '_handle', raise_exc)
-    # Patch logger to capture error
-    errors = []
-
-    class Logger:
-        def error(self, msg):
-            errors.append(msg)
-
-        def exception(self, msg):
-            # used in tests
-            pass
-
-    command_instance.logger = Logger()
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(MetricsException):
         command_instance.handle()
-    assert e.value.code == 1
-    assert errors
 
 
 def test_handle_unexpected_exception(monkeypatch, command_instance):
@@ -154,26 +120,8 @@ def test_handle_unexpected_exception(monkeypatch, command_instance):
         lambda x: None,
     )
 
-    def raise_exc(*a, **k):
-        raise RuntimeError('unexpected')
-
-    monkeypatch.setattr(command_instance, '_handle', raise_exc)
-    # Patch logger to capture exception
-    exceptions = []
-
-    class Logger:
-        def error(self, msg):
-            # Used in Tests
-            pass
-
-        def exception(self, msg):
-            exceptions.append(msg)
-
-    command_instance.logger = Logger()
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(MetricsException):
         command_instance.handle()
-    assert e.value.code == 1
-    assert exceptions
 
 
 def test_command_help(capsys):

--- a/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
+++ b/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
@@ -8,6 +8,7 @@ from metrics_utility.exceptions import (
     BadRequiredEnvVar,
     BadShipTarget,
     FailedToUploadPayload,
+    MetricsException,
     MissingRequiredEnvVar,
     UnparsableParameter,
 )
@@ -59,20 +60,6 @@ def test_command_help(capsys):
     assert e.value.code == 0
 
 
-def test_handle_success(monkeypatch, command_instance):
-    handle_env_validation = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation'
-    monkeypatch.setattr(handle_env_validation, lambda x: None)
-    monkeypatch.setattr(command_instance, '_handle', lambda *a, **k: None)
-    command_instance.logger = type(
-        'Logger',
-        (),
-        {'error': lambda self, msg: None, 'exception': lambda self, msg: None},
-    )()
-    with pytest.raises(SystemExit) as e:
-        command_instance.handle()
-    assert e.value.code == 0
-
-
 @pytest.mark.parametrize(
     'exc',
     [
@@ -87,50 +74,16 @@ def test_handle_known_exceptions(monkeypatch, command_instance, exc):
     handle_env_validation = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation'
     monkeypatch.setattr(handle_env_validation, lambda x: None)
 
-    def raise_exc(*a, **k):
-        raise exc
-
-    monkeypatch.setattr(command_instance, '_handle', raise_exc)
-    errors = []
-
-    class Logger:
-        def error(self, msg):
-            errors.append(msg)
-
-        def exception(self, msg):
-            # used in tests
-            pass
-
-    command_instance.logger = Logger()
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(MetricsException):
         command_instance.handle()
-    assert e.value.code == 1
-    assert errors
 
 
 def test_handle_unexpected_exception(monkeypatch, command_instance):
     handle_env_validation = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation'
     monkeypatch.setattr(handle_env_validation, lambda x: None)
 
-    def raise_exc(*a, **k):
-        raise RuntimeError('unexpected')
-
-    monkeypatch.setattr(command_instance, '_handle', raise_exc)
-    exceptions = []
-
-    class Logger:
-        def error(self, msg):
-            # Used in Tests
-            pass
-
-        def exception(self, msg):
-            exceptions.append(msg)
-
-    command_instance.logger = Logger()
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(MetricsException):
         command_instance.handle()
-    assert e.value.code == 1
-    assert exceptions
 
 
 def test_handle_datelike_days(command_instance):

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -64,15 +64,14 @@ def run_build_int(env, options):
     from metrics_utility.management.commands.build_report import Command
 
     with temporary_env(env):
-        Command()._handle(**options)
+        Command().handle(**options)
 
 
 def run_gather_int(env, options):
     from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
 
     with temporary_env(env):
-        # .handle does exit(0), breaking tests
-        Command()._handle(**options)
+        Command().handle(**options)
 
 
 def generate_renewal_guidance_dataframe(is_empty=False, current_datetime=None):


### PR DESCRIPTION
Follows #137 

Change metrics utility exceptions to inherit from `MetricsException`,
move the try/catch from both commands' `handle()` method to the caller - `ManagementUtility`.

Thus:
* `command.handle` returns an unhandled exception, that's either a bug, or inherits from `MetricsException`
* `management_utility` handles `MetricsException` by printing out a nice message, and `Exception` by printing out the whole stack trace; exit(1) in both cases
* tests no longer mock `_handle`, and don't see a `SystemExit` except for `--help`, getting a `MetricsException` instead