### PR TITLE
Cleanups around `extra_params`

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -13,7 +13,6 @@ from django.utils.timezone import now, timedelta
 from django.utils.translation import gettext_lazy as _
 
 from metrics_utility.base import CsvFileSplitter, register
-from metrics_utility.metric_utils import get_optional_collectors
 
 
 """
@@ -32,6 +31,10 @@ All functions - when called - will be passed a datetime.datetime object,
 functions - like those that return metadata about playbook runs, may return
 data _since_ the last report date - i.e., new data in the last 24 hours)
 """
+
+
+def get_optional_collectors():
+    return os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
 
 
 def daily_slicing(key, last_gather, **kwargs):

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -47,7 +47,8 @@ CSV_SHEETS = {
 class Base:
     LOG_PREFIX = '[ExtractorBase]'
 
-    def __init__(self, logger=logging.getLogger(__name__)):
+    def __init__(self, extra_params, logger=logging.getLogger(__name__)):
+        self.extra_params = extra_params
         self.logger = logger
 
     def load_config(self, file_path):
@@ -107,6 +108,16 @@ class Base:
     def csv_enabled(self, name):
         """Enable CSV extraction based on list of rendered sheets"""
         return self.sheet_enabled(CSV_SHEETS[name])
+
+    def get_path_prefix(self, date):
+        """Return the data/Y/m/d path"""
+        ship_path = self.extra_params['ship_path']
+
+        year = date.strftime('%Y')
+        month = date.strftime('%m')
+        day = date.strftime('%d')
+
+        return f'{ship_path}/data/{year}/{month}/{day}'
 
     def sheet_enabled(self, sheets_required):
         """

--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -10,9 +10,7 @@ class ExtractorControllerDB:
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
         super().__init__()
 
-        self.path = extra_params['ship_path']
         self.extra_params = extra_params
-
         self.logger = logger
 
     def iter_batches(self):

--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -15,16 +15,6 @@ class ExtractorControllerDB:
 
         self.logger = logger
 
-    def get_report_path(self, date):
-        path_prefix = f'{self.path}/reports'
-
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-
-        path = f'{path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self):
         with connection.cursor() as cursor:
             cursor.execute(self.pg_functions())

--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -9,21 +9,7 @@ class ExtractorDirectory(Base):
     LOG_PREFIX = '[ExtractorDirectory]'
 
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
-        super().__init__(logger=logger)
-
-        self.path = extra_params['ship_path']
-        self.extra_params = extra_params
-
-    def _get_path_prefix(self, date):
-        path_prefix = f'{self.path}/data'
-
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-        day = date.strftime('%d')
-
-        path = f'{path_prefix}/{year}/{month}/{day}'
-
-        return path
+        super().__init__(extra_params, logger)
 
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
@@ -48,7 +34,7 @@ class ExtractorDirectory(Base):
                     self.logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {path} failed with {e}')
 
     def fetch_partition_paths(self, date):
-        prefix = self._get_path_prefix(date)
+        prefix = self.get_path_prefix(date)
 
         try:
             paths = [os.path.join(prefix, f) for f in os.listdir(prefix) if os.path.isfile(os.path.join(prefix, f))]

--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -25,16 +25,6 @@ class ExtractorDirectory(Base):
 
         return path
 
-    def get_report_path(self, date):
-        path_prefix = f'{self.path}/reports'
-
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-
-        path = f'{path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
             batch_size = self.batch_size()

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -32,14 +32,6 @@ class ExtractorS3(Base):
 
         return path
 
-    def get_report_path(self, date):
-        report_path_prefix = f'{self.path}/reports'
-
-        year, month = self._create_date_string(date)
-        path = f'{report_path_prefix}/{year}/{month}'
-
-        return path
-
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
             batch_size = self.batch_size()

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -10,27 +10,9 @@ class ExtractorS3(Base):
     LOG_PREFIX = '[ExtractorS3]'
 
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
-        super().__init__(logger=logger)
-
-        self.path = extra_params['ship_path']
-        self.extra_params = extra_params
+        super().__init__(extra_params, logger)
 
         self.s3_handler = S3Handler(params=self.extra_params)
-
-    def _create_date_string(self, date):
-        year = date.strftime('%Y')
-        month = date.strftime('%m')
-        day = date.strftime('%d')
-
-        return {year, month, day}
-
-    def _get_path_prefix(self, date):
-        data_path_prefix = f'{self.path}/data'
-
-        year, month, day = self._create_date_string(date)
-        path = f'{data_path_prefix}/{year}/{month}/{day}'
-
-        return path
 
     def iter_batches(self, date, columns=None, batch_size=None):
         if batch_size is None:
@@ -54,7 +36,7 @@ class ExtractorS3(Base):
                     self.logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {s3_path} failed with {e}')
 
     def fetch_partition_paths(self, date):
-        prefix = self._get_path_prefix(date)
+        prefix = self.get_path_prefix(date)
 
         paths = [file for file in self.s3_handler.list_files(prefix)]
         return paths

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_directory.py
@@ -5,15 +5,12 @@ import os
 class ReportSaverDirectory:
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
         self.extra_params = extra_params
-
         self.logger = logger
 
         self.report_spreadsheet_destination_path = self.extra_params['report_spreadsheet_destination_path']
 
     def report_exist(self):
-        if os.path.exists(self.report_spreadsheet_destination_path):
-            return True
-        return False
+        return os.path.exists(self.report_spreadsheet_destination_path)
 
     def save(self, report_spreadsheet):
         # Create the dir structure for the final report

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
@@ -10,16 +10,14 @@ class ReportSaverS3:
 
     def __init__(self, extra_params, logger=logging.getLogger(__name__)):
         self.extra_params = extra_params
-        self.report_spreadsheet_destination_path = self.extra_params['report_spreadsheet_destination_path']
-
         self.logger = logger
+
+        self.report_spreadsheet_destination_path = self.extra_params['report_spreadsheet_destination_path']
 
         self.s3_handler = S3Handler(params=self.extra_params)
 
     def report_exist(self):
-        if len([file for file in self.s3_handler.list_files(self.report_spreadsheet_destination_path)]) > 0:
-            return True
-        return False
+        return len([file for file in self.s3_handler.list_files(self.report_spreadsheet_destination_path)]) > 0
 
     def save(self, report_spreadsheet):
         with tempfile.TemporaryDirectory(prefix='report_saver_billing_data_') as temp_dir:

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -14,11 +14,7 @@ from metrics_utility.automation_controller_billing.helpers import (
 )
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
-from metrics_utility.exceptions import (
-    BadRequiredEnvVar,
-    BadShipTarget,
-    MissingRequiredEnvVar,
-)
+from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
     handle_env_validation,
@@ -27,7 +23,6 @@ from metrics_utility.management.validation import (
     handle_s3_ship_target,
     validate_build_extra_params,
 )
-from metrics_utility.metric_utils import get_optional_collectors
 
 
 def get_report_path(ship_path, date):
@@ -217,7 +212,6 @@ class Command(BaseCommand):
                 'report_renewal_guidance_dedup_iterations': os.getenv('REPORT_RENEWAL_GUIDANCE_DEDUP_ITERATIONS', '3'),
                 'report_organization_filter': os.getenv('METRICS_UTILITY_ORGANIZATION_FILTER', None),
                 # optional bits
-                'optional_collectors': get_optional_collectors(),
                 'optional_sheets': os.getenv(
                     'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS',
                     'ccsp_summary,managed_nodes,usage_by_organizations,usage_by_collections,usage_by_roles,usage_by_modules',

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -30,6 +30,13 @@ from metrics_utility.management.validation import (
 from metrics_utility.metric_utils import get_optional_collectors
 
 
+def get_report_path(ship_path, date):
+    year = date.strftime('%Y')
+    month = date.strftime('%m')
+
+    return f'{ship_path}/reports/{year}/{month}'
+
+
 class Command(BaseCommand):
     """
     Build Report
@@ -124,13 +131,13 @@ class Command(BaseCommand):
 
             extra_params['report_period'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                extractor.get_report_path(extra_params['until_date']),
-                f'{extra_params["report_type"]}-{opt_since.date()}--{extra_params["until_date"]}.xlsx',
+                get_report_path(extra_params['ship_path'], extra_params['until_date']),
+                f'{extra_params["report_type"]}-{extra_params["since_date"]}--{extra_params["until_date"]}.xlsx',
             )
         else:
             extra_params['report_period'] = opt_month
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                extractor.get_report_path(month),
+                get_report_path(extra_params['ship_path'], month),
                 f'{extra_params["report_type"]}-{opt_month}.xlsx',
             )
 

--- a/metrics_utility/metric_utils.py
+++ b/metrics_utility/metric_utils.py
@@ -1,10 +1,3 @@
-import os
-
-
-def get_optional_collectors():
-    return os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
-
-
 DIRECT = 0
 INDIRECT = 1
 # later also EDGE = 2


### PR DESCRIPTION
More cleanups around `extra_params`, follows #149, pulls out more fixups from #136

`get_report_path`: only used in `build_report`, move there, replaces 3 copies of the same with 1
`get_path_prefix`: move to extractor base class (and pass extra_params), replaces 2 copies with 1, removes dead artifact in controller db
`ReportSaver`s: cosmetic, replaces `True if condition else False` with `condition`
`get_optional_collectors`: only used in `collectors`, move there, removes dead artifact in build report