### PR TITLE
Test fixups

### DIFF
--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
@@ -37,9 +37,7 @@ def test_command(cleanup):
         {
             'since': '2024-02-20',
             'until': '2025-03-02',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_indirect.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_indirect.py
@@ -35,9 +35,7 @@ def test_command(cleanup):
         {
             'since': '2025-02-25',
             'until': '2025-02-26',
-            'ephemeral': None,
             'force': True,
-            'verbose': True,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_scope.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_with_scope.py
@@ -35,9 +35,7 @@ def test_command(cleanup):
         {
             'since': '2025-03-01',
             'until': '2025-03-02',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2.py
@@ -49,9 +49,7 @@ def test_command(cleanup):
         {
             'since': '2025-02-13',
             'until': '2025-02-13',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
@@ -37,9 +37,7 @@ def test_command(cleanup):
         {
             'since': '2024-02-20',
             'until': '2025-03-02',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_indirect.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_indirect.py
@@ -35,9 +35,7 @@ def test_command(cleanup):
         {
             'since': '2025-02-25',
             'until': '2025-02-26',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_nodes_by_orgs.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_nodes_by_orgs.py
@@ -34,9 +34,7 @@ def test_command(cleanup):
         {
             'since': '2025-03-01',
             'until': '2025-03-02',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_scope.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_with_scope.py
@@ -36,9 +36,7 @@ def test_command(cleanup):
         {
             'since': '2025-03-01',
             'until': '2025-03-02',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         },
     )
 

--- a/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
+++ b/metrics_utility/test/ccspv_reports/test_consistent_indirectly_managed_nodes_output.py
@@ -48,9 +48,7 @@ def test_command(cleanup):
         options = {
             'since': '2025-02-25',
             'until': '2025-02-26',
-            'ephemeral': None,
             'force': True,
-            'verbose': False,
         }
 
         run_build_int(

--- a/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
+++ b/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
@@ -80,7 +80,7 @@ def setup_report_renewal_guidance_instance(fixed_now, setup_build_spreadsheet_mo
 
         test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days} days',
+            'opt_ephemeral': f'{test_ephemeral_days}days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',

--- a/metrics_utility/test/renewal_guidance/test_get_intervals.py
+++ b/metrics_utility/test/renewal_guidance/test_get_intervals.py
@@ -29,7 +29,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -92,7 +92,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-04-28,2025-05-12',
             'since_date': '2025-04-28',
@@ -228,7 +228,7 @@ class TestGetIntervals:
         )
 
         extra_params = {
-            'opt_ephemeral': '7 days',
+            'opt_ephemeral': '7days',
             'price_per_node': 0.1,
             'report_period': '2025-04-10,2025-05-12',
             'since_date': '2025-04-10',

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -26,7 +26,7 @@ def setup_report_renewal_guidance_instance(fixed_now):
 
         test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days} days',
+            'opt_ephemeral': f'{test_ephemeral_days}days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',
@@ -101,7 +101,7 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
 
         test_ephemeral_days = 30
         test_extra_params = {
-            'opt_ephemeral': f'{test_ephemeral_days} days',
+            'opt_ephemeral': f'{test_ephemeral_days}days',
             'price_per_node': 0.1,
             'report_period': '2025-01-01,2025-06-03',
             'since_date': '2025-01-01',

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -25,7 +25,7 @@ def expect_build_error(env, klass, mocked):
         run_build_int(
             {**unset, **env},
             {
-                'month': '2022-01',
+                'since': '2022-01-01',
             },
         )
     return e.value
@@ -69,6 +69,7 @@ def test_gather_bad_target():
 def test_build_controller_db():
     e = expect_build_error(
         {
+            'METRICS_UTILITY_REPORT_TYPE': 'RENEWAL_GUIDANCE',
             'METRICS_UTILITY_SHIP_TARGET': 'controller_db',
         },
         MissingRequiredEnvVar,
@@ -104,6 +105,7 @@ def test_gather_crc(caplog):
 def test_build_directory(caplog):
     e = expect_build_error(
         {
+            'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
             'METRICS_UTILITY_SHIP_TARGET': 'directory',
         },
         MissingRequiredEnvVar,
@@ -148,6 +150,7 @@ def test_gather_directory():
 def test_build_s3():
     e = expect_build_error(
         {
+            'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
             'METRICS_UTILITY_SHIP_TARGET': 's3',
         },
         MissingRequiredEnvVar,


### PR DESCRIPTION
Pulling out changes from #136 - test fixups related to param validation

* don't pass `ephemeral` in ccsp tests, not applicable (where not testing for failure when provided)
* don't pass `verbose: False`, is the default
* pass valid values in `ephemeral` - no spaces allowed (yet)
* add report type to build validator tests (where not testing for failure when missing), change shared `month` to `since` to avoid renewal breaking