### PR TITLE
Move parsers/validators to validation.py

### DIFF
--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -1,20 +1,8 @@
-import datetime
 import json
 
-from datetime import timezone
 from itertools import chain
 
 import pandas as pd
-
-from dateutil import parser
-from dateutil.relativedelta import relativedelta
-
-from metrics_utility.exceptions import DateFormatError, UnparsableParameter
-
-
-ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
-SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
-SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
 
 
 def parse_json_array(x):
@@ -67,85 +55,3 @@ def merge_arrays(values):
     # Flatten the list of lists and extract unique events
     unique = set(chain.from_iterable(valid_events))
     return list(unique)
-
-
-# patchable in tests
-def now():
-    return datetime.datetime.now()
-
-
-def parse_date_param(date_option):
-    if not date_option:
-        return None
-
-    parsed_date = None
-    if date_option.endswith('d'):
-        days_ago = int(date_option[0:-1])
-        parsed_date = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
-        months_ago = int(date_option[0:-suffix_length])
-        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('m'):
-        minutes_ago = int(date_option[0:-1])
-        parsed_date = now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        parsed_date = parser.parse(date_option)
-
-    # Set timezone to UTC when missing
-    if parsed_date and parsed_date.tzinfo is None:
-        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
-
-    return parsed_date
-
-
-def parse_number_of_days(date_option):
-    if not date_option:
-        return None
-
-    if date_option.endswith('d') or date_option.endswith('day') or date_option.endswith('days'):
-        if date_option.endswith('d'):
-            suffix_length = len('d')
-        elif date_option.endswith('day'):
-            suffix_length = len('day')
-        elif date_option.endswith('days'):
-            suffix_length = len('days')
-
-        days = int(date_option[0:-suffix_length])
-    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
-
-        days = int(date_option[0:-suffix_length]) * 30  # using 30 days per month
-    else:
-        raise UnparsableParameter(f"Can't parse parameter value {date_option}")
-
-    return days
-
-
-def handle_month(month):
-    """Process month argument"""
-    if month is not None:
-        try:
-            date = datetime.datetime.strptime(f'{month}', '%Y-%m')
-        except ValueError:
-            raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
-    else:
-        """Return last month if no month was passed"""
-        beginning_of_the_month = datetime.datetime.today().replace(day=1)
-        beginning_of_the_previous_month = beginning_of_the_month - relativedelta(months=1)
-        date = beginning_of_the_previous_month
-        y = date.strftime('%Y')
-        m = date.strftime('%m')
-        month = f'{y}-{m}'
-
-    return month, date, date + relativedelta(months=1)

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -59,30 +59,17 @@ class Command(BaseCommand):
             'Months are considered as 30 days in duration. '
             'Example: --ephemeral=3months, or --ephemeral=3days'
         ),
+        'force': ('With this option, the existing reports will be overwritten if running this command again.'),
+        'verbose': ('Starts to print debug information to terminal.'),
     }
 
     def add_arguments(self, parser):
         parser.add_argument('--month', dest='month', action='store', help=self.help_texts.get('month'))
         parser.add_argument('--since', dest='since', action='store', help=self.help_texts.get('since'))
-        parser.add_argument(
-            '--until',
-            dest='until',
-            action='store',
-            help=self.help_texts.get('until'),
-        )
-        parser.add_argument(
-            '--ephemeral',
-            dest='ephemeral',
-            action='store',
-            help=self.help_texts.get('ephemeral'),
-        )
-        parser.add_argument(
-            '--force',
-            dest='force',
-            action='store_true',
-            help='With this option, the existing reports will be overwritten if running this command again.',
-        )
-        parser.add_argument('--verbose', dest='verbose', action='store_true', help='Starts to print debug information to terminal.')
+        parser.add_argument('--until', dest='until', action='store', help=self.help_texts.get('until'))
+        parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=self.help_texts.get('ephemeral'))
+        parser.add_argument('--force', dest='force', action='store_true', help=self.help_texts.get('force'))
+        parser.add_argument('--verbose', dest='verbose', action='store_true', help=self.help_texts.get('verbose'))
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -39,33 +39,29 @@ class Command(BaseCommand):
     """
 
     help = 'Build Report'
-
-    def __init__(self):
-        super().__init__()
-
-        self.help_texts = {
-            'since': (
-                'Start date for collection (e.g. --since=2023-12-20), '
-                'a number of minutes ago (--since=2m), '
-                'a number of days ago (--since=5d), or '
-                'a number of months ago (--since=2mo | 2 month | 2 months).'
-            ),
-            'until': (
-                'End date for collection (e.g. --until=2023-12-21), '
-                'a number of minutes ago (--until=2m), '
-                'a number of days ago (--until=5d), or '
-                'a number of months ago (--since=2mo | 2 month | 2 months).'
-            ),
-            'month': (
-                'Month the report will be generated for, with format YYYY-MM. '
-                "If this parameter is not provided, the previous month's report will be generated if it does not already exist."
-            ),
-            'ephemeral': (
-                'Duration in months or days to determine if host is ephemeral. '
-                'Months are considered as 30 days in duration. '
-                'Example: --ephemeral=3months, or --ephemeral=3days'
-            ),
-        }
+    help_texts = {
+        'since': (
+            'Start date for collection (e.g. --since=2023-12-20), '
+            'a number of minutes ago (--since=2m), '
+            'a number of days ago (--since=5d), or '
+            'a number of months ago (--since=2mo | 2 month | 2 months).'
+        ),
+        'until': (
+            'End date for collection (e.g. --until=2023-12-21), '
+            'a number of minutes ago (--until=2m), '
+            'a number of days ago (--until=5d), or '
+            'a number of months ago (--since=2mo | 2 month | 2 months).'
+        ),
+        'month': (
+            'Month the report will be generated for, with format YYYY-MM. '
+            "If this parameter is not provided, the previous month's report will be generated if it does not already exist."
+        ),
+        'ephemeral': (
+            'Duration in months or days to determine if host is ephemeral. '
+            'Months are considered as 30 days in duration. '
+            'Example: --ephemeral=3months, or --ephemeral=3days'
+        ),
+    }
 
     def add_arguments(self, parser):
         parser.add_argument('--month', dest='month', action='store', help=self.help_texts.get('month'))

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -8,20 +8,18 @@ from django.core.management.base import BaseCommand
 
 from metrics_utility.automation_controller_billing.dataframe_engine.factory import Factory as DataframeEngineFactory
 from metrics_utility.automation_controller_billing.extract.factory import Factory as ExtractorFactory
-from metrics_utility.automation_controller_billing.helpers import (
-    handle_month,
-    parse_date_param,
-    parse_number_of_days,
-)
 from metrics_utility.automation_controller_billing.report.factory import Factory as ReportFactory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
     handle_env_validation,
+    handle_month,
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
+    parse_date_param,
+    parse_number_of_days,
     validate_build_extra_params,
 )
 

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -33,24 +33,15 @@ class Command(BaseCommand):
         'until': (
             'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
         ),
+        'dry-run': ('Gather billing metrics without shipping.'),
+        'ship': ('Enable shipping of billing metrics to the console.redhat.com'),
     }
 
     def add_arguments(self, parser):
-        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help='Gather billing metrics without shipping.')
-        parser.add_argument('--ship', dest='ship', action='store_true', help='Enable shipping of billing metrics to the console.redhat.com')
-
-        parser.add_argument(
-            '--since',
-            dest='since',
-            action='store',
-            help=self.help_texts.get('since'),
-        )
-        parser.add_argument(
-            '--until',
-            dest='until',
-            action='store',
-            help=self.help_texts.get('until'),
-        )
+        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=self.help_texts.get('dry-run'))
+        parser.add_argument('--ship', dest='ship', action='store_true', help=self.help_texts.get('ship'))
+        parser.add_argument('--since', dest='since', action='store', help=self.help_texts.get('since'))
+        parser.add_argument('--until', dest='until', action='store', help=self.help_texts.get('until'))
 
     def init_logging(self):
         self.logger = logging.getLogger('awx.main.analytics')

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -72,8 +72,8 @@ class Command(BaseCommand):
         handle_validate_date_param(opt_since, self.help_texts.get('since'), 'gather')
         handle_validate_date_param(opt_until, self.help_texts.get('until'), 'gather')
 
-        since = handle_datelike(opt_since, self.help_texts.get('since'))
-        until = handle_datelike(opt_until, self.help_texts.get('until'))
+        since = handle_datelike(opt_since)
+        until = handle_datelike(opt_until)
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -27,18 +27,15 @@ class Command(BaseCommand):
     Gather Automation Controller billing data
     """
 
-    def __init__(self):
-        super().__init__()
-        self.help = 'Gather Automation Controller billing data.'
-        self.help_texts = {
-            'since': (
-                'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), '
-                'or a number of months (--since=2m).'
-            ),
-            'until': (
-                'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
-            ),
-        }
+    help = 'Gather Automation Controller billing data'
+    help_texts = {
+        'since': (
+            'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
+        ),
+        'until': (
+            'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
+        ),
+    }
 
     def add_arguments(self, parser):
         parser.add_argument('--dry-run', dest='dry-run', action='store_true', help='Gather billing metrics without shipping.')

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -1,10 +1,7 @@
-import datetime
 import logging
 import os
 
-from dateutil import parser
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
 from metrics_utility.automation_controller_billing.collector import Collector
 from metrics_utility.exceptions import (
@@ -13,6 +10,7 @@ from metrics_utility.exceptions import (
 )
 from metrics_utility.management.validation import (
     handle_crc_ship_target,
+    handle_datelike,
     handle_directory_ship_target,
     handle_env_validation,
     handle_not_crc,
@@ -66,15 +64,16 @@ class Command(BaseCommand):
         self.init_logging()
         handle_env_validation('gather')
 
-        handle_validate_date_param(options.get('since', None), self.help_texts.get('since'), 'gather')
-        handle_validate_date_param(options.get('until', None), self.help_texts.get('until'), 'gather')
-
+        opt_since = options.get('since')
+        opt_until = options.get('until')
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
-        opt_since = options.get('since') or None
-        opt_until = options.get('until') or None
 
-        since, until = self._handle_interval(opt_since, opt_until)
+        handle_validate_date_param(opt_since, self.help_texts.get('since'), 'gather')
+        handle_validate_date_param(opt_until, self.help_texts.get('until'), 'gather')
+
+        since = handle_datelike(opt_since, self.help_texts.get('since'))
+        until = handle_datelike(opt_until, self.help_texts.get('until'))
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)
@@ -111,30 +110,3 @@ class Command(BaseCommand):
         else:
             allowed = ', '.join(['crc', 'directory', 's3'])
             raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')
-
-    def _handle_datelike(self, value, help=''):
-        if not value:
-            return None
-        # # Process ret argument
-        if value.endswith('d'):
-            days_ago = int(value[0:-1])
-            ret = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-        elif value.endswith('m'):
-            minutes_ago = int(value[0:-1])
-            ret = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
-        else:
-            ret = parser.parse(value)
-
-        # Add default utc timezone
-        if ret and ret.tzinfo is None:
-            ret = ret.replace(tzinfo=timezone.utc)
-
-        return ret
-
-    def _handle_interval(self, opt_since, opt_until):
-        # Process since argument
-        since = self._handle_datelike(opt_since, help=self.help_texts.get('since'))
-
-        # Process until argument
-        until = self._handle_datelike(opt_until, help=self.help_texts.get('until'))
-        return since, until

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -511,3 +511,24 @@ def handle_month(month):
         month = f'{y}-{m}'
 
     return month, date, date + relativedelta(months=1)
+
+
+def handle_datelike(value, help=''):
+    if not value:
+        return None
+
+    # Process ret argument
+    if value.endswith('d'):
+        days_ago = int(value[0:-1])
+        ret = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif value.endswith('m'):
+        minutes_ago = int(value[0:-1])
+        ret = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
+    else:
+        ret = parser.parse(value)
+
+    # Add default utc timezone
+    if ret and ret.tzinfo is None:
+        ret = ret.replace(tzinfo=datetime.timezone.utc)
+
+    return ret

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,17 +1,17 @@
+import datetime
 import logging
 import os
 import re
 
 from dateutil import parser
+from dateutil.relativedelta import relativedelta
 
-from metrics_utility.automation_controller_billing.helpers import (
-    ALLOWED_EPHEMERAL_PATTERN,
-    SINCE_AND_UNTIL_BUILD_PATTERN,
-    SINCE_AND_UNTIL_GATHER_PATTERN,
-    parse_date_param,
-)
-from metrics_utility.exceptions import BadParameter, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
+from metrics_utility.exceptions import BadParameter, DateFormatError, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
 
+
+ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
+SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
+SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
 
 # Constants for valid values
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}
@@ -429,3 +429,85 @@ def validate_build_extra_params(help_text, options):
 
     if (has_since and has_until) and until < since:
         raise UnparsableParameter('The date for --until cannot be before the date for --since.')
+
+
+# patchable in tests
+def now():
+    return datetime.datetime.now()
+
+
+def parse_date_param(date_option):
+    if not date_option:
+        return None
+
+    parsed_date = None
+    if date_option.endswith('d'):
+        days_ago = int(date_option[0:-1])
+        parsed_date = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
+        if date_option.endswith('mo'):
+            suffix_length = len('mo')
+        elif date_option.endswith('month'):
+            suffix_length = len('month')
+        elif date_option.endswith('months'):
+            suffix_length = len('months')
+        months_ago = int(date_option[0:-suffix_length])
+        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif date_option.endswith('m'):
+        minutes_ago = int(date_option[0:-1])
+        parsed_date = now() - datetime.timedelta(minutes=minutes_ago)
+    else:
+        parsed_date = parser.parse(date_option)
+
+    # Set timezone to UTC when missing
+    if parsed_date and parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
+
+    return parsed_date
+
+
+def parse_number_of_days(date_option):
+    if not date_option:
+        return None
+
+    if date_option.endswith('d') or date_option.endswith('day') or date_option.endswith('days'):
+        if date_option.endswith('d'):
+            suffix_length = len('d')
+        elif date_option.endswith('day'):
+            suffix_length = len('day')
+        elif date_option.endswith('days'):
+            suffix_length = len('days')
+
+        days = int(date_option[0:-suffix_length])
+    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
+        if date_option.endswith('mo'):
+            suffix_length = len('mo')
+        elif date_option.endswith('month'):
+            suffix_length = len('month')
+        elif date_option.endswith('months'):
+            suffix_length = len('months')
+
+        days = int(date_option[0:-suffix_length]) * 30  # using 30 days per month
+    else:
+        raise UnparsableParameter(f"Can't parse parameter value {date_option}")
+
+    return days
+
+
+def handle_month(month):
+    """Process month argument"""
+    if month is not None:
+        try:
+            date = datetime.datetime.strptime(f'{month}', '%Y-%m')
+        except ValueError:
+            raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
+    else:
+        """Return last month if no month was passed"""
+        beginning_of_the_month = datetime.datetime.today().replace(day=1)
+        beginning_of_the_previous_month = beginning_of_the_month - relativedelta(months=1)
+        date = beginning_of_the_previous_month
+        y = date.strftime('%Y')
+        m = date.strftime('%m')
+        month = f'{y}-{m}'
+
+    return month, date, date + relativedelta(months=1)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -520,10 +520,10 @@ def handle_datelike(value, help=''):
     # Process ret argument
     if value.endswith('d'):
         days_ago = int(value[0:-1])
-        ret = (datetime.datetime.now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        ret = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
     elif value.endswith('m'):
         minutes_ago = int(value[0:-1])
-        ret = datetime.datetime.now() - datetime.timedelta(minutes=minutes_ago)
+        ret = now() - datetime.timedelta(minutes=minutes_ago)
     else:
         ret = parser.parse(value)
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -513,7 +513,7 @@ def handle_month(month):
     return month, date, date + relativedelta(months=1)
 
 
-def handle_datelike(value, help=''):
+def handle_datelike(value):
     if not value:
         return None
 

--- a/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
+++ b/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
@@ -12,9 +12,8 @@ from metrics_utility.exceptions import (
     MissingRequiredEnvVar,
     UnparsableParameter,
 )
-from metrics_utility.management.commands.gather_automation_controller_billing_data import (
-    Command,
-)
+from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
+from metrics_utility.management.validation import handle_datelike
 
 
 @pytest.fixture
@@ -86,35 +85,27 @@ def test_handle_unexpected_exception(monkeypatch, command_instance):
         command_instance.handle()
 
 
-def test_handle_datelike_days(command_instance):
+def test_handle_datelike_days():
     days = 2
     val = f'{days}d'
-    dt = command_instance._handle_datelike(val)
+    dt = handle_datelike(val)
     assert isinstance(dt, datetime.datetime)
     assert dt.tzinfo is not None
 
 
-def test_handle_datelike_minutes(command_instance):
+def test_handle_datelike_minutes():
     mins = 5
     val = f'{mins}m'
-    dt = command_instance._handle_datelike(val)
+    dt = handle_datelike(val)
     assert isinstance(dt, datetime.datetime)
     assert dt.tzinfo is not None
 
 
-def test_handle_datelike_iso(command_instance):
+def test_handle_datelike_iso():
     val = '2024-01-01T00:00:00Z'
-    dt = command_instance._handle_datelike(val)
+    dt = handle_datelike(val)
     assert isinstance(dt, datetime.datetime)
     assert dt.tzinfo is not None
-
-
-def test_handle_interval(command_instance):
-    since = '2024-01-01T00:00:00Z'
-    until = '2024-01-02T00:00:00Z'
-    s, u = command_instance._handle_interval(since, until)
-    assert isinstance(s, datetime.datetime)
-    assert isinstance(u, datetime.datetime)
 
 
 def test_handle_ship_target_crc(monkeypatch, command_instance):

--- a/metrics_utility/test/validation/test_parse_helpers.py
+++ b/metrics_utility/test/validation/test_parse_helpers.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 
 import pytest
 
-from metrics_utility.automation_controller_billing.helpers import (
+from metrics_utility.exceptions import MetricsException
+from metrics_utility.management.validation import (
     parse_date_param,
     parse_number_of_days,
 )
-from metrics_utility.exceptions import MetricsException
 
 
 def test_parse_date_param():
@@ -19,7 +19,7 @@ def test_parse_date_param():
     assert parse_date_param('2024-01-01') == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
     # patch now() to be 2024-02-29 13:59:00 (w/o tz)
-    with patch('metrics_utility.automation_controller_billing.helpers.now') as mock:
+    with patch('metrics_utility.management.validation.now') as mock:
         mock.return_value = datetime.datetime(2024, 2, 29, 13, 59, 0)
 
         assert parse_date_param('1d') == datetime.datetime(2024, 2, 29, 0, 0, tzinfo=datetime.timezone.utc)

--- a/metrics_utility/test/validation/test_parse_helpers.py
+++ b/metrics_utility/test/validation/test_parse_helpers.py
@@ -6,6 +6,7 @@ import pytest
 
 from metrics_utility.exceptions import MetricsException
 from metrics_utility.management.validation import (
+    handle_datelike,
     parse_date_param,
     parse_number_of_days,
 )
@@ -29,6 +30,24 @@ def test_parse_date_param():
     # ensure timezone
     assert parse_date_param('3m').tzinfo == datetime.timezone.utc
     assert parse_date_param('2024-01-01').tzinfo == datetime.timezone.utc
+
+
+def test_handle_datelike():
+    assert handle_datelike(None) is None
+    assert handle_datelike('1d') is not None
+    assert handle_datelike('3m') is not None
+    assert handle_datelike('2024-01-01') == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+
+    # patch now() to be 2024-02-29 13:59:00 (w/o tz)
+    with patch('metrics_utility.management.validation.now') as mock:
+        mock.return_value = datetime.datetime(2024, 2, 29, 13, 59, 0)
+
+        assert handle_datelike('1d') == datetime.datetime(2024, 2, 29, 0, 0, tzinfo=datetime.timezone.utc)
+        assert handle_datelike('3m') == datetime.datetime(2024, 2, 29, 13, 56, tzinfo=datetime.timezone.utc)
+
+    # ensure timezone
+    assert handle_datelike('3m').tzinfo == datetime.timezone.utc
+    assert handle_datelike('2024-01-01').tzinfo == datetime.timezone.utc
 
 
 def test_parse_number_of_days():


### PR DESCRIPTION
Follows #155

Cosmetic changes only (once rebased after 155), and tests.

Move `parse_number_of_days`, `parse_date_param`, `handle_month` and `_handle_datelike` to `validation.py` where the other validation/parsing functions already are.
(No other changes other than import names.)

Unify the 2 commands to set `.help` and `.help_texts` the same way - and we don't need a constructor for that.

(The next step will be to merge `parse_date_param` (build_report), `handle_datelike` (gather), and maybe `handle_validate_date_param` (validation), so this is just preparing ground for *that*.)