### PR TITLE
Merge date parsers

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -12,6 +12,7 @@ from metrics_utility.automation_controller_billing.report.factory import Factory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
 from metrics_utility.management.validation import (
+    date_format_text,
     handle_directory_ship_target,
     handle_env_validation,
     handle_month,
@@ -37,18 +38,8 @@ class Command(BaseCommand):
 
     help = 'Build Report'
     help_texts = {
-        'since': (
-            'Start date for collection (e.g. --since=2023-12-20), '
-            'a number of minutes ago (--since=2m), '
-            'a number of days ago (--since=5d), or '
-            'a number of months ago (--since=2mo | 2 month | 2 months).'
-        ),
-        'until': (
-            'End date for collection (e.g. --until=2023-12-21), '
-            'a number of minutes ago (--until=2m), '
-            'a number of days ago (--until=5d), or '
-            'a number of months ago (--since=2mo | 2 month | 2 months).'
-        ),
+        'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
+        'until': (f'End date for collection, including. {date_format_text.format(name="until")}'),
         'month': (
             'Month the report will be generated for, with format YYYY-MM. '
             "If this parameter is not provided, the previous month's report will be generated if it does not already exist."

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -20,7 +20,7 @@ from metrics_utility.management.validation import (
     handle_not_s3,
     handle_s3_ship_target,
     parse_number_of_days,
-    validate_build_extra_params,
+    validate_build_params,
 )
 
 
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         self.init_logging()
         handle_env_validation('build')
 
-        opt_since, opt_until = validate_build_extra_params(self.help_texts, options)
+        opt_since, opt_until = validate_build_params(options, self.help_texts)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
         opt_ephemeral = parse_number_of_days(options.get('ephemeral'))

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -18,7 +18,6 @@ from metrics_utility.management.validation import (
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
-    parse_date_param,
     parse_number_of_days,
     validate_build_extra_params,
 )
@@ -83,11 +82,9 @@ class Command(BaseCommand):
         self.init_logging()
         handle_env_validation('build')
 
-        validate_build_extra_params(self.help_texts, options)
+        opt_since, opt_until = validate_build_extra_params(self.help_texts, options)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
-        opt_since = parse_date_param(options.get('since'))
-        opt_until = parse_date_param(options.get('until'))
         opt_ephemeral = parse_number_of_days(options.get('ephemeral'))
         opt_force = options.get('force')
 

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
     help_texts = {
         'since': (
-            # FIXME - not months 2m
+            # FIXME - not months 2m .. minutes supported .. but add months
             'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
         ),
         'until': (

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -10,7 +10,6 @@ from metrics_utility.exceptions import (
 )
 from metrics_utility.management.validation import (
     handle_crc_ship_target,
-    handle_datelike,
     handle_directory_ship_target,
     handle_env_validation,
     handle_not_crc,
@@ -28,6 +27,7 @@ class Command(BaseCommand):
     help = 'Gather Automation Controller billing data'
     help_texts = {
         'since': (
+            # FIXME - not months 2m
             'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
         ),
         'until': (
@@ -60,11 +60,8 @@ class Command(BaseCommand):
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
 
-        handle_validate_date_param(opt_since, self.help_texts.get('since'), 'gather')
-        handle_validate_date_param(opt_until, self.help_texts.get('until'), 'gather')
-
-        since = handle_datelike(opt_since)
-        until = handle_datelike(opt_until)
+        since = handle_validate_date_param(opt_since, self.help_texts.get('since'), 'gather')
+        until = handle_validate_date_param(opt_until, self.help_texts.get('until'), 'gather')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -16,7 +16,7 @@ from metrics_utility.management.validation import (
     handle_not_crc,
     handle_not_s3,
     handle_s3_ship_target,
-    handle_validate_date_param,
+    parse_date_param,
 )
 
 
@@ -56,8 +56,8 @@ class Command(BaseCommand):
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
 
-        since = handle_validate_date_param(opt_since, self.help_texts, 'since')
-        until = handle_validate_date_param(opt_until, self.help_texts, 'until')
+        since = parse_date_param(opt_since, self.help_texts, 'since')
+        until = parse_date_param(opt_until, self.help_texts, 'until')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -9,6 +9,7 @@ from metrics_utility.exceptions import (
     NoAnalyticsCollected,
 )
 from metrics_utility.management.validation import (
+    date_format_text,
     handle_crc_ship_target,
     handle_directory_ship_target,
     handle_env_validation,
@@ -26,13 +27,8 @@ class Command(BaseCommand):
 
     help = 'Gather Automation Controller billing data'
     help_texts = {
-        'since': (
-            # FIXME - not months 2m .. minutes supported .. but add months
-            'Start date for collection including (e.g. --since=2023-12-20), a number of days ago (--since=5d), or a number of months (--since=2m).'
-        ),
-        'until': (
-            'End date for collection including (e.g. --until=2023-12-21), a number of days ago (--until=5d), or a number of months (--until=2m).'
-        ),
+        'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
+        'until': (f'End date for collection, including. {date_format_text.format(name="until")}'),
         'dry-run': ('Gather billing metrics without shipping.'),
         'ship': ('Enable shipping of billing metrics to the console.redhat.com'),
     }

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -56,8 +56,8 @@ class Command(BaseCommand):
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
 
-        since = handle_validate_date_param(opt_since, self.help_texts.get('since'), 'gather')
-        until = handle_validate_date_param(opt_until, self.help_texts.get('until'), 'gather')
+        since = handle_validate_date_param(opt_since, self.help_texts, 'since')
+        until = handle_validate_date_param(opt_until, self.help_texts, 'until')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
         billing_provider_params = self._handle_ship_target(ship_target)

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -396,52 +396,70 @@ def parse_date_param(value, help_texts={None: ''}, name=None):
     return parsed
 
 
-def validate_build_extra_params(help_texts, options):
+def validate_ccsp_params(options):
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
-    if not report_type:
-        return None, None
-
     opt_month = options.get('month', None)
     opt_since = options.get('since', None)
     opt_until = options.get('until', None)
     opt_ephemeral = options.get('ephemeral', None)
 
-    if report_type in {'CCSP', 'CCSPv2'}:
-        # bad type
-        if opt_ephemeral:
-            raise BadParameter(f'METRICS_UTILITY_REPORT_TYPE {report_type} does not allow --ephemeral.')
+    # bad type
+    if opt_ephemeral:
+        raise BadParameter(f'METRICS_UTILITY_REPORT_TYPE {report_type} does not allow --ephemeral.')
 
-        # bad combos
-        if opt_month and (opt_since or opt_until):
-            raise BadParameter('The --since and --until parameters are not allowed if the --month parameter is provided.')
-        if opt_until and not opt_since:
-            raise BadParameter('The --until parameter is ignored without --since.')
+    # bad combos
+    if opt_month and (opt_since or opt_until):
+        raise BadParameter('The --since and --until parameters are not allowed if the --month parameter is provided.')
+    if opt_until and not opt_since:
+        raise BadParameter('The --until parameter is ignored without --since.')
 
-    if report_type in {'RENEWAL_GUIDANCE'}:
-        # bad type
-        if opt_month:
-            raise BadParameter('The --month parameter is not allowed for renewal guidance report.')
-        if opt_until:
-            raise BadParameter('The --until parameter is not allowed for renewal guidance report.')
 
-        # required
-        if not opt_since:
-            raise MissingRequiredParameter('The --since parameter is required for renewal guidance report.')
+def validate_renewal_params(options, help_texts):
+    opt_month = options.get('month', None)
+    opt_since = options.get('since', None)
+    opt_until = options.get('until', None)
+    opt_ephemeral = options.get('ephemeral', None)
 
-        # validation
-        if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):
-            raise UnparsableParameter(help_texts.get('ephemeral'))
+    # bad type
+    if opt_month:
+        raise BadParameter('The --month parameter is not allowed for renewal guidance report.')
+    if opt_until:
+        raise BadParameter('The --until parameter is not allowed for renewal guidance report.')
+
+    # required
+    if not opt_since:
+        raise MissingRequiredParameter('The --since parameter is required for renewal guidance report.')
+
+    # validation
+    if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):
+        raise UnparsableParameter(help_texts.get('ephemeral'))
+
+
+def parse_since_until(options, help_texts):
+    opt_since = options.get('since', None)
+    opt_until = options.get('until', None)
 
     since = parse_date_param(opt_since, help_texts, 'since')
     until = parse_date_param(opt_until, help_texts, 'until')
 
-    has_since = opt_since is not None
-    has_until = opt_until is not None
-
-    if (has_since and has_until) and until < since:
+    if (opt_since and opt_until) and until < since:
         raise UnparsableParameter('The date for --until cannot be before the date for --since.')
 
     return since, until
+
+
+def validate_build_params(options, help_texts):
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    if not report_type:
+        return None, None
+
+    if report_type in {'CCSP', 'CCSPv2'}:
+        validate_ccsp_params(options)
+
+    if report_type in {'RENEWAL_GUIDANCE'}:
+        validate_renewal_params(options, help_texts)
+
+    return parse_since_until(options, help_texts)
 
 
 def parse_number_of_days(date_option):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -341,6 +341,11 @@ def handle_not_crc():
         logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": {", ".join(surplus)}')
 
 
+# patchable in tests
+def now():
+    return datetime.datetime.now()
+
+
 def handle_validate_date_param(param, help_text, command):
     exceptions = []
 
@@ -353,29 +358,26 @@ def handle_validate_date_param(param, help_text, command):
         help_text = 'Integers are not allowed for parameters --since and --until.'
         raise UnparsableParameter(help_text)
 
+    """Try to parse the date two ways, fail if both fail."""
     try:
-        """Try to parse the date, and if it fails go to next loop iteration.  Then, determine if we need to render the failure message."""
         parser.parse(param)
     except Exception:
         exceptions.append(help_text)
 
-        """Try to parse the date, and if it fails go to next loop iteration.  Then, determine if we need to render the failure message."""
     if command == 'build':
-        match = match_build_date_param_regex(param)
+        match = re.match(SINCE_AND_UNTIL_BUILD_PATTERN, param)
     elif command == 'gather':
-        match = match_gather_date_param_regex(param)
+        match = re.match(SINCE_AND_UNTIL_GATHER_PATTERN, param)
     if match is None:
         exceptions.append(help_text)
+
     if len(exceptions) > 1:
         raise UnparsableParameter(help_text)
 
-
-def match_build_date_param_regex(date):
-    return re.match(SINCE_AND_UNTIL_BUILD_PATTERN, date)
-
-
-def match_gather_date_param_regex(date):
-    return re.match(SINCE_AND_UNTIL_GATHER_PATTERN, date)
+    if command == 'build':
+        return parse_date_param(param)
+    if command == 'gather':
+        return handle_datelike(param)
 
 
 def validate_build_extra_params(help_text, options):
@@ -418,11 +420,8 @@ def validate_build_extra_params(help_text, options):
         if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):
             raise UnparsableParameter(help_ephemeral)
 
-    handle_validate_date_param(opt_since, help_since, 'build')
-    handle_validate_date_param(opt_until, help_until, 'build')
-
-    since = parse_date_param(opt_since)
-    until = parse_date_param(opt_until)
+    since = handle_validate_date_param(opt_since, help_since, 'build')
+    until = handle_validate_date_param(opt_until, help_until, 'build')
 
     has_since = opt_since is not None
     has_until = opt_until is not None
@@ -430,10 +429,7 @@ def validate_build_extra_params(help_text, options):
     if (has_since and has_until) and until < since:
         raise UnparsableParameter('The date for --until cannot be before the date for --since.')
 
-
-# patchable in tests
-def now():
-    return datetime.datetime.now()
+    return since, until
 
 
 def parse_date_param(date_option):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -406,13 +406,13 @@ def validate_build_extra_params(help_text, options):
     if report_type in {'RENEWAL_GUIDANCE'}:
         # bad type
         if opt_month:
-            raise BadParameter('The --month parameter is not allowed for renewal guidance.')
+            raise BadParameter('The --month parameter is not allowed for renewal guidance report.')
         if opt_until:
-            raise BadParameter('The --until parameter is not allowed when environment variable METRICS_UTILITY_REPORT_TYPE is RENEWAL_GUIDANCE')
+            raise BadParameter('The --until parameter is not allowed for renewal guidance report.')
 
         # required
         if not opt_since:
-            raise MissingRequiredParameter('The --since parameter is required for renewal guidance.')
+            raise MissingRequiredParameter('The --since parameter is required for renewal guidance report.')
 
         # validation
         if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -380,6 +380,57 @@ def handle_validate_date_param(param, help_text, command):
         return handle_datelike(param)
 
 
+def parse_date_param(date_option):
+    if not date_option:
+        return None
+
+    parsed_date = None
+    if date_option.endswith('d'):
+        days_ago = int(date_option[0:-1])
+        parsed_date = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
+        if date_option.endswith('mo'):
+            suffix_length = len('mo')
+        elif date_option.endswith('month'):
+            suffix_length = len('month')
+        elif date_option.endswith('months'):
+            suffix_length = len('months')
+        months_ago = int(date_option[0:-suffix_length])
+        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif date_option.endswith('m'):
+        minutes_ago = int(date_option[0:-1])
+        parsed_date = now() - datetime.timedelta(minutes=minutes_ago)
+    else:
+        parsed_date = parser.parse(date_option)
+
+    # Set timezone to UTC when missing
+    if parsed_date and parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
+
+    return parsed_date
+
+
+def handle_datelike(value):
+    if not value:
+        return None
+
+    # Process ret argument
+    if value.endswith('d'):
+        days_ago = int(value[0:-1])
+        ret = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif value.endswith('m'):
+        minutes_ago = int(value[0:-1])
+        ret = now() - datetime.timedelta(minutes=minutes_ago)
+    else:
+        ret = parser.parse(value)
+
+    # Add default utc timezone
+    if ret and ret.tzinfo is None:
+        ret = ret.replace(tzinfo=datetime.timezone.utc)
+
+    return ret
+
+
 def validate_build_extra_params(help_text, options):
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if not report_type:
@@ -432,36 +483,6 @@ def validate_build_extra_params(help_text, options):
     return since, until
 
 
-def parse_date_param(date_option):
-    if not date_option:
-        return None
-
-    parsed_date = None
-    if date_option.endswith('d'):
-        days_ago = int(date_option[0:-1])
-        parsed_date = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
-        months_ago = int(date_option[0:-suffix_length])
-        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('m'):
-        minutes_ago = int(date_option[0:-1])
-        parsed_date = now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        parsed_date = parser.parse(date_option)
-
-    # Set timezone to UTC when missing
-    if parsed_date and parsed_date.tzinfo is None:
-        parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
-
-    return parsed_date
-
-
 def parse_number_of_days(date_option):
     if not date_option:
         return None
@@ -507,24 +528,3 @@ def handle_month(month):
         month = f'{y}-{m}'
 
     return month, date, date + relativedelta(months=1)
-
-
-def handle_datelike(value):
-    if not value:
-        return None
-
-    # Process ret argument
-    if value.endswith('d'):
-        days_ago = int(value[0:-1])
-        ret = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif value.endswith('m'):
-        minutes_ago = int(value[0:-1])
-        ret = now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        ret = parser.parse(value)
-
-    # Add default utc timezone
-    if ret and ret.tzinfo is None:
-        ret = ret.replace(tzinfo=datetime.timezone.utc)
-
-    return ret

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -9,6 +9,13 @@ from dateutil.relativedelta import relativedelta
 from metrics_utility.exceptions import BadParameter, DateFormatError, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
 
 
+date_format_text = (
+    'An absolute date (--{name}=2023-12-20) (start of day, UTC), '
+    'a number of minutes ago (--{name}=2m) (m, minute, minutes; relative to now), '
+    'a number of days ago (--{name}=5d) (d, day, days; start of day, UTC), or '
+    'a number of months ago (--{name}=2mo) (mo, month, months; start of day, UTC).'
+)
+
 ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
 SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{1,2}-\d{1,2}$'
 SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{1,2}-\d{1,2}$'

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -10,8 +10,8 @@ from metrics_utility.exceptions import BadParameter, DateFormatError, MissingReq
 
 
 ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
-SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{2}-\d{2}$'
-SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{2}-\d{2}$'
+SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{1,2}-\d{1,2}$'
+SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{1,2}-\d{1,2}$'
 
 # Constants for valid values
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 
-from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
 from metrics_utility.exceptions import BadParameter, DateFormatError, MissingRequiredEnvVar, MissingRequiredParameter, UnparsableParameter
@@ -355,54 +354,52 @@ def startofday(dt):
     return dt.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-def handle_validate_date_param(param, help_texts, name):
-    if not param:
+def parse_date_param(value, help_texts={None: ''}, name=None):
+    if not value:
         return None
 
     help_text = help_texts.get(name)
 
-    if param.isdigit():
+    if value.isdigit():
         raise UnparsableParameter(f'Bare integers are not allowed for --{name}: {help_text}')
 
-    ret = None
+    parsed = None
     try:
         # N days ago, start of day
-        match = re.fullmatch(r'(\d+)(d|day|days)', param)
+        match = re.fullmatch(r'(\d+)(d|day|days)', value)
         if match:
             days_ago = int(match.group(1))
-            ret = startofday(now() - datetime.timedelta(days=days_ago - 1))
+            parsed = startofday(now() - datetime.timedelta(days=days_ago - 1))
 
         # N months ago, start of day
-        match = re.fullmatch(r'(\d+)(mo|mon|month|months)', param)
+        match = re.fullmatch(r'(\d+)(mo|mon|month|months)', value)
         if match:
             months_ago = int(match.group(1))
-            ret = startofday(now() - relativedelta(months=months_ago))
+            parsed = startofday(now() - relativedelta(months=months_ago))
 
         # N minutes ago
-        match = re.fullmatch(r'(\d+)(m|min|minute|minutes)', param)
+        match = re.fullmatch(r'(\d+)(m|min|minute|minutes)', value)
         if match:
             minutes_ago = int(match.group(1))
-            ret = now() - datetime.timedelta(minutes=minutes_ago)
+            parsed = now() - datetime.timedelta(minutes=minutes_ago)
 
         # actual date
-        if not ret:
-            # FIXME strptime?
-            ret = parser.parse(param)
+        if not parsed:
+            parsed = datetime.datetime.fromisoformat(value).astimezone(datetime.timezone.utc)
     except Exception as e:
-        breakpoint()
-        raise UnparsableParameter(f'{help_text} {e}')
+        raise UnparsableParameter(f'{str(e)}: {help_text}')
 
     # Set timezone to UTC when missing
-    if ret and ret.tzinfo is None:
-        ret = ret.replace(tzinfo=datetime.timezone.utc)
+    if parsed and parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
 
-    return ret
+    return parsed
 
 
 def validate_build_extra_params(help_texts, options):
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if not report_type:
-        return
+        return None, None
 
     opt_month = options.get('month', None)
     opt_since = options.get('since', None)
@@ -435,8 +432,8 @@ def validate_build_extra_params(help_texts, options):
         if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):
             raise UnparsableParameter(help_texts.get('ephemeral'))
 
-    since = handle_validate_date_param(opt_since, help_texts, 'since')
-    until = handle_validate_date_param(opt_until, help_texts, 'until')
+    since = parse_date_param(opt_since, help_texts, 'since')
+    until = parse_date_param(opt_until, help_texts, 'until')
 
     has_since = opt_since is not None
     has_until = opt_until is not None

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -17,8 +17,6 @@ date_format_text = (
 )
 
 ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
-SINCE_AND_UNTIL_GATHER_PATTERN = r'^\d+[dm]$|^\d{4}-\d{1,2}-\d{1,2}$'
-SINCE_AND_UNTIL_BUILD_PATTERN = r'^\d+(d|mo|month|months|m)$|^\d{4}-\d{1,2}-\d{1,2}$'
 
 # Constants for valid values
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}
@@ -353,92 +351,55 @@ def now():
     return datetime.datetime.now()
 
 
-def handle_validate_date_param(param, help_text, command):
-    exceptions = []
+def startofday(dt):
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    if param is None:
-        return
+
+def handle_validate_date_param(param, help_texts, name):
+    if not param:
+        return None
+
+    help_text = help_texts.get(name)
 
     if param.isdigit():
-        """If the value is a digit stop execution and render the failure message."""
-        exceptions.append('isdigit')
-        help_text = 'Integers are not allowed for parameters --since and --until.'
-        raise UnparsableParameter(help_text)
+        raise UnparsableParameter(f'Bare integers are not allowed for --{name}: {help_text}')
 
-    """Try to parse the date two ways, fail if both fail."""
+    ret = None
     try:
-        parser.parse(param)
-    except Exception:
-        exceptions.append(help_text)
+        # N days ago, start of day
+        match = re.fullmatch(r'(\d+)(d|day|days)', param)
+        if match:
+            days_ago = int(match.group(1))
+            ret = startofday(now() - datetime.timedelta(days=days_ago - 1))
 
-    if command == 'build':
-        match = re.match(SINCE_AND_UNTIL_BUILD_PATTERN, param)
-    elif command == 'gather':
-        match = re.match(SINCE_AND_UNTIL_GATHER_PATTERN, param)
-    if match is None:
-        exceptions.append(help_text)
+        # N months ago, start of day
+        match = re.fullmatch(r'(\d+)(mo|mon|month|months)', param)
+        if match:
+            months_ago = int(match.group(1))
+            ret = startofday(now() - relativedelta(months=months_ago))
 
-    if len(exceptions) > 1:
-        raise UnparsableParameter(help_text)
+        # N minutes ago
+        match = re.fullmatch(r'(\d+)(m|min|minute|minutes)', param)
+        if match:
+            minutes_ago = int(match.group(1))
+            ret = now() - datetime.timedelta(minutes=minutes_ago)
 
-    if command == 'build':
-        return parse_date_param(param)
-    if command == 'gather':
-        return handle_datelike(param)
-
-
-def parse_date_param(date_option):
-    if not date_option:
-        return None
-
-    parsed_date = None
-    if date_option.endswith('d'):
-        days_ago = int(date_option[0:-1])
-        parsed_date = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('mo') or date_option.endswith('month') or date_option.endswith('months'):
-        if date_option.endswith('mo'):
-            suffix_length = len('mo')
-        elif date_option.endswith('month'):
-            suffix_length = len('month')
-        elif date_option.endswith('months'):
-            suffix_length = len('months')
-        months_ago = int(date_option[0:-suffix_length])
-        parsed_date = (now() - relativedelta(months=months_ago)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif date_option.endswith('m'):
-        minutes_ago = int(date_option[0:-1])
-        parsed_date = now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        parsed_date = parser.parse(date_option)
+        # actual date
+        if not ret:
+            # FIXME strptime?
+            ret = parser.parse(param)
+    except Exception as e:
+        breakpoint()
+        raise UnparsableParameter(f'{help_text} {e}')
 
     # Set timezone to UTC when missing
-    if parsed_date and parsed_date.tzinfo is None:
-        parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
-
-    return parsed_date
-
-
-def handle_datelike(value):
-    if not value:
-        return None
-
-    # Process ret argument
-    if value.endswith('d'):
-        days_ago = int(value[0:-1])
-        ret = (now() - datetime.timedelta(days=days_ago - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    elif value.endswith('m'):
-        minutes_ago = int(value[0:-1])
-        ret = now() - datetime.timedelta(minutes=minutes_ago)
-    else:
-        ret = parser.parse(value)
-
-    # Add default utc timezone
     if ret and ret.tzinfo is None:
         ret = ret.replace(tzinfo=datetime.timezone.utc)
 
     return ret
 
 
-def validate_build_extra_params(help_text, options):
+def validate_build_extra_params(help_texts, options):
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if not report_type:
         return
@@ -447,10 +408,6 @@ def validate_build_extra_params(help_text, options):
     opt_since = options.get('since', None)
     opt_until = options.get('until', None)
     opt_ephemeral = options.get('ephemeral', None)
-
-    help_since = help_text.get('since')
-    help_until = help_text.get('until')
-    help_ephemeral = help_text.get('ephemeral')
 
     if report_type in {'CCSP', 'CCSPv2'}:
         # bad type
@@ -476,10 +433,10 @@ def validate_build_extra_params(help_text, options):
 
         # validation
         if opt_ephemeral and not re.match(ALLOWED_EPHEMERAL_PATTERN, opt_ephemeral):
-            raise UnparsableParameter(help_ephemeral)
+            raise UnparsableParameter(help_texts.get('ephemeral'))
 
-    since = handle_validate_date_param(opt_since, help_since, 'build')
-    until = handle_validate_date_param(opt_until, help_until, 'build')
+    since = handle_validate_date_param(opt_since, help_texts, 'since')
+    until = handle_validate_date_param(opt_until, help_texts, 'until')
 
     has_since = opt_since is not None
     has_until = opt_until is not None

--- a/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
+++ b/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
@@ -1,5 +1,3 @@
-import datetime
-
 from argparse import ArgumentParser
 
 import pytest
@@ -13,7 +11,6 @@ from metrics_utility.exceptions import (
     UnparsableParameter,
 )
 from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
-from metrics_utility.management.validation import handle_datelike
 
 
 @pytest.fixture
@@ -83,29 +80,6 @@ def test_handle_unexpected_exception(monkeypatch, command_instance):
 
     with pytest.raises(MetricsException):
         command_instance.handle()
-
-
-def test_handle_datelike_days():
-    days = 2
-    val = f'{days}d'
-    dt = handle_datelike(val)
-    assert isinstance(dt, datetime.datetime)
-    assert dt.tzinfo is not None
-
-
-def test_handle_datelike_minutes():
-    mins = 5
-    val = f'{mins}m'
-    dt = handle_datelike(val)
-    assert isinstance(dt, datetime.datetime)
-    assert dt.tzinfo is not None
-
-
-def test_handle_datelike_iso():
-    val = '2024-01-01T00:00:00Z'
-    dt = handle_datelike(val)
-    assert isinstance(dt, datetime.datetime)
-    assert dt.tzinfo is not None
 
 
 def test_handle_ship_target_crc(monkeypatch, command_instance):

--- a/metrics_utility/test/validation/test_extra_params_validation.py
+++ b/metrics_utility/test/validation/test_extra_params_validation.py
@@ -75,16 +75,27 @@ def test_invalid_build_report_argument_format():
     bad_inputs = ['2', '2y', 'mo3', '3weeks', '3w']
     args = ['until', 'since']
 
-    for bad_input in bad_inputs:
-        for arg in args:
+    inp_errors = [
+        'Bare integers are not allowed',
+        "Invalid isoformat string: '2y'",
+        None,
+        None,
+        None,
+    ]
+    arg_errors = [
+        'End date for collection',
+        'Start date for collection',
+    ]
+
+    for bad_input, err_input in zip(bad_inputs, inp_errors):
+        for arg, err_arg in zip(args, arg_errors):
             cmd = Command()
 
-            help_text = cmd.help_texts[arg]
-            if bad_input == '2':
-                help_text = 'Integers are not allowed for parameters --since and --until.'
             # either {'since': bad_input} or {'since': (valid), 'until': bad_input}
             e = handle_build_exception(env_vars, {'since': '2024-01-01', arg: bad_input}, UnparsableParameter)
-            assert e.name == help_text
+
+            assert (err_input or cmd.help_texts[arg]) in e.name
+            assert err_arg in e.name
 
 
 def test_ephemeral_allowed():
@@ -119,21 +130,26 @@ def handle_gather_exception(env_vars, params, klass):
 def test_invalid_gather_argument_format():
     from metrics_utility.management.commands.gather_automation_controller_billing_data import Command
 
-    bad_inputs = [
-        '2',
-        '2mo',
-        '1day',
-        '2min',
-        '2mins',
-    ]
+    bad_inputs = ['2', '2y', 'mo3', '3weeks', '3w']
     args = ['until', 'since']
 
-    for bad_input in bad_inputs:
-        for arg in args:
+    inp_errors = [
+        'Bare integers are not allowed',
+        "Invalid isoformat string: '2y'",
+        None,
+        None,
+        None,
+    ]
+    arg_errors = [
+        'End date for collection',
+        'Start date for collection',
+    ]
+
+    for bad_input, err_input in zip(bad_inputs, inp_errors):
+        for arg, err_arg in zip(args, arg_errors):
             cmd = Command()
 
-            help_text = cmd.help_texts[arg]
-            if bad_input == '2':
-                help_text = 'Integers are not allowed for parameters --since and --until.'
             e = handle_gather_exception(env_vars, {arg: bad_input}, UnparsableParameter)
-            assert e.name == help_text
+
+            assert (err_input or cmd.help_texts[arg]) in e.name
+            assert err_arg in e.name

--- a/metrics_utility/test/validation/test_extra_params_validation.py
+++ b/metrics_utility/test/validation/test_extra_params_validation.py
@@ -58,7 +58,7 @@ def test_renewal_guidance_fails_with_until_params():
     ]
     for arg in command_args:
         e = handle_build_exception({**env_vars, 'METRICS_UTILITY_REPORT_TYPE': 'RENEWAL_GUIDANCE'}, arg['args'], BadParameter)
-        assert e.name == 'The --until parameter is not allowed when environment variable METRICS_UTILITY_REPORT_TYPE is RENEWAL_GUIDANCE'
+        assert e.name == 'The --until parameter is not allowed for renewal guidance report.'
 
 
 def test_invalid_month_format():

--- a/metrics_utility/test/validation/test_parse_helpers.py
+++ b/metrics_utility/test/validation/test_parse_helpers.py
@@ -6,7 +6,6 @@ import pytest
 
 from metrics_utility.exceptions import MetricsException
 from metrics_utility.management.validation import (
-    handle_datelike,
     parse_date_param,
     parse_number_of_days,
 )
@@ -15,9 +14,13 @@ from metrics_utility.management.validation import (
 def test_parse_date_param():
     assert parse_date_param(None) is None
     assert parse_date_param('1d') is not None
+    assert parse_date_param('1days') is not None
     assert parse_date_param('2mo') is not None
+    assert parse_date_param('2months') is not None
     assert parse_date_param('3m') is not None
+    assert parse_date_param('3minutes') is not None
     assert parse_date_param('2024-01-01') == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    assert parse_date_param('2024-01-01T12:31:00Z') == datetime.datetime(2024, 1, 1, 12, 31, tzinfo=datetime.timezone.utc)
 
     # patch now() to be 2024-02-29 13:59:00 (w/o tz)
     with patch('metrics_utility.management.validation.now') as mock:
@@ -28,26 +31,17 @@ def test_parse_date_param():
         assert parse_date_param('3m') == datetime.datetime(2024, 2, 29, 13, 56, tzinfo=datetime.timezone.utc)
 
     # ensure timezone
+    assert parse_date_param('2mo').tzinfo == datetime.timezone.utc
     assert parse_date_param('3m').tzinfo == datetime.timezone.utc
     assert parse_date_param('2024-01-01').tzinfo == datetime.timezone.utc
 
+    # bare number invalid
+    with pytest.raises(MetricsException):
+        parse_number_of_days('3')
 
-def test_handle_datelike():
-    assert handle_datelike(None) is None
-    assert handle_datelike('1d') is not None
-    assert handle_datelike('3m') is not None
-    assert handle_datelike('2024-01-01') == datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-
-    # patch now() to be 2024-02-29 13:59:00 (w/o tz)
-    with patch('metrics_utility.management.validation.now') as mock:
-        mock.return_value = datetime.datetime(2024, 2, 29, 13, 59, 0)
-
-        assert handle_datelike('1d') == datetime.datetime(2024, 2, 29, 0, 0, tzinfo=datetime.timezone.utc)
-        assert handle_datelike('3m') == datetime.datetime(2024, 2, 29, 13, 56, tzinfo=datetime.timezone.utc)
-
-    # ensure timezone
-    assert handle_datelike('3m').tzinfo == datetime.timezone.utc
-    assert handle_datelike('2024-01-01').tzinfo == datetime.timezone.utc
+    # unknown suffix
+    with pytest.raises(MetricsException):
+        parse_number_of_days('4x')
 
 
 def test_parse_number_of_days():
@@ -58,3 +52,7 @@ def test_parse_number_of_days():
     # bare number invalid
     with pytest.raises(MetricsException):
         parse_number_of_days('3')
+
+    # unknown suffix
+    with pytest.raises(MetricsException):
+        parse_number_of_days('4x')

--- a/metrics_utility/test/validation/test_parse_helpers.py
+++ b/metrics_utility/test/validation/test_parse_helpers.py
@@ -37,11 +37,11 @@ def test_parse_date_param():
 
     # bare number invalid
     with pytest.raises(MetricsException):
-        parse_number_of_days('3')
+        parse_date_param('3')
 
     # unknown suffix
     with pytest.raises(MetricsException):
-        parse_number_of_days('4x')
+        parse_date_param('4x')
 
 
 def test_parse_number_of_days():


### PR DESCRIPTION
Follows #155, #156

Merges the 3 date-parsing functions we have, and the format definition help.

Before:

* `handle_datelike` 
  * used for gather
  * using `dateutil.parser.parse`, accepting various date formats
  * allows `d`, `m`, absolute
  * gather help text documents `m` as months, is minutes
* `parse_date_param`
  * used for build
  * using `dateutil.parser.parse`, accepting various date formats
  * allows `d`, `m`, absolute, `mo`, `month`, `months`
* `handle_validate_date_param`
  * used for validation in both
  * using `dateutil.parser.parse`, but
    * requiring a string YYYY-MM-DD format exactly
  * disallows bare integers

After:

* `parse_date_param`
  * used for all
  * using `datetime.datetime.fromisoformat`
  * allows `d`, `day`, `days`; `m`, `min`, `minute`, `minutes`; `mo`, `mon`, `month`, `months`; absolute
  * disallows bare integers

Means the format accepted for --since and --until is now consistent between gather & build, and less prone to drifting apart :).

Fixups to `help_texts` - include all options, share the date format description.
Fixups to error messages - consistent renewal guidance refs, include messages from date parse errors.
No longer parsing for validation separately - the same function raises a MetricsException child, or returns a parsed value.

Allows using `2023-1-2` again, and also exact timestamps, like `2013-12-23T12:54:00Z`.