### PR TITLE
make psql, make clean: run psql inside the compose environment, reset db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 help:
-	@echo help sync test coverage lint fix compose psql
+	@echo help sync test coverage lint fix compose clean psql
 
 sync:
 	uv run sync
@@ -21,7 +21,10 @@ fix:
 compose:
 	docker compose -f tools/docker/docker-compose.yaml up
 
+clean:
+	docker compose -f tools/docker/docker-compose.yaml down -v
+
 psql:
 	docker compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
 
-.PHONY: help sync test coverage lint fix compose psql
+.PHONY: help sync test coverage lint fix compose clean psql

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 help:
-	@echo help sync test coverage lint fix compose
+	@echo help sync test coverage lint fix compose psql
 
 sync:
 	uv run sync
@@ -21,4 +21,7 @@ fix:
 compose:
 	docker compose -f tools/docker/docker-compose.yaml up
 
-.PHONY: help sync test coverage lint fix compose
+psql:
+	docker compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
+
+.PHONY: help sync test coverage lint fix compose psql


### PR DESCRIPTION
Add a `make psql` command to run psql inside the container.

(A locally-run `psql -h localhost -U myuser awx` will also work, but needs manual input for `mypassword`)

```
$ make psql
docker compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
psql (17.5 (Debian 17.5-1.pgdg120+1))
Type "help" for help.

awx=# select * from main_host;
...
```

---

Add a `make clean` command that just resets the compose env db.