### PR TITLE
Renewal Guidance test

### DIFF
--- a/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
+++ b/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
@@ -61,7 +61,6 @@ expected_sheets = {
         {
             'Host name': [
                 'default_host_hostmetric_1',
-                'default_host_hostmetric_10',
                 'default_host_hostmetric_3',
                 'default_host_hostmetric_4',
                 'default_host_hostmetric_7',
@@ -71,7 +70,6 @@ expected_sheets = {
         {
             'First\nautomation': [
                 '2025-06-01 08:00:00',
-                '2025-06-03 11:15:00',
                 '2025-06-03 12:00:00',
                 '2025-06-02 07:30:00',
                 '2025-06-04 10:30:00',
@@ -81,7 +79,6 @@ expected_sheets = {
         {
             'Last\nautomation': [
                 '2025-06-10 14:30:00',
-                '2025-06-11 10:45:00',
                 '2025-06-11 13:45:00',
                 '2025-06-09 15:30:00',
                 '2025-06-10 12:30:00',
@@ -91,7 +88,6 @@ expected_sheets = {
         {
             'Number of\nAutomations': [
                 12,
-                11,
                 7,
                 10,
                 8,
@@ -101,7 +97,6 @@ expected_sheets = {
         {
             'Number of days\nbetween first_automation\nand last_automation': [
                 9,
-                7,
                 8,
                 7,
                 6,
@@ -110,7 +105,6 @@ expected_sheets = {
         },
         {
             'Number of\nDeletions': [
-                0,
                 0,
                 0,
                 0,
@@ -125,12 +119,10 @@ expected_sheets = {
                 None,
                 None,
                 None,
-                None,
             ]
         },
         {
             'HostMetric\nrecord count': [
-                1,
                 1,
                 1,
                 1,
@@ -145,12 +137,10 @@ expected_sheets = {
                 1,
                 1,
                 1,
-                1,
             ]
         },
         {
             'HostMetric deleted\nrecord count': [
-                0,
                 0,
                 0,
                 0,
@@ -161,7 +151,6 @@ expected_sheets = {
         {
             'Host names': [
                 'default_host_hostmetric_1',
-                'default_host_hostmetric_10',
                 'default_host_hostmetric_3',
                 'default_host_hostmetric_4',
                 'default_host_hostmetric_7',
@@ -170,7 +159,6 @@ expected_sheets = {
         },
         {
             'Variables ansible_host': [
-                None,
                 None,
                 None,
                 None,
@@ -185,12 +173,10 @@ expected_sheets = {
                 None,
                 None,
                 None,
-                None,
             ]
         },
         {
             'Machine UUIDs': [
-                None,
                 None,
                 None,
                 None,
@@ -315,6 +301,7 @@ expected_sheets = {
     ],
 }
 
+
 expected_sheets = convert_datetime_strings(expected_sheets)
 
 
@@ -352,7 +339,7 @@ def test_import(cleanup):
         validate_cell(wb, sh, 'B1', None)
         validate_cell(wb, sh, 'B2', f'{start_year}-{start_month}-{start_day}, {current_year}-{current_month}-{current_day}')
         validate_cell(wb, sh, 'B3', 'Quantity')
-        validate_cell(wb, sh, 'B4', 6)
+        validate_cell(wb, sh, 'B4', 5)
         validate_cell(wb, sh, 'B5', 4)
 
         validate_cell(wb, sh, 'D1', now.strftime('Updated: %b %d, %Y'))

--- a/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
+++ b/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
@@ -326,7 +326,6 @@ expected_sheets = convert_datetime_strings(expected_sheets)
     indirect=True,
 )
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
-@pytest.mark.skip(reason='Skipping this test until PR with data is merged')
 def test_import(cleanup):
     """Build xlsx report using build command and test its contents."""
 

--- a/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
+++ b/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
@@ -11,7 +11,7 @@ from metrics_utility.test.util import run_build_int
 
 # Get current date and time
 now = datetime.now()
-diff_months = 20
+diff_months = 500
 
 # Extract current date components with leading zeros
 current_month = f'{now.month:02}'
@@ -336,8 +336,8 @@ def test_import(cleanup):
             'force': True,
         },
     )
-
     validate_sheet_columns(file_path, expected_sheets, 6)
+
     validate_sheet_tab_names(file_path, expected_sheets, ['Usage Reporting'])
 
     wb = openpyxl.load_workbook(file_path)

--- a/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
+++ b/metrics_utility/test/renewal_guidance/test_integration_gather_build_report_renewal_guidance.py
@@ -11,7 +11,7 @@ from metrics_utility.test.util import run_build_int
 
 # Get current date and time
 now = datetime.now()
-diff_months = 2000
+diff_months = 20
 
 # Extract current date components with leading zeros
 current_month = f'{now.month:02}'

--- a/tools/docker/main_hostmetric.sql
+++ b/tools/docker/main_hostmetric.sql
@@ -193,7 +193,7 @@ BEGIN
   --
   RAISE NOTICE 'Inserted % hosts with IDs: %', array_length(host_ids,1), host_ids;
 
-  INSERT INTO main_hostmetric(
+  INSERT INTO public.main_hostmetric(
      hostname,
      first_automation,
      last_automation,

--- a/tools/docker/main_hostmetric.sql
+++ b/tools/docker/main_hostmetric.sql
@@ -211,7 +211,6 @@ BEGIN
  ('default_host_hostmetric_6', '2025-06-01T06:45:00+00', '2025-06-06T13:15:00+00', NULL, 6, 1, true, 1),
  ('default_host_hostmetric_7', '2025-06-04T10:30:00+00', '2025-06-10T12:30:00+00', NULL, 8, 0, false, 4),
  ('default_host_hostmetric_8', '2025-06-29T09:45:00+00', '2025-06-07T14:00:00+00', '2025-06-13T09:30:00+00', 4, 1, true, 2),
- ('default_host_hostmetric_9', '2025-06-05T08:30:00+00', '2025-06-10T16:00:00+00', NULL, 9, 0, false, 3),
- ('default_host_hostmetric_10', '2025-06-03T11:15:00+00', '2025-06-11T10:45:00+00', NULL, 11, 0, false, 2);
+ ('default_host_hostmetric_9', '2025-06-05T08:30:00+00', '2025-06-10T16:00:00+00', NULL, 9, 0, false, 3);
 END
 $$;


### PR DESCRIPTION
[[AAP-48662](https://issues.redhat.com/browse/AAP-48662)]

## Description

Follow up PR to https://github.com/ansible/metrics-utility/pull/159

Fixes missing public in main_hostmetric table and unskip renewal guidance test.

## Testing

Described in follow up PR

### Prerequisites

<!-- List any specific setup required -->

### Steps to Test

1.
2.
3.

### Expected Results

<!-- Describe what should happen after following the steps -->

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
