### PR TITLE
AAP-50701 - Fill Data for Testathon 2

### DIFF
--- a/testathon/gather_all.py
+++ b/testathon/gather_all.py
@@ -6,13 +6,15 @@ import sys
 
 from datetime import date, timedelta
 
+from helper_ocp_prepare import create_oc_environs
+
 
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
 
 SSH_URL = os.getenv('SSH_URL')
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
-OC_COMMAND = os.getenv('OC_COMMAND', '')
+
 OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
 
 print(f'ENVIRONMENT: {ENVIRONMENT}')
@@ -20,8 +22,11 @@ print(f'ENVIRONMENT: {ENVIRONMENT}')
 print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
 
-print(f'OC_COMMAND: {OC_COMMAND}')
 print(f'OC_LOGIN_COMMAND: {OC_LOGIN_COMMAND}')
+
+if os.getenv('POD_NAME') and os.getenv('NAMESPACE'):
+    print(f'POD_NAME: {os.getenv("POD_NAME")}')
+    print(f'NAMESPACE: {os.getenv("NAMESPACE")}')
 
 # Configure the beginning of your range here
 START_DATE = date(2022, 1, 1)
@@ -135,8 +140,11 @@ def run_command(args, config):
         env_vars = ' '.join([f'{k}={v}' for k, v in config.items()])
         container_cmd = f'{env_vars} metrics-utility {" ".join(args)}'
 
+        NAMESPACE = os.getenv('NAMESPACE')
+        POD_NAME = os.getenv('POD_NAME')
+
         # Use oc exec to run the command
-        oc_cmd = f'{OC_COMMAND} -- /bin/bash -c "{container_cmd}"'
+        oc_cmd = f'oc exec -n {NAMESPACE} {POD_NAME} -- /bin/bash -c "{container_cmd}"'  # noqa: E501
         print('Running OpenShift:', oc_cmd)
         return subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)
 
@@ -155,6 +163,9 @@ def list_gathered_files(config):
     """
     ship_path = config.get('METRICS_UTILITY_SHIP_PATH', path_to_shipped_data)
     print(f'\n=== Listing gathered files in {ship_path} ===')
+
+    NAMESPACE = os.getenv('NAMESPACE')
+    POD_NAME = os.getenv('POD_NAME')
 
     if ENVIRONMENT == 'local':
         # For local environment, list files in the docker container
@@ -193,11 +204,10 @@ def list_gathered_files(config):
 
     elif ENVIRONMENT == 'OpenShift':
         # OpenShift deployment via oc command
-        container_cmd = f'find /var/lib/awx/{ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
-        oc_cmd = f'{OC_COMMAND} exec deployment/automation-controller-web -- /bin/bash -c "{container_cmd}"'
+        cmd = f'find /var/lib/awx/{ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
+        oc_cmd = f'oc exec -n {NAMESPACE} {POD_NAME} -- /bin/bash -c "{cmd}"'
         print('Running OpenShift ls:', oc_cmd)
         result = subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)
-
     else:
         print(f'Unsupported environment for listing files: {ENVIRONMENT}')
         return
@@ -212,6 +222,12 @@ def list_gathered_files(config):
 def main():
     if ENVIRONMENT == 'OpenShift':
         oc_login()
+
+        if not os.getenv('POD_NAME') or not os.getenv('NAMESPACE'):
+            create_oc_environs()
+
+        print(f'POD_NAME: {os.getenv("POD_NAME")}')
+        print(f'NAMESPACE: {os.getenv("NAMESPACE")}')
 
     config = get_metrics_utility_config()
 
@@ -244,8 +260,10 @@ def main():
 
     # print commands how to connect manually to the terminal
     if ENVIRONMENT == 'OpenShift':
+        NAMESPACE = os.getenv('NAMESPACE')
+        POD_NAME = os.getenv('POD_NAME')
         print('To connect manually to the terminal, run:')
-        oc_rsh_command = OC_COMMAND.replace('oc exec', 'oc rsh')
+        oc_rsh_command = f'oc rsh -n {NAMESPACE} {POD_NAME}'
         print(oc_rsh_command)
 
     if ENVIRONMENT == 'containerized':

--- a/testathon/gather_all.py
+++ b/testathon/gather_all.py
@@ -122,7 +122,7 @@ def run_command(args, config):
 
         # Build the command to run inside the container
         env_vars = ' '.join([f'{k}={v}' for k, v in config.items()])
-        container_cmd = f'cd /var/lib/awx && {env_vars} metrics-utility {" ".join(args)}'
+        container_cmd = f'{env_vars} metrics-utility {" ".join(args)}'
 
         # Use podman exec to run the command inside automation-controller-web container
         remote_command = f'echo "{container_cmd}" | podman exec -i automation-controller-web /bin/bash'
@@ -133,10 +133,10 @@ def run_command(args, config):
     elif ENVIRONMENT == 'OpenShift':
         # OpenShift deployment via oc command
         env_vars = ' '.join([f'{k}={v}' for k, v in config.items()])
-        container_cmd = f'cd /var/lib/awx && {env_vars} metrics-utility {" ".join(args)}'
+        container_cmd = f'{env_vars} metrics-utility {" ".join(args)}'
 
         # Use oc exec to run the command
-        oc_cmd = f'{OC_COMMAND} exec deployment/automation-controller-web -- /bin/bash -c "{container_cmd}"'
+        oc_cmd = f'{OC_COMMAND} -- /bin/bash -c "{container_cmd}"'
         print('Running OpenShift:', oc_cmd)
         return subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)
 
@@ -241,6 +241,26 @@ def main():
 
     # List all gathered files after completion
     list_gathered_files(config)
+
+    # print commands how to connect manually to the terminal
+    if ENVIRONMENT == 'OpenShift':
+        print('To connect manually to the terminal, run:')
+        oc_rsh_command = OC_COMMAND.replace('oc exec', 'oc rsh')
+        print(oc_rsh_command)
+
+    if ENVIRONMENT == 'containerized':
+        # ssh and connect to the container
+        ssh_command = f'ssh {SSH_USER}@{SSH_URL}'
+        print('To connect manually to the terminal, run:')
+        print(ssh_command)
+
+    if ENVIRONMENT == 'local':
+        print('To connect manually to the terminal, run:')
+        print('docker exec -it tools_awx_1 /bin/bash')
+
+    if ENVIRONMENT == 'RPM':
+        print('To connect manually to the terminal, run:')
+        print(f'ssh {SSH_USER}@{SSH_URL}')
 
 
 if __name__ == '__main__':

--- a/testathon/gather_all.py
+++ b/testathon/gather_all.py
@@ -204,7 +204,7 @@ def list_gathered_files(config):
 
     elif ENVIRONMENT == 'OpenShift':
         # OpenShift deployment via oc command
-        cmd = f'find /var/lib/awx/{ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
+        cmd = f'find {ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
         oc_cmd = f'oc exec -n {NAMESPACE} {POD_NAME} -- /bin/bash -c "{cmd}"'
         print('Running OpenShift ls:', oc_cmd)
         result = subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)

--- a/testathon/gather_all.py
+++ b/testathon/gather_all.py
@@ -253,6 +253,7 @@ def main():
         ssh_command = f'ssh {SSH_USER}@{SSH_URL}'
         print('To connect manually to the terminal, run:')
         print(ssh_command)
+        print('podman exec -it automation-controller-web /bin/bash')
 
     if ENVIRONMENT == 'local':
         print('To connect manually to the terminal, run:')

--- a/testathon/gather_all.py
+++ b/testathon/gather_all.py
@@ -7,16 +7,31 @@ import sys
 from datetime import date, timedelta
 
 
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
+
 SSH_URL = os.getenv('SSH_URL')
-SSH_USER = os.getenv('SSH_USER')
+SSH_USER = os.getenv('SSH_USER', 'ec2-user')
+
+OC_COMMAND = os.getenv('OC_COMMAND', '')
+OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
+
+print(f'ENVIRONMENT: {ENVIRONMENT}')
 
 print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
+
+print(f'OC_COMMAND: {OC_COMMAND}')
+print(f'OC_LOGIN_COMMAND: {OC_LOGIN_COMMAND}')
 
 # Configure the beginning of your range here
 START_DATE = date(2022, 1, 1)
 # Uses today() as the end of the range; modify if you need a fixed end
 END_DATE = date.today()
+
+path_to_shipped_data = '/var/tmp/shipped_data'
+
+if ENVIRONMENT == 'local' or ENVIRONMENT == 'containerized':
+    path_to_shipped_data = './shipped_data'
 
 
 def month_ranges(start_date, end_date):
@@ -61,13 +76,143 @@ def month_ranges(start_date, end_date):
 
 
 def get_metrics_utility_config():
-    return {
-        'METRICS_UTILITY_SHIP_PATH': './shipped_data',
+    env = {
+        'METRICS_UTILITY_SHIP_PATH': path_to_shipped_data,
         'METRICS_UTILITY_SHIP_TARGET': 'directory',
     }
 
+    return env
+
+
+def run_command(args, config):
+    """
+    Execute the metrics-utility command based on the environment type.
+    """
+    if ENVIRONMENT == 'local':
+        # Local docker exec path
+        docker_env = []
+        for k, v in config.items():
+            docker_env += ['-e', f'{k}={v}']
+        docker_cmd = [
+            'docker',
+            'exec',
+            *docker_env,
+            'tools_awx_1',
+            '/bin/sh',
+            '-c',
+            f'cd awx-dev/metrics-utility && . /var/lib/awx/venv/awx/bin/activate && python3 ./manage.py {" ".join(args)}',
+        ]
+        print('Running local:', ' '.join(docker_cmd))
+        return subprocess.run(docker_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'RPM':
+        # RPM deployment via SSH
+        if not SSH_URL or not SSH_USER:
+            raise ValueError('SSH_URL and SSH_USER must be set for RPM environment')
+
+        env_list = [f'{k}={v}' for k, v in config.items()]
+        ssh_cmd = ['ssh', f'{SSH_USER}@{SSH_URL}', 'sudo', '-E', 'env', *env_list, 'metrics-utility', *args]
+        print('Running RPM:', ' '.join(ssh_cmd))
+        return subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'containerized':
+        # Containerized deployment via SSH with podman
+        if not SSH_URL or not SSH_USER:
+            raise ValueError('SSH_URL and SSH_USER must be set for containerized environment')
+
+        # Build the command to run inside the container
+        env_vars = ' '.join([f'{k}={v}' for k, v in config.items()])
+        container_cmd = f'cd /var/lib/awx && {env_vars} metrics-utility {" ".join(args)}'
+
+        # Use podman exec to run the command inside automation-controller-web container
+        remote_command = f'echo "{container_cmd}" | podman exec -i automation-controller-web /bin/bash'
+        ssh_cmd = ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command]
+        print('Running containerized:', ' '.join(ssh_cmd))
+        return subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'OpenShift':
+        # OpenShift deployment via oc command
+        env_vars = ' '.join([f'{k}={v}' for k, v in config.items()])
+        container_cmd = f'cd /var/lib/awx && {env_vars} metrics-utility {" ".join(args)}'
+
+        # Use oc exec to run the command
+        oc_cmd = f'{OC_COMMAND} exec deployment/automation-controller-web -- /bin/bash -c "{container_cmd}"'
+        print('Running OpenShift:', oc_cmd)
+        return subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)
+
+    else:
+        raise ValueError(f'Unsupported environment: {ENVIRONMENT}')
+
+
+def oc_login():
+    # subprocess run
+    subprocess.run(OC_LOGIN_COMMAND, shell=True)
+
+
+def list_gathered_files(config):
+    """
+    List the files that were gathered in the ship directory.
+    """
+    ship_path = config.get('METRICS_UTILITY_SHIP_PATH', path_to_shipped_data)
+    print(f'\n=== Listing gathered files in {ship_path} ===')
+
+    if ENVIRONMENT == 'local':
+        # For local environment, list files in the docker container
+        docker_cmd = [
+            'docker',
+            'exec',
+            'tools_awx_1',
+            '/bin/sh',
+            '-c',
+            f'cd awx-dev/metrics-utility && find {ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"',
+        ]
+        print('Running local ls:', ' '.join(docker_cmd))
+        result = subprocess.run(docker_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'RPM':
+        # RPM deployment via SSH
+        if not SSH_URL or not SSH_USER:
+            print('SSH_URL and SSH_USER must be set for RPM environment')
+            return
+
+        ssh_cmd = ['ssh', f'{SSH_USER}@{SSH_URL}', f'find {ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"']
+        print('Running RPM ls:', ' '.join(ssh_cmd))
+        result = subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'containerized':
+        # Containerized deployment via SSH with podman
+        if not SSH_URL or not SSH_USER:
+            print('SSH_URL and SSH_USER must be set for containerized environment')
+            return
+
+        container_cmd = f'find /var/lib/awx/{ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
+        remote_command = f'echo "{container_cmd}" | podman exec -i automation-controller-web /bin/bash'
+        ssh_cmd = ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command]
+        print('Running containerized ls:', ' '.join(ssh_cmd))
+        result = subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
+
+    elif ENVIRONMENT == 'OpenShift':
+        # OpenShift deployment via oc command
+        container_cmd = f'find /var/lib/awx/{ship_path} -type f -ls 2>/dev/null || echo "No files found or directory does not exist"'
+        oc_cmd = f'{OC_COMMAND} exec deployment/automation-controller-web -- /bin/bash -c "{container_cmd}"'
+        print('Running OpenShift ls:', oc_cmd)
+        result = subprocess.run(oc_cmd, shell=True, check=False, capture_output=True, text=True)
+
+    else:
+        print(f'Unsupported environment for listing files: {ENVIRONMENT}')
+        return
+
+    # Print the results
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
 
 def main():
+    if ENVIRONMENT == 'OpenShift':
+        oc_login()
+
     config = get_metrics_utility_config()
 
     for since, until in month_ranges(START_DATE, END_DATE):
@@ -80,28 +225,11 @@ def main():
             '--force',
         ]
 
-        if SSH_URL and SSH_USER:
-            # Build remote SSH command list
-            env_list = [f'{k}={v}' for k, v in config.items()]
-            ssh_cmd = ['ssh', f'{SSH_USER}@{SSH_URL}', 'sudo', '-E', 'env', *env_list, 'metrics-utility', *args]
-            print('Running remote:', ' '.join(ssh_cmd))
-            result = subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
-        else:
-            # Local docker exec path
-            docker_env = []
-            for k, v in config.items():
-                docker_env += ['-e', f'{k}={v}']
-            docker_cmd = [
-                'docker',
-                'exec',
-                *docker_env,
-                'tools_awx_1',
-                '/bin/sh',
-                '-c',
-                f'cd awx-dev/metrics-utility && . /var/lib/awx/venv/awx/bin/activate && python3 ./manage.py {" ".join(args)}',
-            ]
-            print('Running local:', ' '.join(docker_cmd))
-            result = subprocess.run(docker_cmd, check=False, capture_output=True, text=True)
+        try:
+            result = run_command(args, config)
+        except ValueError as e:
+            print(f'Configuration error: {e}', file=sys.stderr)
+            sys.exit(1)
 
         # Print output
         if result.stdout:
@@ -110,6 +238,9 @@ def main():
             print(result.stderr, file=sys.stderr)
 
         # Continue through all date ranges (no premature exit)
+
+    # List all gathered files after completion
+    list_gathered_files(config)
 
 
 if __name__ == '__main__':

--- a/testathon/helper_ocp_prepare.py
+++ b/testathon/helper_ocp_prepare.py
@@ -1,10 +1,26 @@
-# Accepts token and server url and creates env variables
-
-# We know OC_LOGIN_COMMAND, now we wants to create OC_COMMAND
-# Get namespace, begins with aap, run subprocess
-
 import os
 import subprocess
+
+
+def get_controller_pod_name(aap_namespace):
+    """Get controller pod name using oc command"""
+
+    result = subprocess.run(['oc', 'get', 'pods', '-n', aap_namespace], capture_output=True, text=True, check=True)
+    pods_text = result.stdout.strip()
+
+    # split them into lines
+    pods = pods_text.split('\n')
+
+    for pod in pods:
+        # search for pod name that contains 'controller-task'
+        if 'controller-task' in pod:
+            # select only the pod name - first word
+            pod_name = pod.split()[0]
+            print(f'pod_name found: {pod_name}')
+            return pod_name
+
+    print('No controller pod found')
+    return None
 
 
 def get_aap_namespace():
@@ -34,29 +50,8 @@ def get_aap_namespace():
         return None
 
 
-def get_controller_pod_name(aap_namespace):
-    """Get controller pod name using oc command"""
-
-    result = subprocess.run(['oc', 'get', 'pods', '-n', aap_namespace], capture_output=True, text=True, check=True)
-    pods_text = result.stdout.strip()
-
-    # split them into lines
-    pods = pods_text.split('\n')
-
-    for pod in pods:
-        # search for pod name that contains 'controller-task'
-        if 'controller-task' in pod:
-            # select only the pod name - first word
-            pod_name = pod.split()[0]
-            print(f'pod_name found: {pod_name}')
-            return pod_name
-
-    print('No controller pod found')
-    return None
-
-
-def create_oc_command():
-    """Create OC_COMMAND environment variable with the aap namespace"""
+def create_oc_environs():
+    """Create POD_NAME and NAMESPACE environment variables with the aap namespace"""
     aap_namespace = get_aap_namespace()
 
     print(f'aap_namespace found: {aap_namespace}')
@@ -65,13 +60,9 @@ def create_oc_command():
 
     print(f'pod_name found: {pod_name}')
 
-    # create OC_COMMAND
-    oc_command = f'oc exec -n {aap_namespace} {pod_name}'
-    print(f'OC_COMMAND: {oc_command}')
+    # create POD_NAME and NAMESPACE
+    os.environ['POD_NAME'] = pod_name
+    os.environ['NAMESPACE'] = aap_namespace
 
-    # set env variable
-    os.environ['OC_COMMAND'] = oc_command
-
-
-if __name__ == '__main__':
-    create_oc_command()
+    print(f'POD_NAME: {os.getenv("POD_NAME")}')
+    print(f'NAMESPACE: {os.getenv("NAMESPACE")}')

--- a/testathon/helper_ocp_prepare.py
+++ b/testathon/helper_ocp_prepare.py
@@ -1,0 +1,77 @@
+# Accepts token and server url and creates env variables
+
+# We know OC_LOGIN_COMMAND, now we wants to create OC_COMMAND
+# Get namespace, begins with aap, run subprocess
+
+import os
+import subprocess
+
+
+def get_aap_namespace():
+    """Get namespace that begins with 'aap' using oc command"""
+    try:
+        # Run oc get namespaces command and filter for those starting with 'aap'
+        result = subprocess.run(
+            ['oc', 'get', 'namespaces', '--no-headers', '-o', 'custom-columns=NAME:.metadata.name'], capture_output=True, text=True, check=True
+        )
+
+        # Filter namespaces that start with 'aap'
+        namespaces = result.stdout.strip().split('\n')
+        aap_namespaces = [ns for ns in namespaces if ns.startswith('aap')]
+
+        if aap_namespaces:
+            # Return the first aap namespace found
+            return aap_namespaces[0]
+        else:
+            print("No namespace starting with 'aap' found")
+            return None
+
+    except subprocess.CalledProcessError as e:
+        print(f'Error running oc command: {e}')
+        return None
+    except FileNotFoundError:
+        print('oc command not found. Make sure OpenShift CLI is installed and in PATH')
+        return None
+
+
+def get_controller_pod_name(aap_namespace):
+    """Get controller pod name using oc command"""
+
+    result = subprocess.run(['oc', 'get', 'pods', '-n', aap_namespace], capture_output=True, text=True, check=True)
+    pods_text = result.stdout.strip()
+
+    # split them into lines
+    pods = pods_text.split('\n')
+
+    for pod in pods:
+        # search for pod name that contains 'controller-task'
+        if 'controller-task' in pod:
+            # select only the pod name - first word
+            pod_name = pod.split()[0]
+            print(f'pod_name found: {pod_name}')
+            return pod_name
+
+    print('No controller pod found')
+    return None
+
+
+def create_oc_command():
+    """Create OC_COMMAND environment variable with the aap namespace"""
+    aap_namespace = get_aap_namespace()
+
+    print(f'aap_namespace found: {aap_namespace}')
+
+    pod_name = get_controller_pod_name(aap_namespace)
+
+    print(f'pod_name found: {pod_name}')
+
+    # create OC_COMMAND
+    oc_command = f'oc exec -n {aap_namespace} {pod_name}'
+    print(f'OC_COMMAND: {oc_command}')
+
+    # set env variable
+    os.environ['OC_COMMAND'] = oc_command
+
+
+if __name__ == '__main__':
+    create_oc_command()

--- a/testathon/printvars.py
+++ b/testathon/printvars.py
@@ -3,16 +3,7 @@
 import os
 
 
-env_vars = [
-    'API_URL',
-    'USERNAME',
-    'PASSWORD',
-    'SSH_URL',
-    'SSH_USER',
-    'ENVIRONMENT',
-    'OC_COMMAND',
-    'OC_LOGIN_COMMAND'
-]
+env_vars = ['API_URL', 'USERNAME', 'PASSWORD', 'SSH_URL', 'SSH_USER', 'ENVIRONMENT', 'OC_COMMAND', 'OC_LOGIN_COMMAND']
 
 for var in env_vars:
     value = os.getenv(var)

--- a/testathon/printvars.py
+++ b/testathon/printvars.py
@@ -3,7 +3,7 @@
 import os
 
 
-env_vars = ['API_URL', 'USERNAME', 'PASSWORD', 'SSH_URL', 'SSH_USER', 'ENVIRONMENT', 'OC_COMMAND', 'OC_LOGIN_COMMAND']
+env_vars = ['API_URL', 'USERNAME', 'PASSWORD', 'SSH_URL', 'SSH_USER', 'ENVIRONMENT', 'POD_NAME', 'NAMESPACE', 'OC_LOGIN_COMMAND']
 
 for var in env_vars:
     value = os.getenv(var)

--- a/testathon/printvars.py
+++ b/testathon/printvars.py
@@ -10,6 +10,8 @@ env_vars = [
     'SSH_URL',
     'SSH_USER',
     'ENVIRONMENT',
+    'OC_COMMAND',
+    'OC_LOGIN_COMMAND'
 ]
 
 for var in env_vars:

--- a/testathon/printvars.py
+++ b/testathon/printvars.py
@@ -1,0 +1,20 @@
+# print env vars used in testathon_data_prepare.py that are set in terminal
+
+import os
+
+
+env_vars = [
+    'API_URL',
+    'USERNAME',
+    'PASSWORD',
+    'SSH_URL',
+    'SSH_USER',
+    'ENVIRONMENT',
+]
+
+for var in env_vars:
+    value = os.getenv(var)
+    if value:
+        print(f'{var} = {value!r}')
+    else:
+        print(f'{var} = None')

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -48,6 +48,114 @@ export SSH_URL='54.90.173.180'
 
 uv run testathon_data_prepare.py
 
+## Containerized build
+
+Containerized build runs in one server and each service runs in containers.
+
+You can access it also using SSH and classic URL, the script then connect to the container by itself.
+
+## Openshift build
+
+This build is very different. 
+
+First, ensure oc is installed on the machine.
+
+You need to fill two env variables:
+
+OC_LOGIN_COMMAND
+OC_COMMAND
+
+Oc login command is used to login only once. It needs token.
+Oc command is command that will acess the pod and allows execution of console command.
+
+Below will be description how to obtain these two variables. Now we will show examples:
+
+
+
+
+
+Below is detailed description by Mauricio Magnani and Apurva.
+
+### Step 1: Access OpenShift Web Console
+
+Open the hive_cluster_claim.yml file
+
+Locate the hive_cluster_deployment_web_console_url field
+
+Copy the URL (example: https://console-openshift-console.apps.aap-test-v418-x86-64-klfxw.ocp4.testing.ansible.com)
+
+Open the URL in your web browser
+
+### Step 2: Login to OpenShift Console
+
+Username: kubeadmin
+Password: Retrieve from the hive_cluster_claim_admin_password file
+
+Click Log in
+
+### Step 3: Configure CLI Access
+
+In the OpenShift web console, click on kube:admin (top right corner)
+
+Select Copy login command
+
+A new tab will open - click Display Token
+
+Copy the command under Log in with this token
+
+Paste and execute the command in your terminal
+
+
+### Step 4: Identify AAP Namespace
+
+First, determine what is the AAP namespace. Go to the web console, tab Namespaces. Search for the namespace that
+begins by aap (it changes).
+
+For example, it can be aap-wrongly-airedale
+
+Run the following command to list all pods in the AAP namespace:
+
+oc get pods -n aap-wrongly-airedale
+You should see output similar to:
+NAME                                                              READY   STATUS      RESTARTS   AGE
+2c5b7eff00e099e06640bb667ad004d92f6d3f1c8d4e261bf38f6d14956jxnp   0/1     Completed   0          128m
+aap-bf37650a-controller-migration-4.6.19-xpxfc                    0/1     Completed   0          121m
+aap-bf37650a-controller-task-7798677c6c-zxmgz                     4/4     Running     0          122m
+aap-bf37650a-controller-web-bb766d678-fqq78                       3/3     Running     0          122m
+aap-bf37650a-eda-activation-worker-54885997c5-l2mj9               1/1     Running     0          122m
+aap-bf37650a-eda-activation-worker-54885997c5-zzzxd               1/1     Running     0          122m
+aap-bf37650a-eda-api-865c748b57-v9plc                             3/3     Running     0          122m
+aap-bf37650a-eda-default-worker-d4fc96799-d8h44                   1/1     Running     0          122m
+aap-bf37650a-eda-default-worker-d4fc96799-zjlgl                   1/1     Running     0          122m
+aap-bf37650a-eda-event-stream-7f7b458c69-cmb8q                    2/2     Running     0          122m
+aap-bf37650a-eda-scheduler-57459b79b-sfht8                        1/1     Running     0          122m
+aap-bf37650a-eda-scheduler-57459b79b-wd8hk                        1/1     Running     0          122m
+aap-bf37650a-gateway-5dffd658-8rm9x                               2/2     Running     0          125m
+aap-bf37650a-hub-api-7f5bb74cd-r7qqx                              1/1     Running     0          122m
+aap-bf37650a-hub-content-74b6bdbc89-2wpj7                         1/1     Running     0          122m
+aap-bf37650a-hub-content-74b6bdbc89-7vbw5                         1/1     Running     0          122m
+aap-bf37650a-hub-redis-7757c684d-82slk                            1/1     Running     0          122m
+aap-bf37650a-hub-web-fd448b87f-l4mpq                              1/1     Running     0          122m
+aap-bf37650a-hub-worker-7489896757-cr5zh                          1/1     Running     0          122m
+aap-bf37650a-hub-worker-7489896757-zxndz                          1/1     Running     0          122m
+aap-bf37650a-postgres-15-0                                        1/1     Running     0          126m
+aap-bf37650a-redis-0                                              1/1     Running     0          126m
+aap-gateway-operator-controller-manager-7b786c9897-qpfzv          2/2     Running     0          128m
+ansible-lightspeed-operator-controller-manager-9584689f5-v7vr6    2/2     Running     0          128m
+automation-controller-operator-controller-manager-5f48c466792dt   2/2     Running     0          128m
+automation-hub-operator-controller-manager-658b7cf6c7-ltznv       2/2     Running     0          128m
+cvporiib-bgrkp                                                    1/1     Running     0          130m
+eda-server-operator-controller-manager-5ccf6f4b74-w2g9m           2/2     Running     0          128m
+resource-operator-controller-manager-5dcc57b745-p9nmx             2/2     Running     0          128m
+
+### Step 5: Access Controller Pod Shell
+
+Connect to the controller task pod using remote shell:
+oc rsh -n aap-wrongly-airedale aap-bf37650a-controller-task-7798677c6c-zxmgz
+
+Once inside the pod shell, you can use the metrics-utility command
+
+
 # gather_all
 
 Gather all gathers whole data from begining to datetime now. It uses SSH_URL and SSH_USER as previous script.

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -73,10 +73,14 @@ Below will be description how to obtain these two variables. Now we will show ex
 OC_LOGIN_COMMAND:
 oc login --token={token} --server=https://api.aap-test-v418-x86-64-knmrp.ocp4.testing.ansible.com:6443
 
+Follow steps 1-3 below to fill OC_LOGIN_COMMAND
+
 OC_COMMAND:
+Will be computed on the fly if you run helper_ocp_prepare and will look something like this:
+
 oc exec -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
 
-
+If you want to set it manually, fully follow steps below.
 
 Below is detailed description by Mauricio Magnani and Apurva.
 

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -30,6 +30,11 @@ Script will directly connect using SSH and do some modification to DB.
 
 If the server is on VPN, do not forget to connect on VPN.
 
+Script will repeatedly ask for passphrase for SSH key, for example:
+Enter passphrase for key '/home/milan/.ssh/id_ed19561'
+
+You can add it before script running:
+
 ## RPM Example:
 
 export PASSWORD='**Fill here**'

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -82,6 +82,8 @@ oc exec -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
 
 If you want to set it manually, fully follow steps below.
 
+For manual access: instead of oc exec, use oc rsh
+
 Below is detailed description by Mauricio Magnani and Apurva.
 
 ### Step 1: Access OpenShift Web Console

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -70,7 +70,11 @@ Oc command is command that will acess the pod and allows execution of console co
 
 Below will be description how to obtain these two variables. Now we will show examples:
 
+OC_LOGIN_COMMAND:
+oc login --token={token} --server=https://api.aap-test-v418-x86-64-knmrp.ocp4.testing.ansible.com:6443
 
+OC_COMMAND:
+oc rsh -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
 
 
 

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -35,6 +35,8 @@ Enter passphrase for key '/home/milan/.ssh/id_ed19561'
 
 You can add it before script running:
 
+ssh-add ~/.ssh/id_ed19561
+
 ## RPM Example:
 
 export PASSWORD='**Fill here**'

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -1,4 +1,8 @@
-# testathon_data_prepare
+# printvars.py
+
+This will print env vars that are used in scripts. Its better than printvars command, more readable.
+
+# testathon_data_prepare.py
 
 If you run this directly without any parameters, it will prepopulate local environment db, provided that it runs
 at this url:
@@ -37,6 +41,10 @@ You can add it before script running:
 
 ssh-add ~/.ssh/id_ed19561
 
+You will find API_URL as gateway URL in inventory artifact of jenkins.
+
+SSH_URL is IP of controller server.
+
 ## RPM Example:
 
 export PASSWORD='**Fill here**'
@@ -53,6 +61,10 @@ uv run testathon_data_prepare.py
 Containerized build runs in one server and each service runs in containers.
 
 You can access it also using SSH and classic URL, the script then connect to the container by itself.
+
+SSH will be again for controller.
+
+You will find it again in inventory file of jenkins artifact.
 
 ## Openshift build
 
@@ -157,9 +169,9 @@ oc rsh -n aap-wrongly-airedale aap-bf37650a-controller-task-7798677c6c-zxmgz
 Once inside the pod shell, you can use the metrics-utility command
 
 
-# gather_all
+# gather_all.py
 
-Gather all gathers whole data from begining to datetime now. It uses SSH_URL and SSH_USER as previous script.
+Gather all gathers whole data from begining to datetime now. It uses the same env variables as previous script.
 
 ## Gather all example
 

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -60,29 +60,20 @@ This build is very different.
 
 First, ensure oc is installed on the machine.
 
-You need to fill two env variables:
+You need to fill this env variable:
 
 OC_LOGIN_COMMAND
-OC_COMMAND
 
 Oc login command is used to login only once. It needs token.
-Oc command is command that will acess the pod and allows execution of console command.
 
-Below will be description how to obtain these two variables. Now we will show examples:
+Below will be description how to obtain this variable. Now we will show examples:
 
 OC_LOGIN_COMMAND:
 oc login --token={token} --server=https://api.aap-test-v418-x86-64-knmrp.ocp4.testing.ansible.com:6443
 
 Follow steps 1-3 below to fill OC_LOGIN_COMMAND
 
-OC_COMMAND:
-Will be computed on the fly if you run helper_ocp_prepare and will look something like this:
-
-oc exec -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
-
-If you want to set it manually, fully follow steps below.
-
-For manual access: instead of oc exec, use oc rsh
+POD_NAME and NAMESPACE is optional env variables, it will be computed on the fly if not empty, otherwise used.
 
 Below is detailed description by Mauricio Magnani and Apurva.
 

--- a/testathon/readme.md
+++ b/testathon/readme.md
@@ -74,7 +74,7 @@ OC_LOGIN_COMMAND:
 oc login --token={token} --server=https://api.aap-test-v418-x86-64-knmrp.ocp4.testing.ansible.com:6443
 
 OC_COMMAND:
-oc rsh -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
+oc exec -n aap-wrongly-airedale aap-cc3e0aa2-controller-task-5d75cd9d68-sz9kp
 
 
 

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -35,8 +35,9 @@ print(f'PASSWORD: {PASSWORD}')
 print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
 print(f'ENVIRONMENT: {ENVIRONMENT}')
-print(f'OC_COMMAND: {OC_COMMAND}')
 print(f'OC_LOGIN_COMMAND: {OC_LOGIN_COMMAND}')
+print(f'OC_COMMAND: {OC_COMMAND}')
+
 
 VERIFY_SSL = False  # Set to True if you have valid SSL certificates
 PAGE_SIZE = 100
@@ -76,16 +77,43 @@ def run(sql_script):
             stderr = process.stderr
 
         if ENVIRONMENT == 'OpenShift':
-            print('openshift')
-            # base64-encode the whole SQL to avoid quote issues
-            b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
-            remote_command = f"{OC_COMMAND} sh -c 'echo {b64} | base64 --decode | awx-manage dbshell'"
+            # extract pod name from OC_COMMAND
+            pod_name = OC_COMMAND.split()[-1]
+            # extract namespace from OC_COMMAND
+            namespace = OC_COMMAND.split()[-2]
 
-            print('remote command: ', remote_command)
+            print(f'pod_name: {pod_name}')
+            print(f'namespace: {namespace}')
 
-            process = subprocess.run(remote_command, check=True, shell=True, capture_output=True, text=True)
-            stdout = process.stdout
-            stderr = process.stderr
+            # run the command
+            # sql_script is the variable that contains the sql script
+            # forget the OC_COMMAND, use the pod name and namespace to run the command
+            # note that -c does not work for dbshell
+
+            # pipe sql script to the command
+            command = [
+                'oc',
+                'exec',
+                '-i',  # keep STDIN open
+                '-n',
+                namespace,
+                pod_name,
+                '--',
+                'awx-manage',
+                'dbshell',
+            ]
+
+            # Run the command and pipe the SQL into STDIN
+            result = subprocess.run(
+                command,
+                input=sql_script,  # <<–– here's where the script goes
+                text=True,  # treat stdin/stdout as str instead of bytes
+                capture_output=True,  # optional: collect results for logging
+                check=True,  # raise if the command fails
+            )
+
+            stdout = result.stdout
+            stderr = result.stderr
 
         print(stderr)
         return stdout
@@ -431,6 +459,8 @@ def oc_login():
 def main():
     if ENVIRONMENT == 'OpenShift':
         oc_login()
+
+    list_main_jobhostsummary()
 
     delete_main_project()
 

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -69,11 +69,13 @@ def run(sql_script):
 
         if ENVIRONMENT == 'OpenShift':
             print('openshift')
-            remote_command = f'{OC_COMMAND} sh -c \'echo "{sql_script}" | awx-manage dbshell\''
+            # base64-encode the whole SQL to avoid quote issues
+            b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
+            remote_command = f'{OC_COMMAND} sh -c \'echo {b64} | base64 --decode | awx-manage dbshell\''
 
             print('remote command: ', remote_command)
 
-            process = subprocess.run(remote_command, check=True, shell=True)
+            process = subprocess.run(remote_command, check=True, shell=True, capture_output=True, text=True)
             stdout = process.stdout
             stderr = process.stderr
 

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -56,19 +56,11 @@ def run(sql_script):
         if ENVIRONMENT == 'containerized':
             # base64-encode the whole SQL
             b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
-            remote_command = (
-                f"echo {b64} | base64 --decode | "
-                f"podman exec -i automation-controller-web awx-manage dbshell"
-            )
-            print("remote_command:", remote_command)
-            process = subprocess.run(
-                ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command],
-                capture_output=True, text=True
-            )
+            remote_command = f'echo {b64} | base64 --decode | podman exec -i automation-controller-web awx-manage dbshell'
+            print('remote_command:', remote_command)
+            process = subprocess.run(['ssh', f'{SSH_USER}@{SSH_URL}', remote_command], capture_output=True, text=True)
             stdout = process.stdout
             stderr = process.stderr
-
-
 
         if ENVIRONMENT == 'OpenShift':
             pass

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -14,7 +14,7 @@ USERNAME = os.getenv('USERNAME', 'admin')
 PASSWORD = os.getenv('PASSWORD', 'admin')
 
 SSH_URL = os.getenv('SSH_URL', None)
-SSH_USER = os.getenv('SSH_USER', None)
+SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
 print(f'API_URL: {API_URL}')
 print(f'USERNAME: {USERNAME}')

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -16,6 +16,9 @@ PASSWORD = os.getenv('PASSWORD', 'admin')
 SSH_URL = os.getenv('SSH_URL', None)
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
+OC_COMMAND = os.getenv('OC_COMMAND', 'oc')
+OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', 'oc login')
+
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
 
 print(f'API_URL: {API_URL}')
@@ -24,6 +27,8 @@ print(f'PASSWORD: {PASSWORD}')
 print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
 print(f'ENVIRONMENT: {ENVIRONMENT}')
+print(f'OC_COMMAND: {OC_COMMAND}')
+print(f'OC_LOGIN_COMMAND: {OC_LOGIN_COMMAND}')
 
 VERIFY_SSL = False  # Set to True if you have valid SSL certificates
 PAGE_SIZE = 100
@@ -57,13 +62,20 @@ def run(sql_script):
             # base64-encode the whole SQL
             b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
             remote_command = f'echo {b64} | base64 --decode | podman exec -i automation-controller-web awx-manage dbshell'
-            print('remote_command:', remote_command)
+            print('remote command:', remote_command)
             process = subprocess.run(['ssh', f'{SSH_USER}@{SSH_URL}', remote_command], capture_output=True, text=True)
             stdout = process.stdout
             stderr = process.stderr
 
         if ENVIRONMENT == 'OpenShift':
-            pass
+            print('openshift')
+            remote_command = f'{OC_COMMAND} sh -c \'echo "{sql_script}" | awx-manage dbshell\''
+
+            print('remote command: ', remote_command)
+
+            process = subprocess.run(remote_command, check=True, shell=True)
+            stdout = process.stdout
+            stderr = process.stderr
 
         print(stderr)
         return stdout
@@ -401,7 +413,15 @@ def set_different_modified_dates(dates):
     run(sql_update)
 
 
+def oc_login():
+    # subprocess run
+    subprocess.run(OC_LOGIN_COMMAND, shell=True)
+
+
 def main():
+    if ENVIRONMENT == 'OpenShift':
+        oc_login()
+
     delete_main_project()
 
     delete_job_templates()

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -21,6 +21,14 @@ OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
 
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
 
+if OC_COMMAND is not None and len(OC_COMMAND) > 0:
+    # command must begin with 'oc exec'
+    if not OC_COMMAND.startswith('oc exec'):
+        raise ValueError('OC_COMMAND must begin with "oc exec"')
+
+    if OC_COMMAND.startswith('oc rsh'):
+        raise ValueError('OC_COMMAND must not begin with "oc rsh"')
+
 print(f'API_URL: {API_URL}')
 print(f'USERNAME: {USERNAME}')
 print(f'PASSWORD: {PASSWORD}')

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -402,7 +402,6 @@ def set_different_modified_dates(dates):
 
 
 def main():
-    delete_main_jobhostsummary()
     delete_main_project()
 
     delete_job_templates()

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -16,8 +16,8 @@ PASSWORD = os.getenv('PASSWORD', 'admin')
 SSH_URL = os.getenv('SSH_URL', None)
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
-OC_COMMAND = os.getenv('OC_COMMAND', 'oc')
-OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', 'oc login')
+OC_COMMAND = os.getenv('OC_COMMAND', '')
+OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
 
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
 
@@ -71,7 +71,7 @@ def run(sql_script):
             print('openshift')
             # base64-encode the whole SQL to avoid quote issues
             b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
-            remote_command = f'{OC_COMMAND} sh -c \'echo {b64} | base64 --decode | awx-manage dbshell\''
+            remote_command = f"{OC_COMMAND} sh -c 'echo {b64} | base64 --decode | awx-manage dbshell'"
 
             print('remote command: ', remote_command)
 

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -34,6 +34,7 @@ requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.
 
 def run(sql_script):
     try:
+        print(sql_script)
         stderr = ''
         stdout = ''
         if ENVIRONMENT == 'local':
@@ -50,17 +51,24 @@ def run(sql_script):
             stderr = process.stderr.decode()
             stdout = process.stdout.decode()
 
+        import base64
+
         if ENVIRONMENT == 'containerized':
-            ssh_command = [
-                'ssh',
-                f'{SSH_USER}@{SSH_URL}',
-                # here, we're giving ssh ONE single remote‐command string:
-                'podman exec -i automation-controller-web bash -lc \'echo "{}" | awx-manage dbshell\''.format(sql_script.strip().replace('"', '\\"')),
-            ]
-            print('ssh_command:', ssh_command)
-            process = subprocess.run(ssh_command, capture_output=True, text=True)
+            # base64-encode the whole SQL
+            b64 = base64.b64encode(sql_script.encode('utf-8')).decode('ascii')
+            remote_command = (
+                f"echo {b64} | base64 --decode | "
+                f"podman exec -i automation-controller-web awx-manage dbshell"
+            )
+            print("remote_command:", remote_command)
+            process = subprocess.run(
+                ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command],
+                capture_output=True, text=True
+            )
             stdout = process.stdout
             stderr = process.stderr
+
+
 
         if ENVIRONMENT == 'OpenShift':
             pass

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -31,17 +31,21 @@ requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.
 
 
 def run(sql_script):
-    if SSH_URL is None:
-        command = ['docker', 'exec', '-i', 'tools_postgres_1', 'psql', '-U', 'awx']
-        process = subprocess.run(command, input=sql_script.encode(), capture_output=True)
-    else:
-        # Send SQL script over SSH and pipe it into `sudo awx-manage dbshell`
-        remote_command = f'echo "{sql_script}" | sudo awx-manage dbshell'
-        ssh_command = ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command]
-        process = subprocess.run(ssh_command, capture_output=True)
+    try:
+        if SSH_URL is None:
+            command = ['docker', 'exec', '-i', 'tools_postgres_1', 'psql', '-U', 'awx']
+            process = subprocess.run(command, input=sql_script.encode(), capture_output=True)
+        else:
+            # Send SQL script over SSH and pipe it into `sudo awx-manage dbshell`
+            remote_command = f'echo "{sql_script}" | sudo awx-manage dbshell'
+            ssh_command = ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command]
+            process = subprocess.run(ssh_command, capture_output=True)
 
-    print(process.stderr.decode())
-    return process.stdout.decode()
+        print(process.stderr.decode())
+        return process.stdout.decode()
+    except Exception as e:
+        print(f'Failed to run SQL script: {e}')
+        return ''
 
 
 def delete_job_templates():
@@ -90,6 +94,7 @@ def delete_job_template(id):
 
 def delete_main_project():
     # delete mock project
+
     url = f'{API_URL}/projects/?name=MockA_Test_Project'
     resp = requests.get(url, auth=(USERNAME, PASSWORD), verify=VERIFY_SSL)
     data = resp.json()

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -16,12 +16,14 @@ PASSWORD = os.getenv('PASSWORD', 'admin')
 SSH_URL = os.getenv('SSH_URL', None)
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
+
 print(f'API_URL: {API_URL}')
 print(f'USERNAME: {USERNAME}')
 print(f'PASSWORD: {PASSWORD}')
 print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
-
+print(f'ENVIRONMENT: {ENVIRONMENT}')
 
 VERIFY_SSL = False  # Set to True if you have valid SSL certificates
 PAGE_SIZE = 100
@@ -32,17 +34,39 @@ requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.
 
 def run(sql_script):
     try:
-        if SSH_URL is None:
+        stderr = ''
+        stdout = ''
+        if ENVIRONMENT == 'local':
             command = ['docker', 'exec', '-i', 'tools_postgres_1', 'psql', '-U', 'awx']
             process = subprocess.run(command, input=sql_script.encode(), capture_output=True)
-        else:
+            stderr = process.stderr.decode()
+            stdout = process.stdout.decode()
+
+        if ENVIRONMENT == 'RPM':
             # Send SQL script over SSH and pipe it into `sudo awx-manage dbshell`
             remote_command = f'echo "{sql_script}" | sudo awx-manage dbshell'
             ssh_command = ['ssh', f'{SSH_USER}@{SSH_URL}', remote_command]
             process = subprocess.run(ssh_command, capture_output=True)
+            stderr = process.stderr.decode()
+            stdout = process.stdout.decode()
 
-        print(process.stderr.decode())
-        return process.stdout.decode()
+        if ENVIRONMENT == 'containerized':
+            ssh_command = [
+                'ssh',
+                f'{SSH_USER}@{SSH_URL}',
+                # here, we're giving ssh ONE single remote‐command string:
+                'podman exec -i automation-controller-web bash -lc \'echo "{}" | awx-manage dbshell\''.format(sql_script.strip().replace('"', '\\"')),
+            ]
+            print('ssh_command:', ssh_command)
+            process = subprocess.run(ssh_command, capture_output=True, text=True)
+            stdout = process.stdout
+            stderr = process.stderr
+
+        if ENVIRONMENT == 'OpenShift':
+            pass
+
+        print(stderr)
+        return stdout
     except Exception as e:
         print(f'Failed to run SQL script: {e}')
         return ''
@@ -378,6 +402,7 @@ def set_different_modified_dates(dates):
 
 
 def main():
+    delete_main_jobhostsummary()
     delete_main_project()
 
     delete_job_templates()

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -5,6 +5,8 @@ import time
 
 import requests
 
+from helper_ocp_prepare import create_oc_environs
+
 
 # Configuration
 
@@ -16,18 +18,9 @@ PASSWORD = os.getenv('PASSWORD', 'admin')
 SSH_URL = os.getenv('SSH_URL', None)
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
-OC_COMMAND = os.getenv('OC_COMMAND', '')
 OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
 
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
-
-if OC_COMMAND is not None and len(OC_COMMAND) > 0:
-    # command must begin with 'oc exec'
-    if not OC_COMMAND.startswith('oc exec'):
-        raise ValueError('OC_COMMAND must begin with "oc exec"')
-
-    if OC_COMMAND.startswith('oc rsh'):
-        raise ValueError('OC_COMMAND must not begin with "oc rsh"')
 
 print(f'API_URL: {API_URL}')
 print(f'USERNAME: {USERNAME}')
@@ -36,7 +29,10 @@ print(f'SSH_URL: {SSH_URL}')
 print(f'SSH_USER: {SSH_USER}')
 print(f'ENVIRONMENT: {ENVIRONMENT}')
 print(f'OC_LOGIN_COMMAND: {OC_LOGIN_COMMAND}')
-print(f'OC_COMMAND: {OC_COMMAND}')
+
+if os.getenv('POD_NAME') and os.getenv('NAMESPACE'):
+    print(f'POD_NAME: {os.getenv("POD_NAME")}')
+    print(f'NAMESPACE: {os.getenv("NAMESPACE")}')
 
 
 VERIFY_SSL = False  # Set to True if you have valid SSL certificates
@@ -78,9 +74,8 @@ def run(sql_script):
 
         if ENVIRONMENT == 'OpenShift':
             # extract pod name from OC_COMMAND
-            pod_name = OC_COMMAND.split()[-1]
-            # extract namespace from OC_COMMAND
-            namespace = OC_COMMAND.split()[-2]
+            pod_name = os.getenv('POD_NAME')
+            namespace = os.getenv('NAMESPACE')
 
             print(f'pod_name: {pod_name}')
             print(f'namespace: {namespace}')
@@ -459,6 +454,8 @@ def oc_login():
 def main():
     if ENVIRONMENT == 'OpenShift':
         oc_login()
+        if not os.getenv('POD_NAME') or not os.getenv('NAMESPACE'):
+            create_oc_environs()
 
     list_main_jobhostsummary()
 


### PR DESCRIPTION
[[AAP-50701](https://issues.redhat.com/browse/AAP-50701)]

## Description

Allows pushing data into containerized and OCP.

Code to access those environments was added.


## Testing

You can use builds there:
https://jenkins-csb-aap-main.dno.corp.redhat.com/job/AAPQA/job/Sandbox/job/abakshi/job/instances_milan/

But they may be inactive by time of testing, so you will have to rerun them.

More instructions in:
testathon/readme.md


