### PR TITLE
Add dest path in --verbose for gather

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -14,7 +14,7 @@ from django.utils.timezone import now, timedelta
 from django.utils.translation import gettext_lazy as _
 
 from metrics_utility.base import CsvFileSplitter, register
-from metrics_utility.base.utils import get_max_gather_period_days
+from metrics_utility.base.utils import get_max_gather_period_days, get_optional_collectors
 from metrics_utility.logger import logger
 
 
@@ -34,10 +34,6 @@ All functions - when called - will be passed a datetime.datetime object,
 functions - like those that return metadata about playbook runs, may return
 data _since_ the last report date - i.e., new data in the last 24 hours)
 """
-
-
-def get_optional_collectors():
-    return os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
 
 
 def daily_slicing(key, last_gather, **kwargs):

--- a/metrics_utility/automation_controller_billing/package/package_directory.py
+++ b/metrics_utility/automation_controller_billing/package/package_directory.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 
 from django.conf import settings
 
@@ -62,9 +61,7 @@ class PackageDirectory(base.Package):
         os.makedirs(os.path.dirname(destination_path), exist_ok=True)
         shutil.copyfile(self.tar_path, destination_path)
 
-        # if args contains --verbose, print the destination path
-        if '--verbose' in sys.argv:
-            logger.info(f'tarball saved to: {destination_path}')
+        logger.debug(f'tarball saved to: {destination_path}')
 
         self.shipping_successful = True
         return True

--- a/metrics_utility/automation_controller_billing/package/package_directory.py
+++ b/metrics_utility/automation_controller_billing/package/package_directory.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 
 from django.conf import settings
 
@@ -60,6 +61,10 @@ class PackageDirectory(base.Package):
 
         os.makedirs(os.path.dirname(destination_path), exist_ok=True)
         shutil.copyfile(self.tar_path, destination_path)
+
+        # if args contains --verbose, print the destination path
+        if '--verbose' in sys.argv:
+            logger.info(f'tarball saved to: {destination_path}')
 
         self.shipping_successful = True
         return True

--- a/metrics_utility/automation_controller_billing/package/package_s3.py
+++ b/metrics_utility/automation_controller_billing/package/package_s3.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from django.conf import settings
 
@@ -60,6 +61,10 @@ class PackageS3(base.Package):
 
         s3_handler = S3Handler(params=self.collector.billing_provider_params)
         s3_handler.upload_file(self.tar_path, object_name=destination_path)
+
+        # if args contains --verbose, print the destination path
+        if '--verbose' in sys.argv:
+            logger.info(f'tarball saved to: {destination_path}')
 
         self.shipping_successful = True
         return True

--- a/metrics_utility/automation_controller_billing/package/package_s3.py
+++ b/metrics_utility/automation_controller_billing/package/package_s3.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from django.conf import settings
 
@@ -62,9 +61,7 @@ class PackageS3(base.Package):
         s3_handler = S3Handler(params=self.collector.billing_provider_params)
         s3_handler.upload_file(self.tar_path, object_name=destination_path)
 
-        # if args contains --verbose, print the destination path
-        if '--verbose' in sys.argv:
-            logger.info(f'tarball saved to: {destination_path}')
+        logger.debug(f'tarball saved to: {destination_path}')
 
         self.shipping_successful = True
         return True

--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -11,14 +11,13 @@ from abc import abstractmethod
 
 from django.utils.timezone import now, timedelta
 
-from metrics_utility.automation_controller_billing.collectors import get_optional_collectors
 from metrics_utility.logger import logger
 
 from .collection import Collection
 from .collection_csv import CollectionCSV
 from .collection_json import CollectionJSON
 from .package import Package
-from .utils import get_max_gather_period_days
+from .utils import get_max_gather_period_days, get_optional_collectors
 
 
 class Collector:
@@ -293,18 +292,23 @@ class Collector:
         disable_job_host_summary_str = os.environ.get('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
         disable_job_host_summary = disable_job_host_summary_str.lower() == 'true'
 
+        optional_collectors = get_optional_collectors()
+
         for collection in self.collections[Collection.COLLECTION_TYPE_CSV]:
             if last_key != collection.key:
                 write_enabled = False
 
-                if collection.key != 'job_host_summary' or not disable_job_host_summary:
+                if collection.key == 'job_host_summary' and not disable_job_host_summary:
                     write_enabled = True
 
-                if collection.key in get_optional_collectors():
+                if collection.key in optional_collectors:
                     write_enabled = True
 
                 if write_enabled:
                     logger.warning(f'Progress info: Now gathering {collection.key}')
+                else:
+                    logger.warning(f'Progress info: Skipping {collection.key} because it is not enabled.')
+
                 last_key = collection.key
 
             collection.gather(self._package_class().max_data_size())

--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -11,6 +11,7 @@ from abc import abstractmethod
 
 from django.utils.timezone import now, timedelta
 
+from metrics_utility.automation_controller_billing.collectors import get_optional_collectors
 from metrics_utility.logger import logger
 
 from .collection import Collection
@@ -289,9 +290,21 @@ class Collector:
 
         last_key = None
 
+        disable_job_host_summary_str = os.environ.get('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
+        disable_job_host_summary = disable_job_host_summary_str.lower() == 'true'
+
         for collection in self.collections[Collection.COLLECTION_TYPE_CSV]:
             if last_key != collection.key:
-                logger.warning(f'Progress info: Now gathering {collection.key}')
+                write_enabled = False
+
+                if collection.key != 'job_host_summary' or not disable_job_host_summary:
+                    write_enabled = True
+
+                if collection.key in get_optional_collectors():
+                    write_enabled = True
+
+                if write_enabled:
+                    logger.warning(f'Progress info: Now gathering {collection.key}')
                 last_key = collection.key
 
             collection.gather(self._package_class().max_data_size())

--- a/metrics_utility/base/utils.py
+++ b/metrics_utility/base/utils.py
@@ -16,3 +16,11 @@ def get_max_gather_period_days():
         logger.error('METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS can not be converted to an integer')
         # raise original exception
         raise
+
+
+def get_optional_collectors():
+    """
+    Get the list of optional collectors from environment variable.
+    Defaults to 'main_jobevent' if not set.
+    """
+    return os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')


### PR DESCRIPTION
[AAP-[50977](https://issues.redhat.com/browse/AAP-50977)]

## Description

Add small change for better logging the info:

1) with --verbose on, it will log path of stored tarballs
2) when logging start of collecting of collector types, it checks if the collector is on, otherwise it logs that collector is disabled

## Testing
METRICS_UTILITY_SHIP_PATH=/var/tmp/shipped_data METRICS_UTILITY_SHIP_TARGET=directory uv run ./manage.py gather_automation_controller_billing_data --ship --since=2024-02-29 --until=2024-02-29 --force

METRICS_UTILITY_SHIP_PATH=/var/tmp/shipped_data METRICS_UTILITY_SHIP_TARGET=directory uv run ./manage.py gather_automation_controller_billing_data --ship --since=2024-02-29 --until=2024-02-29 --force --verbose


