### PR TITLE
Code cleanup

### DIFF
--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -6,15 +6,18 @@ from metrics_utility.management_utility import ManagementUtility
 
 
 def prepare():
-    # Tries to find awx modules. They are either in venv, or can be configured through AWX_PATH ENV
+    """Tries to find awx modules. Either we're already in the venv, or it can be configured through AWX_PATH, or we fall back to the mock."""
     spec = importlib.util.find_spec('awx')
     if spec is None:
         awx_path = os.getenv('AWX_PATH', '/awx_devel')
         sys.path.append(awx_path)
+
         spec = importlib.util.find_spec('awx')
         if spec is None:
             sys.stderr.write(f'Automation Controller modules not found in {awx_path} (AWX_PATH). Using mock and continuing.\n')
-            sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'mock_awx')))
+
+            mock_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'mock_awx'))
+            sys.path.append(mock_path)
 
     import django
 

--- a/metrics_utility/automation_controller_billing/base/s3_handler.py
+++ b/metrics_utility/automation_controller_billing/base/s3_handler.py
@@ -17,10 +17,6 @@ class S3Handler:
 
         self._session = None
 
-        self.s3 = self.get_s3_resource()
-        self.s3_bucket = self.get_s3_bucket()
-        self.s3_client = self.get_s3_client
-
     @property
     def session(self):
         if self._session is not None:
@@ -90,11 +86,3 @@ class S3Handler:
         for resp in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
             for ret_value in resp.get('Contents', []):
                 yield ret_value['Key']
-
-    def list_subdirs(self, prefix):
-        s3_resource = self.get_s3_resource()
-
-        paginator = s3_resource.meta.client.get_paginator('list_objects')
-        for resp in paginator.paginate(Bucket=self.bucket_name, Delimiter='/', Prefix=prefix):
-            for ret_value in resp.get('CommonPrefixes', []):
-                yield ret_value

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -9,11 +9,6 @@ from django.db import connection
 
 import metrics_utility.base as base
 
-
-# from awx.conf.license import get_license
-# from awx.main.models import Job
-# from awx.main.access import access_registry
-# from rest_framework.exceptions import PermissionDenied
 from metrics_utility.automation_controller_billing.package.factory import Factory as PackageFactory
 from metrics_utility.logger import logger
 
@@ -70,6 +65,7 @@ class Collector(base.Collector):
                 return None
 
             self._gather_json_collections()
+
             # Extend the config collection to contain billing specific info:
             config_collection = self.collections['config']
             data = json.loads(config_collection.data)
@@ -89,19 +85,10 @@ class Collector(base.Collector):
 
     def _is_valid_license(self):
         # TODO: which license to check? Any license will do?
-        #
-        # try:
-        #     if get_license().get('license_type', 'UNLICENSED') == 'open':
-        #         return False
-        #     access_registry[Job](None).check_license()
-        # except PermissionDenied:
-        #     logger.exception("A valid license was not found:")
-        #     return False
         return True
 
     def _is_shipping_configured(self):
         # This check is already done in each Package class
-
         return True
 
     @staticmethod

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -55,7 +55,7 @@ class Collector(base.Collector):
             return None
 
         key = 'gather_automation_controller_billing_lock'
-        suffix = os.environ.get('METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX')
+        suffix = os.getenv('METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX')
         if suffix:
             key = f'gather_automation_controller_billing_{suffix}_lock'
 
@@ -137,7 +137,7 @@ class Collector(base.Collector):
     def _gather_finalize(self):
         """Persisting timestamps (manual/schedule mode only)"""
 
-        disabled_str = os.environ.get('METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES', 'false')
+        disabled_str = os.getenv('METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES', 'false')
         disabled = False
         if disabled_str and (disabled_str.lower() == 'true'):
             disabled = True

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -88,20 +88,25 @@ def limit_slicing(key, last_gather, **kwargs):
     yield (today, today)
 
 
+def get_install_type():
+    if os.getenv('container') == 'oci':
+        return 'openshift'
+
+    if os.getenv('KUBERNETES_SERVICE_PORT'):
+        return 'k8s'
+
+    return 'traditional'
+
+
 @register('config', '1.0', description=_('General platform configuration.'), config=True)
 def config(since, **kwargs):
     license_info = get_license()
-    install_type = 'traditional'
-    if os.getenv('container') == 'oci':
-        install_type = 'openshift'
-    elif 'KUBERNETES_SERVICE_PORT' in os.environ:
-        install_type = 'k8s'
     return {
         'platform': {
             'system': platform.system(),
             'dist': distro.linux_distribution(),
             'release': platform.release(),
-            'type': install_type,
+            'type': get_install_type(),
         },
         'install_uuid': settings.INSTALL_UUID,
         'instance_uuid': settings.SYSTEM_UUID,

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -92,7 +92,7 @@ def limit_slicing(key, last_gather, **kwargs):
 def config(since, **kwargs):
     license_info = get_license()
     install_type = 'traditional'
-    if os.environ.get('container') == 'oci':
+    if os.getenv('container') == 'oci':
         install_type = 'openshift'
     elif 'KUBERNETES_SERVICE_PORT' in os.environ:
         install_type = 'k8s'
@@ -209,7 +209,7 @@ def yaml_and_json_parsing_functions():
 
 @register('job_host_summary', '1.2', format='csv', description=_('Data for billing'), fnc_slicing=daily_slicing)
 def job_host_summary_table(since, full_path, until, **kwargs):
-    disable_job_host_summary_str = os.environ.get('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
+    disable_job_host_summary_str = os.getenv('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
     disable_job_host_summary = False
     if disable_job_host_summary_str and (disable_job_host_summary_str.lower() == 'true'):
         disable_job_host_summary = True
@@ -540,7 +540,7 @@ def total_workers_vcpu(since, full_path, until, **kwargs):
     if 'total_workers_vcpu' not in get_optional_collectors():
         return None
 
-    cluster_name = os.environ.get('METRICS_UTILITY_CLUSTER_NAME')
+    cluster_name = os.getenv('METRICS_UTILITY_CLUSTER_NAME')
     if not cluster_name:
         logger.error('environment variable METRICS_UTILITY_CLUSTER_NAME is not set')
         raise MissingRequiredEnvVar('environment variable METRICS_UTILITY_CLUSTER_NAME is not set')
@@ -549,7 +549,7 @@ def total_workers_vcpu(since, full_path, until, **kwargs):
 
     info = {'cluster_name': cluster_name, 'timestamp': now.isoformat(), 'nodes': []}
     # If METRICS_UTILITY_USAGE_BASED_BILLING_ENABLED is not set or set to false then it returns 1
-    usage_based_billing_enabled_str = os.environ.get('METRICS_UTILITY_USAGE_BASED_BILLING_ENABLED')
+    usage_based_billing_enabled_str = os.getenv('METRICS_UTILITY_USAGE_BASED_BILLING_ENABLED')
     usage_based_billing_enabled = False
     if usage_based_billing_enabled_str and (usage_based_billing_enabled_str.lower() == 'true'):
         usage_based_billing_enabled = True

--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -358,12 +358,6 @@ class DedupRenewalExperimental(BaseDedupRenewal):
                 final_deduped_list.append(merged_data)
                 break
 
-    def _clean_serial_field(self, value):
-        """Clean serial field values similar to existing logic."""
-        if pd.isna(value) or value in ['', 'NA']:
-            return None
-        return value
-
     def _merge_hostname_groups(self, hostname_df, groups_to_merge):
         """Merge multiple hostname groups into a single group."""
         groups_data = hostname_df[hostname_df['hostname'].isin(groups_to_merge)]

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -29,13 +29,13 @@ class PackageCRC(base.Package):
         return os.getenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
 
     def get_proxy_url(self):
-        return os.getenv('METRICS_UTILITY_PROXY_URL', None)
+        return os.getenv('METRICS_UTILITY_PROXY_URL')
 
     def _get_rh_user(self):
-        return os.getenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', None)
+        return os.getenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID')
 
     def _get_rh_password(self):
-        return os.getenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', None)
+        return os.getenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET')
 
     def _get_http_request_headers(self):
         return get_awx_http_client_headers()

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -48,7 +48,7 @@ class PackageCRC(base.Package):
         return self.SHIPPING_AUTH_SERVICE_ACCOUNT
 
     def is_shipping_configured(self):
-        # TODO: move to base
+        # TODO: move to base, or children
         ret = super()
         if ret is False:
             return False

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -63,13 +63,13 @@ class ReportCCSP(Base):
         default_sku_description = [
             ['SKU', 'SKU Description', '', 'Term', 'Unit of Measure', 'Currency', 'MSRP'],
             [
-                f'{extra_params["report_sku"]}',
-                f'{extra_params["report_sku_description"]}',
+                extra_params['report_sku'],
+                extra_params['report_sku_description'],
                 '',
                 'MONTH',
                 'MANAGED NODE',
                 'USD',
-                f'{extra_params["price_per_node"]}',
+                str(extra_params['price_per_node']),
             ],
         ]
 

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -57,13 +57,13 @@ class ReportCCSPv2(Base):
         default_sku_description = [
             ['SKU', 'SKU Description', '', 'Term', 'Unit of Measure', 'Currency', 'MSRP'],
             [
-                f'{extra_params["report_sku"]}',
-                f'{extra_params["report_sku_description"]}',
+                extra_params['report_sku'],
+                extra_params['report_sku_description'],
                 '',
                 'MONTH',
                 'MANAGED NODE',
                 'USD',
-                f'{extra_params["price_per_node"]}',
+                str(extra_params['price_per_node']),
             ],
         ]
 

--- a/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/report/report_renewal_guidance.py
@@ -21,7 +21,6 @@ class ReportRenewalGuidance(Base):
         self.extra_params = extra_params
 
         self.ephemeral_days = extra_params['ephemeral_days']
-        self.price_per_node = extra_params['price_per_node']
         self.report_period = extra_params['report_period']
 
         self.config = {

--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -292,7 +292,7 @@ class Collector:
 
         last_key = None
 
-        disable_job_host_summary_str = os.environ.get('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
+        disable_job_host_summary_str = os.getenv('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
         disable_job_host_summary = disable_job_host_summary_str.lower() == 'true'
 
         optional_collectors = get_optional_collectors()

--- a/metrics_utility/base/utils.py
+++ b/metrics_utility/base/utils.py
@@ -23,4 +23,4 @@ def get_optional_collectors():
     Get the list of optional collectors from environment variable.
     Defaults to 'main_jobevent' if not set.
     """
-    return os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
+    return os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -99,14 +99,14 @@ class Command(BaseCommand):
         opt_ephemeral = parse_number_of_days(options.get('ephemeral'))
         opt_force = options.get('force')
 
-        ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
+        ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
         extra_params = self._handle_extra_params(ship_target)
         extra_params['opt_since'] = opt_since
         extra_params['opt_until'] = opt_until
         extra_params['ephemeral_days'] = opt_ephemeral
         extra_params['month_since'] = month
         extra_params['month_until'] = next_month
-        extra_params['deduplicator'] = os.getenv('METRICS_UTILITY_DEDUPLICATOR', None) or None
+        extra_params['deduplicator'] = os.getenv('METRICS_UTILITY_DEDUPLICATOR') or None
 
         extractor = ExtractorFactory(ship_target, extra_params).create()
 
@@ -174,7 +174,7 @@ class Command(BaseCommand):
     def _handle_extra_params(self, ship_target=None):
         base = self._handle_ship_target(ship_target)
 
-        report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+        report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
         price_per_node = float(os.getenv('METRICS_UTILITY_PRICE_PER_NODE', 0))
 
         if not report_type:
@@ -205,7 +205,7 @@ class Command(BaseCommand):
                 'report_end_user_company_country': os.getenv('METRICS_UTILITY_REPORT_END_USER_COUNTRY', ''),
                 # Renewal guidance specific params
                 'report_renewal_guidance_dedup_iterations': os.getenv('REPORT_RENEWAL_GUIDANCE_DEDUP_ITERATIONS', '3'),
-                'report_organization_filter': os.getenv('METRICS_UTILITY_ORGANIZATION_FILTER', None),
+                'report_organization_filter': os.getenv('METRICS_UTILITY_ORGANIZATION_FILTER'),
                 # optional bits
                 'optional_sheets': os.getenv(
                     'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS',

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -2,7 +2,6 @@ import datetime
 import os
 
 from argparse import RawDescriptionHelpFormatter
-from datetime import timezone
 
 from django.core.management.base import BaseCommand
 
@@ -101,6 +100,8 @@ class Command(BaseCommand):
         opt_force = options.get('force')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
+
+        # FIXME: separate params per factory
         extra_params = self._handle_extra_params(ship_target)
         extra_params['opt_since'] = opt_since
         extra_params['opt_until'] = opt_until
@@ -109,24 +110,26 @@ class Command(BaseCommand):
         extra_params['month_until'] = next_month
         extra_params['deduplicator'] = os.getenv('METRICS_UTILITY_DEDUPLICATOR') or None
 
-        extractor = ExtractorFactory(ship_target, extra_params).create()
-
         # Determine destination path for generated report and skip processing if it exists
+        report_type = extra_params['report_type']
+        ship_path = extra_params['ship_path']
         if opt_since is not None:
-            now = datetime.datetime.now().replace(second=0, microsecond=0, tzinfo=timezone.utc)
-            extra_params['since_date'] = opt_since.date()
-            extra_params['until_date'] = opt_until.date() if opt_until else now.date()
+            since_date = opt_since.date()
+            until_date = opt_until.date() if opt_until else datetime.date.today()
 
-            extra_params['report_period'] = f'{extra_params["since_date"]}, {extra_params["until_date"]}'
+            extra_params['since_date'] = since_date
+            extra_params['until_date'] = until_date
+
+            extra_params['report_period'] = f'{since_date}, {until_date}'
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                get_report_path(extra_params['ship_path'], extra_params['until_date']),
-                f'{extra_params["report_type"]}-{extra_params["since_date"]}--{extra_params["until_date"]}.xlsx',
+                get_report_path(ship_path, until_date),
+                f'{report_type}-{since_date}--{until_date}.xlsx',
             )
         else:
             extra_params['report_period'] = opt_month
             extra_params['report_spreadsheet_destination_path'] = os.path.join(
-                get_report_path(extra_params['ship_path'], month),
-                f'{extra_params["report_type"]}-{opt_month}.xlsx',
+                get_report_path(ship_path, month),
+                f'{report_type}-{opt_month}.xlsx',
             )
 
         report_saver_engine = ReportSaverFactory(ship_target, extra_params=extra_params).create()
@@ -140,6 +143,9 @@ class Command(BaseCommand):
             )
             return
 
+        extractor = ExtractorFactory(ship_target, extra_params).create()
+
+        # FIXME move from month to extra_params
         dataframes = DataframeFactory(extractor=extractor, month=month, extra_params=extra_params).create()
 
         dedup = DedupFactory(dataframes=dataframes, extra_params=extra_params).create()
@@ -147,7 +153,7 @@ class Command(BaseCommand):
 
         if all(dataframe is None or dataframe.empty for _name, dataframe in dataframes.items()):
             if opt_since is not None:
-                logger.info(f'No billing data for input date range {extra_params["since_date"]}--{extra_params["until_date"]}')
+                logger.info(f'No billing data for input date range {since_date}--{until_date}')
             else:
                 logger.info(f'No billing data for month {opt_month}')
             return

--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -91,6 +91,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options.get('verbose'):
             debug()
+
         handle_env_validation('build')
 
         opt_since, opt_until = validate_build_params(options, self.help_texts)

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
         since = parse_date_param(opt_since, self.help_texts, 'since')
         until = parse_date_param(opt_until, self.help_texts, 'until')
 
-        ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
+        ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
         billing_provider_params = self._handle_ship_target(ship_target)
 
         if opt_ship and opt_dry_run:

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         until = parse_date_param(opt_until, self.help_texts, 'until')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
-        billing_provider_params = self._handle_ship_target(ship_target)
+        extra_params = self._handle_ship_target(ship_target)
 
         if opt_ship and opt_dry_run:
             logger.error('Arguments --ship and --dry-run cannot be processed at the same time, set only one of these.')
@@ -64,10 +64,10 @@ class Command(BaseCommand):
         collector = Collector(
             collection_type=Collector.MANUAL_COLLECTION if opt_ship else Collector.DRY_RUN,
             ship_target=ship_target,
-            billing_provider_params=billing_provider_params,
+            billing_provider_params=extra_params,
         )
 
-        tgzfiles = collector.gather(since=since, until=until, billing_provider_params=billing_provider_params)
+        tgzfiles = collector.gather(since=since, until=until, billing_provider_params=extra_params)
         if not tgzfiles:
             logger.error('No analytics collected')
             raise NoAnalyticsCollected('No analytics collected')

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -528,7 +528,7 @@ def handle_month(month):
     """Process month argument"""
     if month is not None:
         try:
-            date = datetime.datetime.strptime(f'{month}', '%Y-%m')
+            date = datetime.datetime.strptime(month, '%Y-%m')
         except ValueError:
             raise DateFormatError('Invalid --month format. Supported date format: YYYY-MM')
     else:

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -56,7 +56,7 @@ ship_path_description = 'place for collected data and built reports'
 
 
 def handle_directory_ship_target():
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
 
     if not ship_path:
         raise MissingRequiredEnvVar(f'Missing required env variable METRICS_UTILITY_SHIP_PATH - {ship_path_description}')
@@ -65,14 +65,14 @@ def handle_directory_ship_target():
 
 
 def handle_s3_ship_target():
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
-    bucket_name = os.getenv('METRICS_UTILITY_BUCKET_NAME', None)
-    bucket_endpoint = os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', None)
-    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION', None)  # optional
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
+    bucket_name = os.getenv('METRICS_UTILITY_BUCKET_NAME')
+    bucket_endpoint = os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT')
+    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION')  # optional
 
     # S3 credentials
-    bucket_access_key = os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', None)
-    bucket_secret_key = os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY', None)
+    bucket_access_key = os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY')
+    bucket_secret_key = os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY')
 
     missing = []
     if not bucket_name:
@@ -104,15 +104,15 @@ def handle_s3_ship_target():
 def handle_not_s3():
     surplus = []
 
-    if os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', None):
+    if os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY'):
         surplus += ['METRICS_UTILITY_BUCKET_ACCESS_KEY']
-    if os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', None):
+    if os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT'):
         surplus += ['METRICS_UTILITY_BUCKET_ENDPOINT']
-    if os.getenv('METRICS_UTILITY_BUCKET_NAME', None):
+    if os.getenv('METRICS_UTILITY_BUCKET_NAME'):
         surplus += ['METRICS_UTILITY_BUCKET_NAME']
-    if os.getenv('METRICS_UTILITY_BUCKET_REGION', None):
+    if os.getenv('METRICS_UTILITY_BUCKET_REGION'):
         surplus += ['METRICS_UTILITY_BUCKET_REGION']
-    if os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY', None):
+    if os.getenv('METRICS_UTILITY_BUCKET_SECRET_KEY'):
         surplus += ['METRICS_UTILITY_BUCKET_SECRET_KEY']
 
     if surplus:
@@ -120,12 +120,12 @@ def handle_not_s3():
 
 
 def handle_crc_ship_target():
-    billing_provider = os.getenv('METRICS_UTILITY_BILLING_PROVIDER', None)
-    red_hat_org_id = os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID', None)
+    billing_provider = os.getenv('METRICS_UTILITY_BILLING_PROVIDER')
+    red_hat_org_id = os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID')
 
     billing_provider_params = {'billing_provider': billing_provider}
     if billing_provider == 'aws':
-        billing_account_id = os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', None)
+        billing_account_id = os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID')
         if not billing_account_id:
             raise MissingRequiredEnvVar('Env var: METRICS_UTILITY_BILLING_ACCOUNT_ID, containing  AWS 12 digit customer id needs to be provided.')
         billing_provider_params['billing_account_id'] = billing_account_id
@@ -136,7 +136,7 @@ def handle_crc_ship_target():
         billing_provider_params['red_hat_org_id'] = red_hat_org_id
 
     # only used for the other modes
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
     if ship_path:
         allowed = '", "'.join(['controller_db', 'directory', 's3'])
         logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
@@ -157,7 +157,7 @@ def validate_report_type(errors, method):
     Returns:
         str or None: The value of the 'METRICS_UTILITY_REPORT_TYPE' environment variable if set, otherwise None.
     """
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
     if report_type and report_type not in VALID_REPORT_TYPES:
         errors.append(
             f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
@@ -230,7 +230,7 @@ def validate_collectors(errors):
           valid values.
     """
 
-    collectors = os.environ.get('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
+    collectors = os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').split(',')
     if collectors:
         invalid = set(collectors) - VALID_COLLECTORS
         if invalid:
@@ -254,7 +254,7 @@ def validate_ship_target(errors, method):
         - The set of valid ship targets is defined by the global variable VALID_SHIP_TARGET.
         - Error messages include the invalid ship target and the list of valid values.
     """
-    ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET', None)
+    ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
     ship_target_type = VALID_SHIP_TARGET_BUILD
     if method == 'gather':
         ship_target_type = VALID_SHIP_TARGET_GATHER
@@ -303,7 +303,7 @@ def validate_max_gather_period_days(errors):
     Returns:
         int or None: The validated value as an integer if set and valid, otherwise None.
     """
-    max_gather_days_str = os.getenv('METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS', None)
+    max_gather_days_str = os.getenv('METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS')
 
     if max_gather_days_str is None:
         return None
@@ -368,11 +368,11 @@ def handle_env_validation(method: str):
 def handle_not_crc():
     surplus = []
 
-    if os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', None):
+    if os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID'):
         surplus += ['METRICS_UTILITY_BILLING_ACCOUNT_ID']
-    if os.getenv('METRICS_UTILITY_BILLING_PROVIDER', None):
+    if os.getenv('METRICS_UTILITY_BILLING_PROVIDER'):
         surplus += ['METRICS_UTILITY_BILLING_PROVIDER']
-    if os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID', None):
+    if os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID'):
         surplus += ['METRICS_UTILITY_RED_HAT_ORG_ID']
 
     if surplus:
@@ -431,7 +431,7 @@ def parse_date_param(value, help_texts={None: ''}, name=None):
 
 
 def validate_ccsp_params(options):
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
     opt_month = options.get('month', None)
     opt_since = options.get('since', None)
     opt_until = options.get('until', None)
@@ -483,7 +483,7 @@ def parse_since_until(options, help_texts):
 
 
 def validate_build_params(options, help_texts):
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
     if not report_type:
         return None, None
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -127,7 +127,7 @@ def handle_crc_ship_target():
     if billing_provider == 'aws':
         billing_account_id = os.getenv('METRICS_UTILITY_BILLING_ACCOUNT_ID')
         if not billing_account_id:
-            raise MissingRequiredEnvVar('Env var: METRICS_UTILITY_BILLING_ACCOUNT_ID, containing  AWS 12 digit customer id needs to be provided.')
+            raise MissingRequiredEnvVar('METRICS_UTILITY_BILLING_ACCOUNT_ID, containing AWS 12 digit customer id needs to be provided.')
         billing_provider_params['billing_account_id'] = billing_account_id
     else:
         raise MissingRequiredEnvVar('Uknown METRICS_UTILITY_BILLING_PROVIDER env var, supported values are [aws].')
@@ -259,7 +259,7 @@ def validate_ship_target(errors, method):
     if method == 'gather':
         ship_target_type = VALID_SHIP_TARGET_GATHER
     if ship_target is None:
-        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET is Empty. Valid values: {", ".join(ship_target_type)}')
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET is empty. Valid values: {", ".join(ship_target_type)}')
     if ship_target and ship_target not in ship_target_type:
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(ship_target_type)}')
     return ship_target
@@ -277,16 +277,13 @@ def validate_ship_path(errors, ship_target, method):
         - For 'directory' ship target, checks if METRICS_UTILITY_SHIP_PATH is an existing directory.
         - Appends an error message to 'errors' if the directory does not exist.
     """
-    no_path = 'No Path Provided'
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', no_path)
-    dir_paths = VALID_SHIP_TARGET_BUILD
-    if 's3' in dir_paths:
-        dir_paths.remove('s3')
-    if ship_target and ship_target in dir_paths and method == 'build':
-        if not os.path.isdir(ship_path):
-            errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
-    if ship_path == no_path and method == 'gather' and ship_target == 'directory':
-        logger.info('No path set under METRICS_UTILITY_SHIP_PATH. A directory will be created')
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
+    if not ship_path:
+        # already handled in handle_*_ship_target
+        return
+
+    if method == 'build' and ship_target in VALID_SHIP_TARGET_BUILD - {'s3'} and not os.path.isdir(ship_path):
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
 
 
 def validate_max_gather_period_days(errors):

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -4,6 +4,7 @@ import pytest
 
 from metrics_utility.exceptions import MissingRequiredEnvVar
 from metrics_utility.management.validation import (
+    handle_directory_ship_target,
     handle_env_validation,
     validate_ccsp_report_sheets,
     validate_collectors,
@@ -230,10 +231,9 @@ def test_validate_ship_path_build_valid(monkeypatch):
 
 
 def test_validate_ship_path_build_empty_build_valid(monkeypatch):
-    errors = []
-    validate_ship_path(errors, 'directory', 'build')
-    assert errors
-    assert 'Invalid METRICS_UTILITY_SHIP_PATH' in errors[0]
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_directory_ship_target()
+    assert str(excinfo.value).startswith('Missing required env variable METRICS_UTILITY_SHIP_PATH')
 
 
 def test_validate_ship_path_build_empty_gather_valid(monkeypatch):

--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -23,13 +23,13 @@ API_GATEWAY_URL = API_URL.replace('/controller/v2', '/gateway/v1')
 USERNAME = os.getenv('USERNAME', 'admin')
 PASSWORD = os.getenv('PASSWORD', 'admin')
 
-SSH_URL = os.getenv('SSH_URL', None)
+SSH_URL = os.getenv('SSH_URL')
 SSH_USER = os.getenv('SSH_USER', 'ec2-user')
 
 OC_LOGIN_COMMAND = os.getenv('OC_LOGIN_COMMAND', '')
 
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'local')
-INV_PREFIX = os.getenv('INV_PREFIX', None)
+INV_PREFIX = os.getenv('INV_PREFIX')
 
 if not INV_PREFIX:
     # random 3 high letters


### PR DESCRIPTION
* Use `os.getenv`, not `os.environ.get`; drop default if None (consistency only)
* Cleanup more dead code/props
* Change `f'{val}'` to `val` or `str(val)`
* Separate `get_install_type` from `config` collector
* No `price_per_node` in renewal guidance
* `build_report`: use more readable variables; use `date.today` instead of `datetime.now`; move extractor to after `extra_params` is fully set
* `validate_ship_path`: don't mutate global const, remove unused gather code path