### PR TITLE
pyproject: add more data, use dynamic version

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -4,6 +4,7 @@ import os.path
 import platform
 
 from datetime import datetime, timezone
+from importlib.metadata import version
 from typing import Tuple
 
 import distro
@@ -142,7 +143,7 @@ def config(since, **kwargs):
         'logging_aggregators': settings.LOG_AGGREGATOR_LOGGERS,
         'external_logger_enabled': settings.LOG_AGGREGATOR_ENABLED,
         'external_logger_type': getattr(settings, 'LOG_AGGREGATOR_TYPE', None),
-        'metrics_utility_version': '0.6.1dev',  # TODO read from setup.cfg
+        'metrics_utility_version': version('metrics-utility'),  # version from setup.cfg
         'billing_provider_params': {},  # Is being overwritten in collector.gather by set ENV VARS
     }
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from importlib import import_module
+from importlib.metadata import version
 
 import django.core.management as management
 
@@ -50,8 +51,7 @@ class ManagementUtility(management.ManagementUtility):
         # Special-cases: We want 'django-admin --version' and
         # 'django-admin --help' to work, for backwards compatibility.
         elif subcommand == 'version' or self.argv[1:] == ['--version']:
-            # sys.stdout.write(django.get_version() + "\n")
-            sys.stdout.write('0.6.1dev' + '\n')
+            sys.stdout.write(version('metrics-utility') + '\n')
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metrics-utility"
-version = "0.1.0"
+dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
     "boto3==1.35.96",
@@ -19,6 +19,25 @@ dependencies = [
     "setuptools==70.3.0",
 ]
 requires-python = ">=3.11"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE.md"]
+authors = [
+  {name = "Red Hat", email = "info@ansible.com"},
+]
+keywords = ["ansible", "metrics"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python"
+]
+
+[project.scripts]
+metrics-utility = "metrics_utility:manage"
+
+[project.urls]
+Repository = "https://github.com/ansible/metrics-utility.git"
+Issues = "https://github.com/ansible/metrics-utility/issues"
+Changelog = "https://github.com/ansible/metrics-utility/blob/devel/CHANGELOG.md"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,6 @@ wheels = [
 
 [[package]]
 name = "metrics-utility"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Related to AAP-54478

RPM builds still delete pyproject and use setup.cfg.

But any library builds for pypi will use pyproject and not setup.

Adding more package details to pyproject, and switching to consume dynamic version from `setup.cfg`.
Removes any references to 0.5.1dev (current future version) except for changelog and setup.cfg (and uv.lock).

(Tested on containerized, returns '0.5.1' (`/var/lib/awx/env/bin/python`; `from importlib.metadata import version`; `version('metrics-utility')`))