### PR TITLE
When json collector is disabled (returns None), it will generate tarball even it should not

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -429,6 +429,11 @@ def main_indirectmanagednodeaudit_table(since, full_path, until, **kwargs):
         return None
 
 
+@register('test_json', '1.0', format='json', description=_('JSON'), fnc_slicing=limit_slicing)
+def test_json(since, full_path, until, **kwargs):
+    return None
+
+
 @register('main_host', '1.0', format='csv', description=_('Inventory data'), fnc_slicing=limit_slicing)
 def main_host_table(since, full_path, until, **kwargs):
     if 'main_host' not in get_optional_collectors():

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -429,11 +429,6 @@ def main_indirectmanagednodeaudit_table(since, full_path, until, **kwargs):
         return None
 
 
-@register('test_json', '1.0', format='json', description=_('JSON'), fnc_slicing=limit_slicing)
-def test_json(since, full_path, until, **kwargs):
-    return None
-
-
 @register('main_host', '1.0', format='csv', description=_('Inventory data'), fnc_slicing=limit_slicing)
 def main_host_table(since, full_path, until, **kwargs):
     if 'main_host' not in get_optional_collectors():

--- a/metrics_utility/base/collection_json.py
+++ b/metrics_utility/base/collection_json.py
@@ -24,7 +24,7 @@ class CollectionJSON(Collection):
         return len(self.data) if self.data else 0
 
     def is_empty(self):
-        return self.data is None
+        return self.data is None or self.data == 'null'
 
     def target(self):
         """Data attribute specific for this data type"""

--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -278,6 +278,9 @@ class Collector:
         for collection in self.collections[Collection.COLLECTION_TYPE_JSON]:
             collection.gather(self._package_class().max_data_size())
 
+            if collection.is_empty() or not collection.gathering_successful:
+                continue
+
             self._add_collection_to_package(collection)
 
     def _gather_csv_collections(self):


### PR DESCRIPTION
[AAP-[50991](https://issues.redhat.com/browse/AAP-50991)]

## Description

On devel - tarball is generated for json collector that is not empty, which is wrong. Tarball should not be generated, just as it works for csv collectors.

This PR checks for empty data in json collectors and not store tarball at all.

## Testing

Add this into:
metrics_utility/automation_controller_billing/collectors.py

@register('test_json', '1.0', format='json', description=_('JSON'), fnc_slicing=limit_slicing)
def test_json(since, full_path, until, **kwargs):
    return None
    
This will create empty json collector. Now run:

METRICS_UTILITY_SHIP_PATH=/var/tmp/shipped_data METRICS_UTILITY_SHIP_TARGET=directory uv run ./manage.py gather_automation_controller_billing_data --ship --since=2024-02-29 --until=2024-02-29 --force

You should not see any tarball with json (containing no data).
Without this PR on devel, tarball should be generated.