### PR TITLE
ExtractorS3 - fix "process_tarballs() takes 3 positional arguments but 4 were given"

### DIFF
--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -31,7 +31,7 @@ class ExtractorS3(Base):
                     local_path = os.path.join(temp_dir, 'source_tarball')
                     self.s3_handler.download_file(s3_path, local_path)
 
-                    yield self.process_tarballs(self, s3_path, temp_dir)
+                    yield self.process_tarballs(s3_path, temp_dir)
 
                 except Exception as e:
                     logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {s3_path} failed with {e}')


### PR DESCRIPTION
Issue: AAP-52439

introduced in #86, originally the helper was a function taking `self` as a real param; now it's a method, no longer takes `self`, but it was still being passed in s3.

Fixes:

```
    TypeError: Base.process_tarballs() takes 3 positional arguments but 4 were given
  [ExtractorS3] ERROR: Extracting metrics-utility/shipped_data/data/2025/08/03/3ecd5e03-cc9f-4bf3-9a00-7dd494631bfb-2025-08-03-000000+0000-2025-08-04-000000+0000-2.tar.gz failed with Base.process_tarballs() takes 3 positional arguments but 4 were given
  Traceback (most recent call last):
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/extract/extractor_s3.py", line 34, in iter_batches
      yield self.process_tarballs(self, s3_path, temp_dir)
```


Now: 

```
metrics_utility/automation_controller_billing/extract/base.py
59:    def process_tarballs(self, path, temp_dir):

metrics_utility/automation_controller_billing/extract/extractor_directory.py
28:                    yield self.process_tarballs(path, temp_dir)

metrics_utility/automation_controller_billing/extract/extractor_s3.py
34:                    yield self.process_tarballs(s3_path, temp_dir)
```