### PR TITLE
validation: require "controller_db" extractor for "RENEWAL_GUIDANCE" report

### DIFF
--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -58,6 +58,10 @@ class DedupRenewal(BaseDedupRenewal):
     """Original deduplication logic with iterative relationship discovery."""
 
     def run(self):
+        # Check if dataframe is empty or missing required columns
+        if self.dataframe is None or self.dataframe.empty:
+            return {'host_metric': pd.DataFrame()}
+
         self._cleanup_null_values()
         deduped_list = []
         processed_dupes_index = set()
@@ -106,7 +110,7 @@ class DedupRenewalHostname(BaseDedupRenewal):
 
     def run(self):
         # Check if dataframe is empty or missing required columns
-        if self.dataframe.empty:
+        if self.dataframe is None or self.dataframe.empty:
             return {'host_metric': pd.DataFrame()}
 
         # Ensure required columns exist
@@ -151,8 +155,8 @@ class DedupRenewalExperimental(BaseDedupRenewal):
     """
 
     def run(self):
-        # Check if dataframe is empty
-        if self.dataframe.empty:
+        # Check if dataframe is empty or missing required columns
+        if self.dataframe is None or self.dataframe.empty:
             return {'host_metric': pd.DataFrame()}
 
         # Step 1: Apply hostname-based deduplication first

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -237,7 +237,7 @@ def validate_collectors(errors):
             errors.append(f'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS: {", ".join(invalid)}. Valid values: {", ".join(VALID_COLLECTORS)}')
 
 
-def validate_ship_target(errors, method):
+def validate_ship_target(errors, method, report_type):
     """
     Validates the 'METRICS_UTILITY_SHIP_TARGET' environment variable against a set of valid ship targets.
 
@@ -262,6 +262,8 @@ def validate_ship_target(errors, method):
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET is empty. Valid values: {", ".join(ship_target_type)}')
     if ship_target and ship_target not in ship_target_type:
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(ship_target_type)}')
+    if report_type == 'RENEWAL_GUIDANCE' and ship_target != 'controller_db':
+        errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Only "controller_db" is allowed for "RENEWAL_GUIDANCE"')
     return ship_target
 
 
@@ -354,9 +356,7 @@ def handle_env_validation(method: str):
     validate_max_gather_period_days(errors)
     if method == 'build':
         validate_ccsp_report_sheets(errors, report_type)
-        ship_target = validate_ship_target(errors, method)
-    else:
-        ship_target = validate_ship_target(errors, method)
+    ship_target = validate_ship_target(errors, method, report_type)
     validate_ship_path(errors, ship_target, method)
     if errors:
         raise MissingRequiredEnvVar('\n'.join(errors))

--- a/metrics_utility/test/validation/test_extra_params_validation.py
+++ b/metrics_utility/test/validation/test_extra_params_validation.py
@@ -25,9 +25,8 @@ def handle_build_exception(env_vars, params, klass):
 
 
 def test_uses_since_and_until_values():
-    env_vars['METRICS_UTILITY_REPORT_TYPE'] = 'CCSPv2'
     args = {'since': '2025-02-25', 'until': '2025-02-26', 'force': True}
-    run_build_int(env_vars, args)
+    run_build_int({**env_vars, 'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2'}, args)
     try:
         workbook = load_workbook(filename=file_path)
         worksheet = read_excel(file_path, sheet_name='Usage Reporting')
@@ -37,9 +36,6 @@ def test_uses_since_and_until_values():
     finally:
         workbook.close()
         os.remove(file_path)
-
-
-month_file_path = './metrics_utility/test/test_data/reports/2025/04/CCSPv2-2025-04.xlsx'
 
 
 def test_accepts_month_and_ignores_since_until():
@@ -56,8 +52,9 @@ def test_renewal_guidance_fails_with_until_params():
         {'args': {'until': '2025-01-01'}},
         {'args': {'until': '2025-01-01', 'since': '2024-02-01'}},
     ]
+    env = {**env_vars, 'METRICS_UTILITY_REPORT_TYPE': 'RENEWAL_GUIDANCE', 'METRICS_UTILITY_SHIP_TARGET': 'controller_db'}
     for arg in command_args:
-        e = handle_build_exception({**env_vars, 'METRICS_UTILITY_REPORT_TYPE': 'RENEWAL_GUIDANCE'}, arg['args'], BadParameter)
+        e = handle_build_exception(env, arg['args'], BadParameter)
         assert e.name == 'The --until parameter is not allowed for renewal guidance report.'
 
 
@@ -108,10 +105,10 @@ def test_ephemeral_allowed():
         '4mon',
         '5mons',
     ]
-    env_vars['METRICS_UTILITY_REPORT_TYPE'] = 'RENEWAL_GUIDANCE'
 
+    env = {**env_vars, 'METRICS_UTILITY_REPORT_TYPE': 'RENEWAL_GUIDANCE', 'METRICS_UTILITY_SHIP_TARGET': 'controller_db'}
     for value in illegal_values:
-        e = handle_build_exception(env_vars, {'since': '2024-01-01', 'ephemeral': value}, UnparsableParameter)
+        e = handle_build_exception(env, {'since': '2024-01-01', 'ephemeral': value}, UnparsableParameter)
         expected = (
             'Duration in months or days to determine if host is ephemeral.'
             ' Months are considered as 30 days in duration. Example: --ephemeral=3months, or'

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -188,7 +188,7 @@ def test_validate_ship_target_valid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
     VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
     errors = []
-    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD, 'CCSPv2')
     assert result == 'directory'
     assert not errors
 
@@ -197,7 +197,7 @@ def test_validate_ship_target_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
     VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
     errors = []
-    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_BUILD, 'CCSPv2')
     assert result == 'invalid'
     assert errors
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]
@@ -207,7 +207,7 @@ def test_validate_ship_target_gather_valid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
     VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
     errors = []
-    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER, None)
     assert result == 'directory'
     assert not errors
 
@@ -216,7 +216,7 @@ def test_validate_ship_target_gather_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'invalid')
     VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
     errors = []
-    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER)
+    result = validate_ship_target(errors, VALID_SHIP_TARGET_GATHER, None)
     assert result == 'invalid'
     assert errors
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in errors[0]


### PR DESCRIPTION
Issue: AAP-52438

The `RENEWAL_GUIDANCE` report only works with the `ExtractorControllerDB` extractor.

With `ExtractorDirectory`:

```
  $ sudo -E metrics-utility build_report --force --since=2025-08-01
  ExtractorDirectory.iter_batches() missing 1 required positional argument: 'date'
  Traceback (most recent call last):
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/management_utility.py", line 78, in run_subcommand
      self.fetch_command(subcommand).run_from_argv(argv)
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
      self.execute(*args, **cmd_options)
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
      output = self.handle(*args, **options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/management/commands/build_report.py", line 144, in handle
      dedup = DedupFactory(dataframes=dataframes, extra_params=extra_params).create()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/dedup/factory.py", line 24, in create
      return self._get_deduplicator(deduplicator, report_type, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/dedup/factory.py", line 28, in _get_deduplicator
      return self._get_default_deduplicator(report_type, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/dedup/factory.py", line 35, in _get_default_deduplicator
      return DedupRenewal(**kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py", line 8, in __init__
      self.dataframe = dataframes['host_metric'].build_dataframe()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/metrics_utility/automation_controller_billing/dataframe_engine/db_dataframe_host_metric.py", line 14, in build_dataframe
      for data in self.extractor.iter_batches():
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: ExtractorDirectory.iter_batches() missing 1 required positional argument: 'date'
```

Adding a validator check to get a nicer error :)

After:

```
Invalid METRICS_UTILITY_SHIP_TARGET: directory. Only "controller_db" is allowed for "RENEWAL_GUIDANCE"
```

---

And fix exceptions when the dataframe returns None.