### PR TITLE
[AAP-49235] Adds env var help text for build report and gather commands.

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -12,8 +12,9 @@ from metrics_utility.automation_controller_billing.report.factory import Factory
 from metrics_utility.automation_controller_billing.report_saver.factory import Factory as ReportSaverFactory
 from metrics_utility.exceptions import BadRequiredEnvVar, BadShipTarget, MissingRequiredEnvVar
 from metrics_utility.logger import debug, logger
+from metrics_utility.management.help_text import HelpTextGenerator
 from metrics_utility.management.validation import (
-    date_format_text,
+    format_env_var_help,
     handle_directory_ship_target,
     handle_env_validation,
     handle_month,
@@ -44,55 +45,33 @@ class Command(BaseCommand):
     Build Report
     """
 
-    help = 'Build Report'
-    help_texts = {
-        'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
-        'until': (f'End date for collection, including. {date_format_text.format(name="until")}'),
-        'month': (
-            'Month the report will be generated for, with format YYYY-MM. '
-            "If this parameter is not provided, the previous month's report will be generated if it does not already exist."
-        ),
-        'ephemeral': (
-            'Duration in months or days to determine if host is ephemeral. '
-            'Months are considered as 30 days in duration. '
-            'Example: --ephemeral=3months, or --ephemeral=3days'
-        ),
-        'force': ('With this option, the existing reports will be overwritten if running this command again.'),
-        'verbose': ('Print debug information to console.'),
-    }
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.help_generator = HelpTextGenerator()
+
+        self.help = self.help_generator.build_report_help_title
+        self.help_texts = self.help_generator.build_report_param_help_texts
 
     def create_parser(self, prog_name, subcommand, **kwargs):
-        return super().create_parser(
+        # Delay property evaluation until help is actually displayed
+        parser = super().create_parser(
             prog_name,
             subcommand,
-            # ensure newlines are preserved in descriptions and epilog
             formatter_class=RawDescriptionHelpFormatter,
-            epilog='\n'.join(
-                [
-                    'ENVIRONMENT',
-                    "    METRICS_UTILITY_REPORT_TYPE (required, case sensitive): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'",
-                    "        determines which kind of report we're generating",
-                    '',
-                    "    METRICS_UTILITY_SHIP_TARGET (required): one of 'directory', 's3', 'controller_db'",
-                    '        input/output mechanism',
-                    '',
-                    '    METRICS_UTILITY_SHIP_PATH (required): a path',
-                    '        local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/',
-                    '',
-                    "    METRICS_UTILITY_DEDUPLICATOR (optional): one of 'ccsp', 'renewal', 'ccsp-experimental'",
-                    "        choice of deduplication algorithm, defaults to 'ccsp' or 'renewal' based on the chosen report type",
-                ]
-            ),
             **kwargs,
         )
+        # Set epilog dynamically
+        parser.epilog = self.help_generator.build_report_env_var_help_text
+        return parser
 
     def add_arguments(self, parser):
-        parser.add_argument('--month', dest='month', action='store', help=self.help_texts.get('month'))
-        parser.add_argument('--since', dest='since', action='store', help=self.help_texts.get('since'))
-        parser.add_argument('--until', dest='until', action='store', help=self.help_texts.get('until'))
-        parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=self.help_texts.get('ephemeral'))
-        parser.add_argument('--force', dest='force', action='store_true', help=self.help_texts.get('force'))
-        parser.add_argument('--verbose', dest='verbose', action='store_true', help=self.help_texts.get('verbose'))
+        help_texts = self.help_generator.build_report_param_help_texts
+        parser.add_argument('--month', dest='month', action='store', help=help_texts.get('month'))
+        parser.add_argument('--since', dest='since', action='store', help=help_texts.get('since'))
+        parser.add_argument('--until', dest='until', action='store', help=help_texts.get('until'))
+        parser.add_argument('--ephemeral', dest='ephemeral', action='store', help=help_texts.get('ephemeral'))
+        parser.add_argument('--force', dest='force', action='store_true', help=help_texts.get('force'))
+        parser.add_argument('--verbose', dest='verbose', action='store_true', help=help_texts.get('verbose'))
 
     def handle(self, *args, **options):
         if options.get('verbose'):
@@ -100,7 +79,7 @@ class Command(BaseCommand):
 
         handle_env_validation('build')
 
-        opt_since, opt_until = validate_build_params(options, self.help_texts)
+        opt_since, opt_until = validate_build_params(options, self.help_generator.build_report_param_help_texts)
 
         opt_month, month, next_month = handle_month(options.get('month') or None)
         opt_ephemeral = parse_number_of_days(options.get('ephemeral'))
@@ -177,10 +156,10 @@ class Command(BaseCommand):
             # controller_db is just directory but with different extractor
             handle_not_crc()
             handle_not_s3()
-            return handle_directory_ship_target()
+            return handle_directory_ship_target(self.help_generator.env_var_help_texts)
         elif ship_target == 's3':
             handle_not_crc()
-            return handle_s3_ship_target()
+            return handle_s3_ship_target(self.help_generator.env_var_help_texts)
         else:
             allowed = ', '.join(['controller_db', 'directory', 's3'])
             raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')
@@ -192,7 +171,7 @@ class Command(BaseCommand):
         price_per_node = float(os.getenv('METRICS_UTILITY_PRICE_PER_NODE', 0))
 
         if not report_type:
-            raise MissingRequiredEnvVar('Missing required env variable METRICS_UTILITY_REPORT_TYPE.')
+            raise MissingRequiredEnvVar(format_env_var_help('METRICS_UTILITY_REPORT_TYPE', self.help_generator.env_var_help_texts))
 
         if report_type not in ['CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE']:
             raise BadRequiredEnvVar(

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -1,5 +1,7 @@
 import os
 
+from argparse import RawDescriptionHelpFormatter
+
 from django.core.management.base import BaseCommand
 
 from metrics_utility.automation_controller_billing.collector import Collector
@@ -8,8 +10,8 @@ from metrics_utility.exceptions import (
     NoAnalyticsCollected,
 )
 from metrics_utility.logger import debug, logger
+from metrics_utility.management.help_text import HelpTextGenerator
 from metrics_utility.management.validation import (
-    date_format_text,
     handle_crc_ship_target,
     handle_directory_ship_target,
     handle_env_validation,
@@ -25,21 +27,31 @@ class Command(BaseCommand):
     Gather Automation Controller billing data
     """
 
-    help = 'Gather Automation Controller billing data'
-    help_texts = {
-        'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
-        'until': (f'End date for collection, excluding. {date_format_text.format(name="until")}'),
-        'dry-run': ('Gather billing metrics without shipping.'),
-        'ship': ('Enable shipping of billing metrics to the console.redhat.com'),
-        'verbose': ('Print debug information to console.'),
-    }
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.help_generator = HelpTextGenerator()
+        self.help = self.help_generator.gather_help_title
+        self.help_texts = self.help_generator.gather_param_help_texts
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        # Delay property evaluation until help is actually displayed
+        parser = super().create_parser(
+            prog_name,
+            subcommand,
+            formatter_class=RawDescriptionHelpFormatter,
+            **kwargs,
+        )
+        # Set epilog dynamically
+        parser.epilog = self.help_generator.gather_env_var_help_text
+        return parser
 
     def add_arguments(self, parser):
-        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=self.help_texts.get('dry-run'))
-        parser.add_argument('--ship', dest='ship', action='store_true', help=self.help_texts.get('ship'))
-        parser.add_argument('--since', dest='since', action='store', help=self.help_texts.get('since'))
-        parser.add_argument('--until', dest='until', action='store', help=self.help_texts.get('until'))
-        parser.add_argument('--verbose', dest='verbose', action='store_true', help=self.help_texts.get('verbose'))
+        help_texts = self.help_generator.gather_param_help_texts
+        parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=help_texts.get('dry-run'))
+        parser.add_argument('--ship', dest='ship', action='store_true', help=help_texts.get('ship'))
+        parser.add_argument('--since', dest='since', action='store', help=help_texts.get('since'))
+        parser.add_argument('--until', dest='until', action='store', help=help_texts.get('until'))
+        parser.add_argument('--verbose', dest='verbose', action='store_true', help=help_texts.get('verbose'))
 
     def handle(self, *args, **options):
         if options.get('verbose'):
@@ -51,8 +63,8 @@ class Command(BaseCommand):
         opt_ship = options.get('ship')
         opt_dry_run = options.get('dry-run')
 
-        since = parse_date_param(opt_since, self.help_texts, 'since')
-        until = parse_date_param(opt_until, self.help_texts, 'until')
+        since = parse_date_param(opt_since, self.help_generator.gather_param_help_texts, 'since')
+        until = parse_date_param(opt_until, self.help_generator.gather_param_help_texts, 'until')
 
         ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
         extra_params = self._handle_ship_target(ship_target)
@@ -81,10 +93,10 @@ class Command(BaseCommand):
         elif ship_target == 'directory':
             handle_not_crc()
             handle_not_s3()
-            return handle_directory_ship_target()
+            return handle_directory_ship_target(self.help_generator.env_var_help_texts)
         elif ship_target == 's3':
             handle_not_crc()
-            return handle_s3_ship_target()
+            return handle_s3_ship_target(self.help_generator.env_var_help_texts)
         else:
             allowed = ', '.join(['crc', 'directory', 's3'])
             raise BadShipTarget(f'Unexpected value for METRICS_UTILITY_SHIP_TARGET env var ({ship_target}), allowed values: {allowed}')

--- a/metrics_utility/management/help_text.py
+++ b/metrics_utility/management/help_text.py
@@ -1,0 +1,311 @@
+import os
+
+from typing import Dict, List, Optional, TypedDict
+
+from metrics_utility.management.validation import date_format_text
+
+
+# Type definitions for better type safety
+class EnvVarInfo(TypedDict):
+    required: bool
+    text: str
+
+
+class EnvVarSection(TypedDict):
+    title: str
+    vars: Dict[str, EnvVarInfo]
+
+
+# Type aliases for better readability
+EnvVarConfig = Dict[str, EnvVarSection]
+ParamHelpTexts = Dict[str, str]
+
+env_vars_for_build_and_gather: EnvVarConfig = {
+    'billing_provider': {
+        'title': 'Billing Provider Configuration',
+        'vars': {
+            'METRICS_UTILITY_BILLING_PROVIDER': {'required': False, 'text': "one of 'aws'"},
+            'METRICS_UTILITY_BILLING_ACCOUNT_ID': {'required': False, 'text': 'AWS 12 digit customer id'},
+            'METRICS_UTILITY_RED_HAT_ORG_ID': {'required': True, 'text': 'Red Hat org id'},
+        },
+    },
+    'crc': {
+        'title': 'CRC Configuration',
+        'vars': {
+            'METRICS_UTILITY_CRC_INGRESS_URL': {'required': False, 'text': 'CRC ingress url'},
+            'METRICS_UTILITY_CRC_SSO_URL': {'required': False, 'text': 'CRC sso url'},
+            'METRICS_UTILITY_PROXY_URL': {'required': False, 'text': 'Proxy url'},
+            'METRICS_UTILITY_SERVICE_ACCOUNT_ID': {'required': False, 'text': 'Service account id'},
+            'METRICS_UTILITY_SERVICE_ACCOUNT_SECRET': {'required': False, 'text': 'Service account secret'},
+        },
+    },
+    's3': {
+        'title': 'S3 Configuration',
+        'vars': {
+            'METRICS_UTILITY_BUCKET_NAME': {'required': False, 'text': 's3 bucket name to which save the report'},
+            'METRICS_UTILITY_BUCKET_ENDPOINT': {'required': False, 'text': 's3 bucket endpoint'},
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': {'required': False, 'text': 's3 bucket access key'},
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': {'required': False, 'text': 's3 bucket secret key'},
+            'METRICS_UTILITY_BUCKET_REGION': {'required': False, 'text': 's3 bucket region'},
+        },
+    },
+    'ship': {
+        'title': 'Ship Configuration (Always Required)',
+        'vars': {
+            'METRICS_UTILITY_SHIP_TARGET': {
+                'required': True,
+                'text': ("one of 'directory', 's3', 'controller_db' - input/output mechanism"),
+            },
+            'METRICS_UTILITY_SHIP_PATH': {
+                'required': True,
+                'text': 'A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/',
+            },
+        },
+    },
+    'installation': {
+        'title': 'Installation Type Detection',
+        'vars': {
+            'KUBERNETES_SERVICE_PORT': {
+                'required': False,
+                'text': "Used by collectors' get_install_type - for k8s",
+            },
+            'container': {
+                'required': False,
+                'text': "Used by collectors' get_install_type - for oci",
+            },
+        },
+    },
+}
+build_report_help_title: str = 'Build Report'
+build_report_param_help_texts: ParamHelpTexts = {
+    'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
+    'until': (f'End date for collection, including. {date_format_text.format(name="until")}'),
+    'month': (
+        'Month the report will be generated for, with format YYYY-MM. '
+        "If this parameter is not provided, the previous month's report will be generated if it does not already exist."
+    ),
+    'ephemeral': (
+        'Duration in months or days to determine if host is ephemeral. '
+        'Months are considered as 30 days in duration. '
+        'Example: --ephemeral=3months, or --ephemeral=3days'
+    ),
+    'force': ('With this option, the existing reports will be overwritten if running this command again.'),
+    'verbose': ('Print debug information to console.'),
+}
+
+build_report_env_var_help_texts: EnvVarConfig = {
+    'deduplication': {
+        'title': 'Deduplication Configuration',
+        'vars': {
+            'METRICS_UTILITY_DEDUPLICATOR': {'required': False, 'text': "one of 'ccsp', 'renewal', 'ccsp-experimental'"},
+            'REPORT_RENEWAL_GUIDANCE_DEDUP_ITERATIONS': {
+                'required': False,
+                'text': 'number of max dedup iterations, specifically for `dedup-renewal`, with the `RENEWAL_GUIDANCE` report',
+            },
+        },
+    },
+    'core': {
+        'title': 'Core Configuration (Always Required)',
+        'vars': {
+            'METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS': {'required': False, 'text': 'enables optional report sheets, comma-separated list'},
+            'METRICS_UTILITY_ORGANIZATION_FILTER': {
+                'required': False,
+                'text': 'CCSPv2 only, `report_organization_filter` - semicolon-separated list of org names to filter by',
+            },
+            'METRICS_UTILITY_REPORT_TYPE': {
+                'required': True,
+                'text': ("one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'. Determines which kind of report is generated"),
+            },
+        },
+    },
+    # CCSP Configuration data
+    'ccsp': {
+        'title': 'CCSP Configuration',
+        'vars': {
+            'METRICS_UTILITY_PRICE_PER_NODE': {
+                'required': False,
+                'text': 'price_per_node / unit_price - field value and multiplied by',
+            },
+            'METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER': {
+                'required': False,
+                'text': 'Name of person responsible for metrics',
+            },
+            'METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER': {
+                'required': False,
+                'text': "Company's procurement person for report header",
+            },
+            'METRICS_UTILITY_REPORT_COMPANY_NAME': {
+                'required': False,
+                'text': 'Name of company',
+            },
+            'METRICS_UTILITY_REPORT_EMAIL': {
+                'required': False,
+                'text': 'Email used for reports',
+            },
+            'METRICS_UTILITY_REPORT_END_USER_CITY': {
+                'required': False,
+                'text': 'City of end user company',
+            },
+            'METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME': {
+                'required': False,
+                'text': 'Name of end user company',
+            },
+            'METRICS_UTILITY_REPORT_END_USER_COUNTRY': {
+                'required': False,
+                'text': 'Country of end user company',
+            },
+            'METRICS_UTILITY_REPORT_END_USER_STATE': {
+                'required': False,
+                'text': 'State of end user company',
+            },
+            'METRICS_UTILITY_REPORT_H1_HEADING': {
+                'required': False,
+                'text': 'Heading for report',
+            },
+            'METRICS_UTILITY_REPORT_PO_NUMBER': {
+                'required': False,
+                'text': 'Purchase order number',
+            },
+            'METRICS_UTILITY_REPORT_RHN_LOGIN': {
+                'required': False,
+                'text': 'Red Hat Network login',
+            },
+            'METRICS_UTILITY_REPORT_SKU': {
+                'required': False,
+                'text': 'SKU',
+            },
+            'METRICS_UTILITY_REPORT_SKU_DESCRIPTION': {
+                'required': False,
+                'text': 'SKU description',
+            },
+        },
+    },
+}
+
+gather_env_var_help_texts: EnvVarConfig = {
+    'gather': {
+        'title': 'Gather automation controller billing data',
+        'vars': {
+            'METRICS_UTILITY_CLUSTER_NAME': {
+                'required': False,
+                'text': '`total_workers_vcpu` collector payload `.cluster_name` (required when that collector is enabled)',
+            },
+            'METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX': {'required': False, 'text': 'total_workers_vcpu collector custom lock name'},
+            'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': {
+                'required': False,
+                'text': 'disable `job_host_summary` collector (use together with `METRICS_UTILITY_OPTIONAL_COLLECTORS`)',
+            },
+            'METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES': {
+                'required': False,
+                'text': 'Skip updating last gather info from controller settings',
+            },
+            'METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS': {
+                'required': False,
+                'text': 'Maximum length of collection interval in days, default 28; `get_max_gather_period_days`',
+            },
+            'METRICS_UTILITY_OPTIONAL_COLLECTORS': {'required': False, 'text': 'Optional collectors, comma-separated list'},
+            'METRICS_UTILITY_USAGE_BASED_BILLING_ENABLED': {
+                'required': False,
+                'text': '`total_workers_vcpu` collector toggle - skips kubernetes when disabled (default: false)',
+            },
+        },
+    },
+}
+gather_help_title: str = 'Gather Automation Controller billing data'
+gather_param_help_texts: ParamHelpTexts = {
+    'since': (f'Start date for collection, including. {date_format_text.format(name="since")}'),
+    'until': (f'End date for collection, including. {date_format_text.format(name="until")}'),
+    'dry-run': ('Gather billing metrics without shipping.'),
+    'ship': ('Enable shipping of billing metrics to the console.redhat.com'),
+    'verbose': ('Print debug information to console.'),
+}
+
+
+class HelpTextGenerator:
+    """Class to generate environment variable help text."""
+
+    def __init__(self) -> None:
+        self.build_report_env_var_help_texts: EnvVarConfig = build_report_env_var_help_texts
+        self.gather_env_var_help_texts: EnvVarConfig = gather_env_var_help_texts
+        self.gather_help_title: str = gather_help_title
+        self.gather_param_help_texts: ParamHelpTexts = gather_param_help_texts
+        self.build_report_param_help_texts: ParamHelpTexts = build_report_param_help_texts
+        self.build_report_help_title: str = build_report_help_title
+        self.env_vars_for_build_and_gather: EnvVarConfig = env_vars_for_build_and_gather
+
+    @property
+    def build_report_env_var_help_text(self) -> str:
+        lines: List[str] = []
+        ship_target: Optional[str] = os.getenv('METRICS_UTILITY_SHIP_TARGET')
+
+        # Combine both dictionaries for build_report command
+        all_sections: EnvVarConfig = {**self.build_report_env_var_help_texts, **self.env_vars_for_build_and_gather}
+
+        for section_key, section_data in all_sections.items():
+            lines.extend(self.format_help_text_section(section_key, section_data, ship_target))
+
+        return self._ensure_trailing_newlines('\n'.join(lines))
+
+    @property
+    def gather_env_var_help_text(self) -> str:
+        lines: List[str] = []
+        ship_target: Optional[str] = os.getenv('METRICS_UTILITY_SHIP_TARGET')
+
+        # Combine both dictionaries for gather command
+        all_sections: EnvVarConfig = {**self.gather_env_var_help_texts, **self.env_vars_for_build_and_gather}
+
+        for section_key, section_data in all_sections.items():
+            lines.extend(self.format_help_text_section(section_key, section_data, ship_target))
+
+        return self._ensure_trailing_newlines('\n'.join(lines))
+
+    def format_help_text_section(self, section_key: str, section_data: EnvVarSection, ship_target: Optional[str]) -> List[str]:
+        lines: List[str] = []
+
+        # Add section title
+        lines.append('')  # Empty line before section
+        lines.append(f'   {section_data["title"]}:')
+        lines.append('')  # Empty line after title
+
+        # Add variables in this section
+        for var_name, var_info in section_data['vars'].items():
+            # Determine if required based on current context
+            required_text: str
+            if section_key == 's3' and ship_target == 's3':
+                required_text = 'required'
+            elif var_info['required'] is True:
+                required_text = 'required'
+            elif var_info['required'] is False:
+                required_text = 'optional'
+            else:
+                required_text = str(var_info['required'])
+
+            lines.append(f'  {var_name} ({required_text}): {var_info["text"]}')
+
+        return lines
+
+    def _ensure_trailing_newlines(self, text: str, count: int = 4) -> str:
+        """Ensure text ends with specified number of newlines."""
+        # Add newlines with a non-breaking space to prevent stripping
+        return text.rstrip() + '\n' * count + ' '
+
+    @property
+    def env_var_help_texts(self) -> Dict[str, EnvVarInfo]:
+        """Backward compatibility: flatten all env vars into single dict for validation functions."""
+        flattened: Dict[str, EnvVarInfo] = {}
+
+        # Flatten build_report env vars
+        for section_data in self.build_report_env_var_help_texts.values():
+            for var_name, var_info in section_data['vars'].items():
+                flattened[var_name] = var_info
+
+        # Flatten shared env vars
+        for section_data in self.env_vars_for_build_and_gather.values():
+            for var_name, var_info in section_data['vars'].items():
+                flattened[var_name] = var_info
+
+        return flattened
+
+
+# Create a singleton instance for easy import
+help_generator = HelpTextGenerator()

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -49,26 +49,51 @@ VALID_SHEETS = {
     },
 }
 VALID_COLLECTORS = {'main_host', 'main_jobevent', 'main_indirectmanagednodeaudit', 'total_workers_vcpu', ''}
-VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
-VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
+VALID_SHIP_TARGET_BUILD = ['directory', 'controller_db', 's3']  # Keep ordered for consistent messaging
+VALID_SHIP_TARGET_GATHER = ['directory', 's3', 'crc']  # Keep ordered for consistent messaging
 
 ship_path_description = 'place for collected data and built reports'
 
 
-def handle_directory_ship_target():
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
+def format_env_var_help(env_var_name, help_texts, fallback_description=None):
+    """Format environment variable help text with requirement status."""
+    env_var_help = help_texts.get(env_var_name, {})
+
+    # Use the same context-aware logic as help_text.py
+    ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
+
+    # Check if this is an S3 variable by looking for variables with required=False
+    # that contain 'bucket' in their name (S3-specific pattern)
+    is_s3_var = 'BUCKET' in env_var_name and env_var_help.get('required') is False
+
+    if is_s3_var and ship_target == 's3':
+        required_text = 'required'
+    elif env_var_help.get('required') is True:
+        required_text = 'required'
+    elif env_var_help.get('required') is False:
+        required_text = 'optional'
+    else:
+        required_text = str(env_var_help.get('required', 'required'))
+
+    description = env_var_help.get('text', fallback_description or '')
+    return f'{env_var_name} ({required_text}): {description}'
+
+
+def handle_directory_ship_target(help_texts):
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
 
     if not ship_path:
-        raise MissingRequiredEnvVar(f'Missing required env variable METRICS_UTILITY_SHIP_PATH - {ship_path_description}')
+        formatted_help = format_env_var_help('METRICS_UTILITY_SHIP_PATH', help_texts, ship_path_description)
+        raise MissingRequiredEnvVar(formatted_help)
 
     return {'ship_path': ship_path}
 
 
-def handle_s3_ship_target():
-    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
-    bucket_name = os.getenv('METRICS_UTILITY_BUCKET_NAME')
-    bucket_endpoint = os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT')
-    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION')  # optional
+def handle_s3_ship_target(env_var_help_texts):
+    ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH', None)
+    bucket_name = os.getenv('METRICS_UTILITY_BUCKET_NAME', None)
+    bucket_endpoint = os.getenv('METRICS_UTILITY_BUCKET_ENDPOINT', None)
+    bucket_region = os.getenv('METRICS_UTILITY_BUCKET_REGION', None)  # optional
 
     # S3 credentials
     bucket_access_key = os.getenv('METRICS_UTILITY_BUCKET_ACCESS_KEY')
@@ -76,19 +101,19 @@ def handle_s3_ship_target():
 
     missing = []
     if not bucket_name:
-        missing += ['METRICS_UTILITY_BUCKET_NAME - name of S3 bucket']
+        missing.append(format_env_var_help('METRICS_UTILITY_BUCKET_NAME', env_var_help_texts))
     if not bucket_endpoint:
-        missing += ['METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com']
+        missing.append(format_env_var_help('METRICS_UTILITY_BUCKET_ENDPOINT', env_var_help_texts))
     if not bucket_access_key:
-        missing += ['METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key']
+        missing.append(format_env_var_help('METRICS_UTILITY_BUCKET_ACCESS_KEY', env_var_help_texts))
     if not bucket_secret_key:
-        missing += ['METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key']
+        missing.append(format_env_var_help('METRICS_UTILITY_BUCKET_SECRET_KEY', env_var_help_texts))
     if not ship_path:
-        missing += [f'METRICS_UTILITY_SHIP_PATH - {ship_path_description}']
+        missing.append(format_env_var_help('METRICS_UTILITY_SHIP_PATH', env_var_help_texts, ship_path_description))
     # bucket_region is optional
 
     if missing:
-        raise MissingRequiredEnvVar(f'Missing some required env variables for S3 configuration, namely: {", ".join(missing)}.')
+        raise MissingRequiredEnvVar(f'Missing some required env variables for S3 configuration: {", ".join(missing)}.')
 
     # S3Handler params
     return {
@@ -130,7 +155,7 @@ def handle_crc_ship_target():
             raise MissingRequiredEnvVar('METRICS_UTILITY_BILLING_ACCOUNT_ID, containing AWS 12 digit customer id needs to be provided.')
         billing_provider_params['billing_account_id'] = billing_account_id
     else:
-        raise MissingRequiredEnvVar('Uknown METRICS_UTILITY_BILLING_PROVIDER env var, supported values are [aws].')
+        raise MissingRequiredEnvVar('self.Uknown METRICS_UTILITY_BILLING_PROVIDER env var, supported values are [aws].')
 
     if red_hat_org_id:
         billing_provider_params['red_hat_org_id'] = red_hat_org_id
@@ -138,7 +163,7 @@ def handle_crc_ship_target():
     # only used for the other modes
     ship_path = os.getenv('METRICS_UTILITY_SHIP_PATH')
     if ship_path:
-        allowed = '", "'.join(['controller_db', 'directory', 's3'])
+        allowed = '", "'.join(VALID_SHIP_TARGET_BUILD)
         logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
 
     return billing_provider_params
@@ -288,7 +313,7 @@ def validate_ship_path(errors, ship_target, method):
         # already handled in handle_*_ship_target
         return
 
-    if method == 'build' and ship_target in VALID_SHIP_TARGET_BUILD - {'s3'} and not os.path.isdir(ship_path):
+    if method == 'build' and ship_target in set(VALID_SHIP_TARGET_BUILD) - {'s3'} and not os.path.isdir(ship_path):
         errors.append(f'Invalid METRICS_UTILITY_SHIP_PATH: {ship_path} is not an existing directory.')
 
 
@@ -483,8 +508,8 @@ def parse_since_until(options, help_texts):
     return since, until
 
 
-def validate_build_params(options, help_texts):
-    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
+def validate_build_params(options, param_help_texts):
+    report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE', None)
     if not report_type:
         return None, None
 
@@ -492,9 +517,9 @@ def validate_build_params(options, help_texts):
         validate_ccsp_params(options)
 
     if report_type in {'RENEWAL_GUIDANCE'}:
-        validate_renewal_params(options, help_texts)
+        validate_renewal_params(options, param_help_texts)
 
-    return parse_since_until(options, help_texts)
+    return parse_since_until(options, param_help_texts)
 
 
 def parse_number_of_days(date_option):

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -10,6 +10,82 @@ from metrics_utility.logger import logger
 
 
 class ManagementUtility(management.ManagementUtility):
+    def main_help_text(self, commands_only=False):
+        """
+        Return the script's main help text, as a string.
+        """
+        if commands_only:
+            usage = sorted(self.get_commands())
+        else:
+            usage = [
+                '',
+                "Type 'manage.py help <subcommand>' for help on a specific subcommand.",
+                '',
+                'Available subcommands:',
+            ]
+            commands_dict = self.get_commands()
+
+            # First show custom commands with detailed help
+            custom_commands = ['build_report', 'gather_automation_controller_billing_data']
+            for name in sorted(custom_commands):
+                if name in commands_dict:
+                    usage.append('')
+                    app_name = commands_dict[name]
+                    try:
+                        command = self.fetch_command(name)
+                        help_text = command.help if hasattr(command, 'help') else 'No help available'
+                        usage.append(f'[{app_name}]')
+                        usage.append(f'    {name}')
+                        usage.append(f'        {help_text}')
+                        if hasattr(command, 'help_generator'):
+                            # Add environment variable help sections
+                            if name == 'build_report':
+                                usage.append('')
+                                usage.append('        Environment Variables for build_report:')
+                                # Use the existing help text generator logic
+                                ship_target = os.getenv('METRICS_UTILITY_SHIP_TARGET')
+                                all_sections = {
+                                    **command.help_generator.build_report_env_var_help_texts,
+                                    **command.help_generator.env_vars_for_build_and_gather,
+                                }
+                                for section_key, section_data in all_sections.items():
+                                    section_lines = command.help_generator.format_help_text_section(section_key, section_data, ship_target)
+                                    # Adjust indentation for main help context (add 6 spaces to each line)
+                                    for line in section_lines:
+                                        if line.strip():  # Only indent non-empty lines
+                                            usage.append(f'      {line}')
+                                        else:
+                                            usage.append('')
+                            elif name == 'gather_automation_controller_billing_data':
+                                usage.append('')
+                                usage.append('        Environment Variables for gather_automation_controller_billing_data:')
+                                # Use the existing help text generator logic
+                                all_sections = {
+                                    **command.help_generator.gather_env_var_help_texts,
+                                    **command.help_generator.env_vars_for_build_and_gather,
+                                }
+                                for section_key, section_data in all_sections.items():
+                                    section_lines = command.help_generator.format_help_text_section(section_key, section_data, ship_target)
+                                    # Adjust indentation for main help context (add 6 spaces to each line)
+                                    for line in section_lines:
+                                        if line.strip():  # Only indent non-empty lines
+                                            usage.append(f'      {line}')
+                                        else:
+                                            usage.append('')
+                    except Exception:
+                        usage.append(f'[{app_name}]')
+                        usage.append(f'    {name}')
+
+            # Then show Django built-in commands in a separate section
+            django_commands = [name for name in sorted(commands_dict) if name not in custom_commands]
+            if django_commands:
+                usage.append('')
+                usage.append('')
+                usage.append('[django]')
+                for name in django_commands:
+                    usage.append(f'    {name}')
+        return '\n'.join(usage)
+
     def execute(self):
         """
         Given the command-line arguments, figure out which subcommand is being
@@ -56,13 +132,6 @@ class ManagementUtility(management.ManagementUtility):
             sys.stdout.write(self.main_help_text() + '\n')
         else:
             self.run_subcommand(subcommand, self.argv)
-
-    def main_help_text(self, commands_only=False):
-        commands = 'Commands: build_report, gather_automation_controller_billing_data'
-        if commands_only:
-            return commands
-        else:
-            return f'Usage: {os.path.basename(sys.argv[0])} <command> [options]\n{commands}'
 
     def fetch_command(self, subcommand):
         try:

--- a/metrics_utility/test/management/commands/test_build_report_unit.py
+++ b/metrics_utility/test/management/commands/test_build_report_unit.py
@@ -39,7 +39,7 @@ def test_add_arguments_adds_expected_arguments(parser):
 def test_handle_ship_target_directory(monkeypatch, command_instance):
     monkeypatch.setattr(
         'metrics_utility.management.commands.build_report.handle_directory_ship_target',
-        lambda: {'ship_path': 'directory'},
+        lambda help_texts: {'ship_path': 'directory'},
     )
     assert command_instance._handle_ship_target('directory') == {'ship_path': 'directory'}
 
@@ -47,7 +47,7 @@ def test_handle_ship_target_directory(monkeypatch, command_instance):
 def test_handle_ship_target_s3(monkeypatch, command_instance):
     monkeypatch.setattr(
         'metrics_utility.management.commands.build_report.handle_s3_ship_target',
-        lambda: {'ship_path': 's3'},
+        lambda env_var_help_texts: {'ship_path': 's3'},
     )
     assert command_instance._handle_ship_target('s3') == {'ship_path': 's3'}
 
@@ -101,7 +101,14 @@ def test_handle_extra_params_all_valid(monkeypatch, command_instance):
 def test_handle_known_exceptions(monkeypatch, command_instance, exc):
     monkeypatch.setattr(
         'metrics_utility.management.commands.build_report.handle_env_validation',
-        lambda x: None,
+        lambda method: None,
+    )
+
+    # Mock _handle_extra_params to raise the specific exception being tested
+    monkeypatch.setattr(
+        command_instance,
+        '_handle_extra_params',
+        lambda ship_target: (_ for _ in ()).throw(exc),
     )
 
     with pytest.raises(MetricsException):
@@ -111,10 +118,18 @@ def test_handle_known_exceptions(monkeypatch, command_instance, exc):
 def test_handle_unexpected_exception(monkeypatch, command_instance):
     monkeypatch.setattr(
         'metrics_utility.management.commands.build_report.handle_env_validation',
-        lambda x: None,
+        lambda method: None,
     )
 
-    with pytest.raises(MetricsException):
+    # Mock _handle_extra_params to raise an unexpected exception (not a MetricsException subclass)
+    monkeypatch.setattr(
+        command_instance,
+        '_handle_extra_params',
+        lambda ship_target: (_ for _ in ()).throw(ValueError('Unexpected error')),
+    )
+
+    # The command should raise the ValueError, not wrap it in MetricsException
+    with pytest.raises(ValueError):
         command_instance.handle()
 
 

--- a/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
+++ b/metrics_utility/test/management/commands/test_gather_automation_controller_billing_data.py
@@ -68,7 +68,14 @@ def test_command_help(capsys):
 )
 def test_handle_known_exceptions(monkeypatch, command_instance, exc):
     handle_env_validation = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation'
-    monkeypatch.setattr(handle_env_validation, lambda x: None)
+    monkeypatch.setattr(handle_env_validation, lambda method: None)
+
+    # Mock _handle_ship_target to raise the specific exception being tested
+    monkeypatch.setattr(
+        command_instance,
+        '_handle_ship_target',
+        lambda ship_target: (_ for _ in ()).throw(exc),
+    )
 
     with pytest.raises(MetricsException):
         command_instance.handle()
@@ -76,9 +83,17 @@ def test_handle_known_exceptions(monkeypatch, command_instance, exc):
 
 def test_handle_unexpected_exception(monkeypatch, command_instance):
     handle_env_validation = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_env_validation'
-    monkeypatch.setattr(handle_env_validation, lambda x: None)
+    monkeypatch.setattr(handle_env_validation, lambda method: None)
 
-    with pytest.raises(MetricsException):
+    # Mock _handle_ship_target to raise an unexpected exception (not a MetricsException subclass)
+    monkeypatch.setattr(
+        command_instance,
+        '_handle_ship_target',
+        lambda ship_target: (_ for _ in ()).throw(ValueError('Unexpected error')),
+    )
+
+    # The command should raise the ValueError, not wrap it in MetricsException
+    with pytest.raises(ValueError):
         command_instance.handle()
 
 
@@ -98,7 +113,7 @@ def test_handle_ship_target_directory(monkeypatch, command_instance):
     monkeypatch.setattr(handle_not_s3, lambda: None)
     monkeypatch.setattr(
         handle_directory_ship_target,
-        lambda: {'ship_path': 'directory'},
+        lambda help_texts: {'ship_path': 'directory'},
     )
     assert command_instance._handle_ship_target('directory') == {'ship_path': 'directory'}
 
@@ -107,7 +122,7 @@ def test_handle_ship_target_s3(monkeypatch, command_instance):
     handle_not_crc = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_not_crc'
     handle_s3_ship_target = 'metrics_utility.management.commands.gather_automation_controller_billing_data.handle_s3_ship_target'
     monkeypatch.setattr(handle_not_crc, lambda: None)
-    monkeypatch.setattr(handle_s3_ship_target, lambda: {'ship_path': 's3'})
+    monkeypatch.setattr(handle_s3_ship_target, lambda env_var_help_texts: {'ship_path': 's3'})
     assert command_instance._handle_ship_target('s3') == {'ship_path': 's3'}
 
 

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -12,6 +12,7 @@ unset = {
     'METRICS_UTILITY_BUCKET_NAME': None,
     'METRICS_UTILITY_BUCKET_REGION': None,
     'METRICS_UTILITY_BUCKET_SECRET_KEY': None,
+    'METRICS_UTILITY_SHIP_PATH': None,
 }
 
 
@@ -74,7 +75,10 @@ def test_build_controller_db():
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+    assert (
+        e.name
+        == 'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/'
+    )
 
     e = expect_build_error(
         {
@@ -83,7 +87,9 @@ def test_build_controller_db():
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+    assert (
+        e.name == "METRICS_UTILITY_REPORT_TYPE (required): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'. Determines which kind of report is generated"
+    )
 
 
 def test_gather_crc(caplog):
@@ -99,7 +105,7 @@ def test_gather_crc(caplog):
             'dry-run': True,
         },
     )
-    assert caplog.messages[0] == 'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="controller_db", "directory", "s3"'
+    assert caplog.messages[0] == 'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="directory", "controller_db", "s3"'
 
 
 def test_build_directory(caplog):
@@ -110,7 +116,10 @@ def test_build_directory(caplog):
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+    assert (
+        e.name
+        == 'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/'
+    )
 
     e = expect_build_error(
         {
@@ -121,7 +130,9 @@ def test_build_directory(caplog):
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+    assert (
+        e.name == "METRICS_UTILITY_REPORT_TYPE (required): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'. Determines which kind of report is generated"
+    )
     assert caplog.messages[-1] == 'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="s3": METRICS_UTILITY_BUCKET_NAME'
     assert caplog.messages[-2] == 'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="crc": METRICS_UTILITY_BILLING_PROVIDER'
 
@@ -133,7 +144,10 @@ def test_gather_directory():
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_SHIP_PATH - place for collected data and built reports'
+    (
+        e.name
+        == 'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/'
+    )
 
     run_gather_int(
         {
@@ -155,13 +169,13 @@ def test_build_s3():
         },
         MissingRequiredEnvVar,
     )
-    assert (
-        e.name == 'Missing some required env variables for S3 configuration, namely: '
-        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
-        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
-        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
-        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
-        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+    assert e.name == (
+        'Missing some required env variables for S3 configuration: '
+        'METRICS_UTILITY_BUCKET_NAME (required): s3 bucket name to which save the report, '
+        'METRICS_UTILITY_BUCKET_ENDPOINT (required): s3 bucket endpoint, '
+        'METRICS_UTILITY_BUCKET_ACCESS_KEY (required): s3 bucket access key, '
+        'METRICS_UTILITY_BUCKET_SECRET_KEY (required): s3 bucket secret key, '
+        'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/.'
     )
 
     e = expect_build_error(
@@ -175,7 +189,9 @@ def test_build_s3():
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+    assert (
+        e.name == "METRICS_UTILITY_REPORT_TYPE (required): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'. Determines which kind of report is generated"
+    )
 
     e = expect_build_error(
         {
@@ -189,7 +205,9 @@ def test_build_s3():
         },
         MissingRequiredEnvVar,
     )
-    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+    assert (
+        e.name == "METRICS_UTILITY_REPORT_TYPE (required): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'. Determines which kind of report is generated"
+    )
 
 
 def test_gather_s3():
@@ -200,12 +218,12 @@ def test_gather_s3():
         MissingRequiredEnvVar,
     )
     assert (
-        e.name == 'Missing some required env variables for S3 configuration, namely: '
-        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
-        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
-        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
-        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
-        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
+        e.name == 'Missing some required env variables for S3 configuration: '
+        'METRICS_UTILITY_BUCKET_NAME (required): s3 bucket name to which save the report, '
+        'METRICS_UTILITY_BUCKET_ENDPOINT (required): s3 bucket endpoint, '
+        'METRICS_UTILITY_BUCKET_ACCESS_KEY (required): s3 bucket access key, '
+        'METRICS_UTILITY_BUCKET_SECRET_KEY (required): s3 bucket secret key, '
+        'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/.'
     )
 
     run_gather_int(

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -3,6 +3,7 @@ import tempfile
 import pytest
 
 from metrics_utility.exceptions import MissingRequiredEnvVar
+from metrics_utility.management.help_text import HelpTextGenerator
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
     handle_env_validation,
@@ -232,8 +233,11 @@ def test_validate_ship_path_build_valid(monkeypatch):
 
 def test_validate_ship_path_build_empty_build_valid(monkeypatch):
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
-        handle_directory_ship_target()
-    assert str(excinfo.value).startswith('Missing required env variable METRICS_UTILITY_SHIP_PATH')
+        help_text_generator = HelpTextGenerator()
+        handle_directory_ship_target(help_text_generator.env_var_help_texts)
+    assert str(excinfo.value).startswith(
+        'METRICS_UTILITY_SHIP_PATH (required): A path - local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/'
+    )
 
 
 def test_validate_ship_path_build_empty_gather_valid(monkeypatch):


### PR DESCRIPTION
[AAP-49235]

## Description
This PR refactors the Django management command help system to provide comprehensive, dynamically-generated environment variable documentation. The changes introduce a new HelpTextGenerator class using composition pattern that centralizes all help text data with TypedDict definitions for type safety, and generates context-aware help text where S3-related environment variables automatically become "required" when METRICS_UTILITY_SHIP_TARGET=s3. The implementation overrides Django's ManagementUtility.main_help_text() to display custom commands first with their full environment variable documentation, while maintaining backwards compatibility and replacing multiple inheritance with cleaner composition. All environment variable definitions are now centralized in metrics_utility/management/help_text.py with consistent formatting and proper sectional grouping.
## Testing


### Steps to Test
To test these changes, run uv run python manage.py --help to verify that custom commands (build_report and gather_automation_controller_billing_data) appear first with comprehensive environment variable help text, and test individual command help with uv run python manage.py build_report --help to ensure the epilog shows properly formatted environment variables with correct requirement indicators. Additionally, set METRICS_UTILITY_SHIP_TARGET=s3 and re-run the help commands to verify that S3-related environment variables dynamically change from "(optional)" to "(required)" status.

### Expected Results

Help text appears with correct requirement value

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
