### PR TITLE
Adds all env vars for both build and gather

### DIFF
--- a/metrics_utility/management/commands/build_report.py
+++ b/metrics_utility/management/commands/build_report.py
@@ -70,17 +70,41 @@ class Command(BaseCommand):
             epilog='\n'.join(
                 [
                     'ENVIRONMENT',
-                    "    METRICS_UTILITY_REPORT_TYPE (required, case sensitive): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE'",
-                    "        determines which kind of report we're generating",
                     '',
-                    "    METRICS_UTILITY_SHIP_TARGET (required): one of 'directory', 's3', 'controller_db'",
-                    '        input/output mechanism',
+                    '  Core Configuration:',
+                    "    METRICS_UTILITY_REPORT_TYPE (required): one of 'CCSPv2', 'CCSP', 'RENEWAL_GUIDANCE' - determines which kind of report we're generating",  # noqa: E501
+                    "    METRICS_UTILITY_SHIP_TARGET (required): one of 'directory', 's3', 'controller_db' - input/output mechanism",
+                    '    METRICS_UTILITY_SHIP_PATH (required): local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/',  # noqa: E501
                     '',
-                    '    METRICS_UTILITY_SHIP_PATH (required): a path',
-                    '        local or s3 directory path, input tarballs in path/data/, output xlsx in path/reports/',
+                    '  Optional Configuration:',
+                    "    METRICS_UTILITY_DEDUPLICATOR (optional): one of 'ccsp', 'renewal', 'ccsp-experimental' - choice of deduplication algorithm",  # noqa: E501
+                    '    METRICS_UTILITY_ORGANIZATION_FILTER (optional): CCSPv2 only, semicolon-separated list of org names to filter by',  # noqa: E501
+                    '    METRICS_UTILITY_PRICE_PER_NODE (optional): price per node multiplier for cost calculations',
+                    '    METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS (optional): enables optional report sheets, comma-separated list',  # noqa: E501
+                    '    REPORT_RENEWAL_GUIDANCE_DEDUP_ITERATIONS (optional): max dedup iterations for renewal guidance (default: 3)',  # noqa: E501
                     '',
-                    "    METRICS_UTILITY_DEDUPLICATOR (optional): one of 'ccsp', 'renewal', 'ccsp-experimental'",
-                    "        choice of deduplication algorithm, defaults to 'ccsp' or 'renewal' based on the chosen report type",
+                    '  Report Customization (Optional):',
+                    '    METRICS_UTILITY_REPORT_SKU (optional): SKU identifier for the report',
+                    '    METRICS_UTILITY_REPORT_SKU_DESCRIPTION (optional): SKU description for the report',
+                    '    METRICS_UTILITY_REPORT_H1_HEADING (optional): main heading for the report',
+                    '    METRICS_UTILITY_REPORT_COMPANY_NAME (optional): company name for the report',
+                    '    METRICS_UTILITY_REPORT_EMAIL (optional): contact email for the report',
+                    '    METRICS_UTILITY_REPORT_RHN_LOGIN (optional): Red Hat Network login for the report',
+                    '    METRICS_UTILITY_REPORT_PO_NUMBER (optional): purchase order number for the report',
+                    '    METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER (optional): business leader name for the report',  # noqa: E501
+                    '    METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER (optional): procurement leader name for the report',  # noqa: E501
+                    '    METRICS_UTILITY_REPORT_END_USER_COMPANY_NAME (optional): end user company name for the report',  # noqa: E501
+                    '    METRICS_UTILITY_REPORT_END_USER_CITY (optional): end user company city for the report',
+                    '    METRICS_UTILITY_REPORT_END_USER_STATE (optional): end user company state for the report',
+                    '    METRICS_UTILITY_REPORT_END_USER_COUNTRY (optional): end user company country for the report',
+                    '',
+                    '  S3 Configuration:',
+                    '    METRICS_UTILITY_BUCKET_NAME (optional): S3 bucket name',
+                    '    METRICS_UTILITY_BUCKET_ENDPOINT (optional): S3 endpoint URL',
+                    '    METRICS_UTILITY_BUCKET_ACCESS_KEY (optional): S3 access key',
+                    '    METRICS_UTILITY_BUCKET_SECRET_KEY (optional): S3 secret key',
+                    '    METRICS_UTILITY_BUCKET_REGION (optional): S3 region',
+                    '',
                 ]
             ),
             **kwargs,

--- a/metrics_utility/management/commands/gather_automation_controller_billing_data.py
+++ b/metrics_utility/management/commands/gather_automation_controller_billing_data.py
@@ -1,5 +1,7 @@
 import os
 
+from argparse import RawDescriptionHelpFormatter
+
 from django.core.management.base import BaseCommand
 
 from metrics_utility.automation_controller_billing.collector import Collector
@@ -33,6 +35,52 @@ class Command(BaseCommand):
         'ship': ('Enable shipping of billing metrics to the console.redhat.com'),
         'verbose': ('Print debug information to console.'),
     }
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        return super().create_parser(
+            prog_name,
+            subcommand,
+            # ensure newlines are preserved in descriptions and epilog
+            formatter_class=RawDescriptionHelpFormatter,
+            epilog='\n'.join(
+                [
+                    'ENVIRONMENT',
+                    '',
+                    '  Core Configuration:',
+                    "    METRICS_UTILITY_SHIP_TARGET (required): one of 'crc', 'directory', 's3' - input/output mechanism",
+                    '    METRICS_UTILITY_SHIP_PATH (required): directory path for data collection and storage',
+                    '',
+                    '  Collection Configuration:',
+                    '    METRICS_UTILITY_CLUSTER_NAME (optional): cluster name for total_workers_vcpu collector (required when enabled)',  # noqa: E501
+                    '    METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX (optional): custom lock name for total_workers_vcpu collector',
+                    '    METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR (optional): disable job_host_summary collector',  # noqa: E501
+                    '    METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES (optional): skip updating last gather info from controller settings',  # noqa: E501
+                    '    METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS (optional): maximum length of collection interval in days (default: 28)',  # noqa: E501
+                    '    METRICS_UTILITY_OPTIONAL_COLLECTORS (optional): optional collectors, comma-separated list',
+                    '    METRICS_UTILITY_USAGE_BASED_BILLING_ENABLED (optional): total_workers_vcpu collector toggle (default: false)',  # noqa: E501
+                    '',
+                    '  Billing Provider Configuration:',
+                    '    METRICS_UTILITY_BILLING_ACCOUNT_ID (optional): AWS account ID for billing',
+                    '    METRICS_UTILITY_BILLING_PROVIDER (optional): billing provider type',
+                    '    METRICS_UTILITY_RED_HAT_ORG_ID (optional): Red Hat organization ID',
+                    '',
+                    '  S3 Configuration:',
+                    '    METRICS_UTILITY_BUCKET_NAME (optional): S3 bucket name',
+                    '    METRICS_UTILITY_BUCKET_ENDPOINT (optional): S3 endpoint URL',
+                    '    METRICS_UTILITY_BUCKET_ACCESS_KEY (optional): S3 access key',
+                    '    METRICS_UTILITY_BUCKET_SECRET_KEY (optional): S3 secret key',
+                    '    METRICS_UTILITY_BUCKET_REGION (optional): S3 region',
+                    '',
+                    '  CRC Configuration:',
+                    '    METRICS_UTILITY_CRC_INGRESS_URL (optional): CRC upload URL',
+                    '    METRICS_UTILITY_CRC_SSO_URL (optional): CRC login URL',
+                    '    METRICS_UTILITY_PROXY_URL (optional): upload proxy URL',
+                    '    METRICS_UTILITY_SERVICE_ACCOUNT_ID (optional): service account ID',
+                    '    METRICS_UTILITY_SERVICE_ACCOUNT_SECRET (optional): service account secret',
+                ]
+            ),
+            **kwargs,
+        )
 
     def add_arguments(self, parser):
         parser.add_argument('--dry-run', dest='dry-run', action='store_true', help=self.help_texts.get('dry-run'))


### PR DESCRIPTION
[AAP-49235]


## Description
This PR significantly improves the help text documentation for both build_report and gather_automation_controller_billing_data management commands by providing comprehensive, well-organized environment variable reference guides. The documentation now includes all environment variables actually used by each command (21 for build_report, 16 for gather), organized into logical sections like Core Configuration, S3 Configuration, CRC Configuration, etc.
Previously, the help text was incomplete, inconsistently formatted, and included variables not relevant to specific commands. The new structured approach provides clear (required)/(optional) indicators, descriptive explanations, and consistent formatting that makes it much easier for users to understand and configure the necessary environment variables for their use case.