### PR TITLE
generator: allow outputing main_host once per interval or weekly

### DIFF
--- a/tools/perf/generator.py
+++ b/tools/perf/generator.py
@@ -400,14 +400,16 @@ Environment vars:
             return
 
         if table == 'main_host':
-            # main_host - only generate csvs once, not filtered by since/until; use for each daily tarball
+            # main_host - only generate csvs once, not filtered by since/until; output once, at end of the month
             with tempfile.TemporaryDirectory(prefix=f'metrics-generator-save-{table}') as temp_dir:
                 file_list = self.save_csvs(table, temp_dir, df)
 
                 for since, until in daily_slicing(since=self.output_from, until=self.output_to):
-                    logger.info(f'{table} - {since}-{until}')
-                    for file in file_list:
-                        self.tarify(table, since, until, file)
+                    pass  # just need the last set of values from the generator
+
+                logger.info(f'{table} - {since}-{until}')
+                for file in file_list:
+                    self.tarify(table, since, until, file)
         else:
             # generate csvs daily, filtered by since/until
             for since, until in daily_slicing(since=self.output_from, until=self.output_to):

--- a/tools/perf/generator.py
+++ b/tools/perf/generator.py
@@ -252,6 +252,7 @@ class Main:
         self.main_host = (
             int(os.getenv('MAIN_HOST_SIZE', '10000')),
             int(os.getenv('MAIN_HOST_UNIQUE_SIZE', '2000')),
+            int(os.getenv('MAIN_HOST_FREQUENCY', '1')),  # every N days; or once when 0
         )
         self.main_indirectmanagednodeaudit = (
             int(os.getenv('MAIN_INDIRECT_SIZE', '10000')),
@@ -287,6 +288,7 @@ Environment vars:
     MAIN_JOBHOSTSUMMARY_UNIQUE_SIZE (default: 2000)
     MAIN_HOST_SIZE (default: 10000)
     MAIN_HOST_UNIQUE_SIZE (default: 2000)
+    MAIN_HOST_FREQUENCY (default: 1)
     MAIN_INDIRECT_SIZE (default: 10000)
     MAIN_INDIRECT_UNIQUE_SIZE (default: 2000)
     MAIN_JOBEVENT_SIZE (default: 10000)
@@ -400,16 +402,28 @@ Environment vars:
             return
 
         if table == 'main_host':
-            # main_host - only generate csvs once, not filtered by since/until; output once, at end of the month
+            # main_host - only generate csvs once, not filtered by since/until
             with tempfile.TemporaryDirectory(prefix=f'metrics-generator-save-{table}') as temp_dir:
                 file_list = self.save_csvs(table, temp_dir, df)
 
+                # output every N days (MAIN_HOST_FREQUENCY=1), or at the end of the period if 0
+                frequency = self.main_host[2]
+                idx = 0
                 for since, until in daily_slicing(since=self.output_from, until=self.output_to):
-                    pass  # just need the last set of values from the generator
+                    idx += 1
+                    if not frequency:
+                        continue
+                    if idx % frequency:
+                        continue
 
-                logger.info(f'{table} - {since}-{until}')
-                for file in file_list:
-                    self.tarify(table, since, until, file)
+                    logger.info(f'{table} - {since}-{until}')
+                    for file in file_list:
+                        self.tarify(table, since, until, file)
+
+                if not frequency:
+                    logger.info(f'{table} - {since}-{until}')
+                    for file in file_list:
+                        self.tarify(table, since, until, file)
         else:
             # generate csvs daily, filtered by since/until
             for since, until in daily_slicing(since=self.output_from, until=self.output_to):

--- a/tools/perf/run-perf-gen
+++ b/tools/perf/run-perf-gen
@@ -19,6 +19,7 @@ run_generator() {
   export MAIN_JOBHOSTSUMMARY_UNIQUE_SIZE="$2"
   export MAIN_HOST_SIZE="$1"
   export MAIN_HOST_UNIQUE_SIZE="$2"
+  export MAIN_HOST_FREQUENCY="$5"
   export MAIN_INDIRECT_SIZE="$1"
   export MAIN_INDIRECT_UNIQUE_SIZE="$2"
   export MAIN_JOBEVENT_SIZE="$1"
@@ -35,13 +36,13 @@ run_generator() {
 
 ## generator
 log "gen 10,000"
-run_generator 10000 2000 2026-01-01 2026-02-01
+run_generator 10000 2000 2026-01-01 2026-02-01 1
 
 log "gen 100,000"
-run_generator 100000 20000 2026-02-01 2026-03-01
+run_generator 100000 20000 2026-02-01 2026-03-01 7
 
 log "gen 1,000,000"
-run_generator 1000000 200000 2026-03-01 2026-04-01
+run_generator 1000000 200000 2026-03-01 2026-04-01 0
 
 ## checkup
 set -x


### PR DESCRIPTION
During build report perf tests, 1M hosts are generated, but the same set gets saved on each day - so extractors have to parse 31M host entries, not 1M, skewing the results.

=> Allow setting the frequency at which we output main_host tarballs from the generator.

This prevents having to parse 31M host entries when generating 1M, by only outputting the main_host data once per month in the generator.

```
MAIN_HOST_FREQUENCY=1 # default, output every day; used for 10k
MAIN_HOST_FREQUENCY=7 # output every 7 days; used for 100k
MAIN_HOST_FREQUENCY=0 # output once, at the end of the interval; used for 1M
```

(This only affects the generator, we should try to have the main_host collector only pick up hosts modified since, or something like that, for when something like this happens in the real world, but that's for #209.)