### PR TITLE
gather validation - don't validate report_type, only used in build_report

### DIFF
--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -157,13 +157,16 @@ def validate_report_type(errors, method):
     Returns:
         str or None: The value of the 'METRICS_UTILITY_REPORT_TYPE' environment variable if set, otherwise None.
     """
+    if method == 'gather':
+        return None
+
     report_type = os.getenv('METRICS_UTILITY_REPORT_TYPE')
     if report_type and report_type not in VALID_REPORT_TYPES:
         errors.append(
             f'Invalid METRICS_UTILITY_REPORT_TYPE: {report_type}. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
         )
-    if method == 'build' and report_type is None:
+    if report_type is None:
         errors.append(
             f'Invalid METRICS_UTILITY_REPORT_TYPE is Empty. Valid values: {", ".join(VALID_REPORT_TYPES)}. '
             f'Please note these values are case sensitive'
@@ -266,7 +269,7 @@ def validate_ship_target(errors, method, report_type):
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET is empty. Valid values: {", ".join(ship_target_type)}')
     if ship_target and ship_target not in ship_target_type:
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Valid values: {", ".join(ship_target_type)}')
-    if report_type == 'RENEWAL_GUIDANCE' and ship_target != 'controller_db':
+    if method == 'build' and report_type == 'RENEWAL_GUIDANCE' and ship_target != 'controller_db':
         errors.append(f'Invalid METRICS_UTILITY_SHIP_TARGET: {ship_target}. Only "controller_db" is allowed for "RENEWAL_GUIDANCE"')
     return ship_target
 
@@ -340,19 +343,15 @@ def handle_env_validation(method: str):
     - Validating the max gather period days.
 
     Args:
-        method (str): Determines which set of valid ship targets to use for validation.
-            Should be either 'gather' or another supported method.
+        method (str): Determines which command is running, for command-specific logic
+            Should be either 'gather' or 'build'
+
+    Raises:
+        MissingRequiredEnvVar: If any required environment variable or configuration is missing or invalid.
 
     Notes:
-        - The function accumulates all errors before raising an exception, providing a comprehensive
-          error message.
-        - The specific validation functions (`validate_report_type`, `validate_ccsp_report_sheets`,
-          `validate_collectors`, `validate_ship_target`, `validate_ship_path`, `validate_max_gather_period_days`) are expected to
-          append error messages to the provided `errors` list.
-        - The `method` parameter controls which ship target validation set is used.
-        - Raises:
-            MissingRequiredEnvVar: If any required environment variable or configuration is missing
-            or invalid.
+        - The function accumulates all errors before raising an exception, providing a comprehensive error message.
+        - The specific validation functions (`validate_*`) are expected to append error messages to the provided `errors` list.
     """
     errors = []
     report_type = validate_report_type(errors, method)

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -43,11 +43,11 @@ def test_validate_report_type_build_valid(monkeypatch):
     assert not errors
 
 
-def test_validate_report_type_gather_valid(monkeypatch):
-    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'CCSP')
+def test_validate_report_type_gather(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'ignored')
     errors = []
     result = validate_report_type(errors, 'gather')
-    assert result == 'CCSP'
+    assert result is None
     assert not errors
 
 
@@ -55,15 +55,6 @@ def test_validate_report_type_build_invalid(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
     errors = []
     result = validate_report_type(errors, 'build')
-    assert result == 'INVALID'
-    assert errors
-    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in errors[0]
-
-
-def test_validate_report_type_gather_invalid(monkeypatch):
-    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'INVALID')
-    errors = []
-    result = validate_report_type(errors, 'gather')
     assert result == 'INVALID'
     assert errors
     assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in errors[0]
@@ -300,7 +291,6 @@ def test_handle_env_validation_gather_raises1(monkeypatch):
     with pytest.raises(MissingRequiredEnvVar) as excinfo:
         handle_env_validation('gather')
     msg = str(excinfo.value)
-    assert 'Invalid METRICS_UTILITY_REPORT_TYPE' in msg
     assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
 
@@ -343,3 +333,11 @@ def test_handle_env_validation_raises_valid_buid_report_type(monkeypatch):
     msg = str(excinfo.value)
     assert 'Invalid METRICS_UTILITY_OPTIONAL_COLLECTORS' in msg
     assert 'Invalid METRICS_UTILITY_SHIP_TARGET' in msg
+
+
+def test_report_type_ignored_in_gather(monkeypatch):
+    monkeypatch.setenv('METRICS_UTILITY_REPORT_TYPE', 'RENEWAL_GUIDANCE')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_TARGET', 'directory')
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', 'whatever')
+    # Only "controller_db" is allowed for "RENEWAL_GUIDANCE" .. but only in build_report
+    handle_env_validation('gather')


### PR DESCRIPTION
Issue: AAP-52436

```
METRICS_UTILITY_SHIP_TARGET=directory
METRICS_UTILITY_SHIP_PATH=anywhere
METRICS_UTILITY_REPORT_TYPE=RENEWAL_GUIDANCE # should be irrelevant for gather

$ metrics-utility gather_automation_controller_billing_data --ship --since=20d
Invalid METRICS_UTILITY_SHIP_TARGET: directory. Only "controller_db" is allowed for "RENEWAL_GUIDANCE"
```

that particular validation is only relevant for `build_report`, not for `gather_automation_controller_billing_data`

=> Change `validate_report_type` to return `None`  (and no errors) when `method == 'gather'`
=> Change `validate_ship_target` to only do `report_type`-based checks when `method == 'build'` (although the type is `None` now anyway)