### PR TITLE
build_report w/ .._SHIP_TARGET=s3: Fix No such file or directory loading the tarballs

### DIFF
--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -8,16 +8,10 @@ from metrics_utility.logger import logger
 class ExtractorDirectory(Base):
     LOG_PREFIX = '[ExtractorDirectory]'
 
-    def iter_batches(self, date, columns=None, batch_size=None):
-        if batch_size is None:
-            batch_size = self.batch_size()
-
+    def iter_batches(self, date, columns=None):
         # Read tarball in memory in batches
         logger.debug(f'{self.LOG_PREFIX} Processing {date}')
         paths = self.fetch_partition_paths(date)
-
-        if batch_size is None:
-            batch_size = self.batch_size()
 
         for path in paths:
             if not path.endswith('.tar.gz'):
@@ -39,7 +33,3 @@ class ExtractorDirectory(Base):
             paths = []
 
         return paths
-
-    @staticmethod
-    def batch_size():
-        return 100000

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -31,7 +31,7 @@ class ExtractorS3(Base):
                     local_path = os.path.join(temp_dir, 'source_tarball')
                     self.s3_handler.download_file(s3_path, local_path)
 
-                    yield self.process_tarballs(s3_path, temp_dir)
+                    yield self.process_tarballs(local_path, temp_dir)
 
                 except Exception as e:
                     logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {s3_path} failed with {e}')

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -14,16 +14,10 @@ class ExtractorS3(Base):
 
         self.s3_handler = S3Handler(params=self.extra_params)
 
-    def iter_batches(self, date, columns=None, batch_size=None):
-        if batch_size is None:
-            batch_size = self.batch_size()
-
+    def iter_batches(self, date, columns=None):
         # Read tarball in memory in batches
         logger.debug(f'{self.LOG_PREFIX} Processing {date}')
         s3_paths = self.fetch_partition_paths(date)
-
-        if batch_size is None:
-            batch_size = self.batch_size()
 
         for s3_path in s3_paths:
             with tempfile.TemporaryDirectory(prefix='automation_controller_billing_data_') as temp_dir:
@@ -41,7 +35,3 @@ class ExtractorS3(Base):
 
         paths = [file for file in self.s3_handler.list_files(prefix)]
         return paths
-
-    @staticmethod
-    def batch_size():
-        return 100000

--- a/metrics_utility/test/gather/test_jobhostsummary_gather.py
+++ b/metrics_utility/test/gather/test_jobhostsummary_gather.py
@@ -85,32 +85,32 @@ test_lines = [
     'job_template_name,inventory_remote_id,inventory_name,organization_remote_id,'
     'organization_name,project_remote_id,project_name',
     '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,1,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,1,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',
     '2,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,2,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,1,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',
     '3,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,1,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,2,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',
     '4,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,2,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,2,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',
     '5,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,1,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,3,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',
     '6,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,2,'
-    'default_ansible_host,default_ansible_connection,0,0,0,0,0,0,f,0,0,'
+    'default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
     '2025-06-13 10:00:00+00,3,1,default_unified_job_2025-06-13,1,'
     'default_inventory_2025-06-13,1,default_org_2025-06-13,1,'
     'default_unified_job_template_2025-06-13',

--- a/metrics_utility/test/gather/test_s3_gather.py
+++ b/metrics_utility/test/gather/test_s3_gather.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from metrics_utility.test.util import run_gather_ext, run_gather_int
+from metrics_utility.test.util import run_build_ext, run_gather_ext, run_gather_int
 
 
 env_vars = {
@@ -12,7 +12,7 @@ env_vars = {
     'METRICS_UTILITY_BUCKET_REGION': 'us-east-1',
     'METRICS_UTILITY_BUCKET_SECRET_KEY': 'myusersecretkey',
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
-    'METRICS_UTILITY_SHIP_PATH': 'metrics-utility/shipped_data',
+    'METRICS_UTILITY_SHIP_PATH': f'metrics-utility/shipped_data_{os.getpid()}',
     'METRICS_UTILITY_SHIP_TARGET': 's3',
 }
 
@@ -21,7 +21,7 @@ env_vars = {
 def test_command():
     """Build xlsx report using build command and test its contents."""
     run_gather_ext(env_vars, ['--ship', '--until=10m'])
-    # mc ls -r local/metricsutilitys3/metrics-utility/shipped_data/data/
+    # mc ls -r local/metricsutilitys3/metrics-utility/shipped_data_*/data/
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
@@ -34,3 +34,19 @@ def test_import():
             'until': '10m',
         },
     )
+
+
+def test_full():
+    rg = run_gather_ext(env_vars, ['--ship', '--since=2025-06-13', '--until=2025-06-14'])
+    rb = run_build_ext(env_vars, ['--since=2025-06-13', '--until=2025-06-13'])
+
+    assert 'Final since-until: 2025-06-13 00:00:00+00:00 to 2025-06-14 00:00:00+00:00' in rg.stderr
+    assert 'Progress info: Now gathering job_host_summary' in rg.stderr
+    assert 'Progress info: Skipping main_host because it is not enabled.' in rg.stderr
+    assert 'Progress info: Skipping main_indirectmanagednodeaudit because it is not enabled.' in rg.stderr
+    assert 'Progress info: Now gathering main_jobevent' in rg.stderr
+    assert 'Analytics collected' in rg.stderr
+
+    output_filename = env_vars['METRICS_UTILITY_SHIP_PATH'] + '/reports/2025/06/CCSPv2-2025-06-13--2025-06-13.xlsx'
+    assert f'Report sent into S3 bucket into path: {output_filename}' in rb.stderr
+    assert f'Report generated into s3: {output_filename}' in rb.stderr

--- a/run-s3-gather-build
+++ b/run-s3-gather-build
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+cd "`dirname "$0"`"
+
+export METRICS_UTILITY_REPORT_TYPE="CCSPv2"
+export METRICS_UTILITY_SHIP_PATH="$$"
+export METRICS_UTILITY_SHIP_TARGET="s3"
+
+export METRICS_UTILITY_BUCKET_ACCESS_KEY="myuseraccesskey"
+export METRICS_UTILITY_BUCKET_ENDPOINT="http://localhost:9000"
+export METRICS_UTILITY_BUCKET_NAME="metricsutilitys3"
+export METRICS_UTILITY_BUCKET_REGION="us-east-1"
+export METRICS_UTILITY_BUCKET_SECRET_KEY="myusersecretkey"
+
+if ! pg_isready -h localhost; then
+  echo "run-s3-gather-build: DB not ready, run make compose first"
+  exit 1
+fi
+
+minio-mc alias set local "$METRICS_UTILITY_BUCKET_ENDPOINT" "$METRICS_UTILITY_BUCKET_ACCESS_KEY" "$METRICS_UTILITY_BUCKET_SECRET_KEY"
+echo
+echo minio-mc ls -r local/"$METRICS_UTILITY_BUCKET_NAME"/"$METRICS_UTILITY_SHIP_PATH"
+minio-mc ls -r local/"$METRICS_UTILITY_BUCKET_NAME"/"$METRICS_UTILITY_SHIP_PATH"
+echo
+uv run ./manage.py gather_automation_controller_billing_data --ship --since=2025-06-01 --until=2025-07-01 --force
+echo
+minio-mc ls -r local/"$METRICS_UTILITY_BUCKET_NAME"/"$METRICS_UTILITY_SHIP_PATH"/data
+echo
+uv run ./manage.py build_report --month=2025-06 --force
+echo
+minio-mc ls -r local/"$METRICS_UTILITY_BUCKET_NAME"/"$METRICS_UTILITY_SHIP_PATH"/reports

--- a/tools/docker/main_jobhostsummary.sql
+++ b/tools/docker/main_jobhostsummary.sql
@@ -521,7 +521,7 @@ $yaml$,
         0,-- changed
         0,-- dark
         0,-- failures
-        0,-- ok
+        1,-- ok
         0,-- processed
         0,-- skipped
         false,-- failed


### PR DESCRIPTION
Issue: AAP-52435

Found a bug in build_report during hackathon - gather successfully saves data to s3, but build can't then find it using the same bucket & ship setings

```
$ minio-mc ls -r local/metricsutilitys3/1864272
...
[2025-08-29 20:28:15 UTC] 1.3KiB STANDARD data/2024/04/01/00000000-0000-0000-0000-000000000000-2024-04-01-000000+0000-2024-04-02-000000+0000-0.tar.gz
...
$ metrics-utility build_report --month=2024-04
Automation Controller modules not found in /awx_devel (AWX_PATH). Using mock and continuing.
[ExtractorS3] ERROR: Extracting 1864272/data/2024/04/01/00000000-0000-0000-0000-000000000000-2024-04-01-000000+0000-2024-04-02-000000+0000-0.tar.gz failed with [Errno 2] No such file or directory: '1864272/data/2024/04/01/00000000-0000-0000-0000-000000000000-2024-04-01-000000+0000-2024-04-02-000000+0000-0.tar.gz'
Traceback (most recent call last):
  File "/home/himdel/metrics/metrics-utility/metrics_utility/automation_controller_billing/extract/extractor_s3.py", line 34, in iter_batches
    yield self.process_tarballs(s3_path, temp_dir)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/automation_controller_billing/extract/base.py", line 60, in process_tarballs
    _safe_extract(path, temp_dir)
  File "/home/himdel/metrics/metrics-utility/metrics_utility/automation_controller_billing/extract/base.py", line 155, in _safe_extract
    with tarfile.open(tar_path, 'r:*') as tar:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/tarfile.py", line 1835, in open
    return func(name, "r", fileobj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/tarfile.py", line 1903, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/gzip.py", line 192, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '1864272/data/2024/04/01/00000000-0000-0000-0000-000000000000-2024-04-01-000000+0000-2024-04-02-000000+0000-0.tar.gz'
...
```

* gather outputs data to s3 just fine
* build outputs reports to s3 fine too
* build downloads from s3, then loads the local file
* but since #75 it tried to unpack the remote path, instead of the local one => fixing

---

=> Change ExtractorS3 to use `local_path` for `process_tarballs`
=> Update `main_jobhostquery.sql` data and test to generate a non-empty report so we can test this
=> Add a `run_s3_gather_build` script that tests we can run gather & build configured with s3 and end up with a report. all in s3.
=> Clean up unused batch_size code in extractors
=> Add tests