### PR TITLE
main_host collector: filter hosts by since & until (created OR modified)

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -23,6 +23,7 @@ from metrics_utility.base import register
 from metrics_utility.base.utils import get_max_gather_period_days, get_optional_collectors
 from metrics_utility.exceptions import MetricsException, MissingRequiredEnvVar
 from metrics_utility.library import CsvFileSplitter
+from metrics_utility.library.collectors.util import date_where
 from metrics_utility.logger import logger, logger_info_level
 
 from .prometheus_client import PrometheusClient
@@ -453,100 +454,119 @@ def main_indirectmanagednodeaudit_table(since, full_path, until, **kwargs):
         return None
 
 
+# shared function, not a standalone collector
+def _main_host_query(where):
+    return f"""
+        SELECT main_host.name as host_name,
+                main_host.id AS host_id,
+                main_inventory.id AS inventory_remote_id,
+                main_inventory.name AS inventory_name,
+                main_organization.id AS organization_remote_id,
+                main_organization.name AS organization_name,
+                main_unifiedjob.created AS last_automation,
+
+                CASE
+                    WHEN (metrics_utility_is_valid_json(main_host.variables))
+                        THEN main_host.variables::jsonb->>'ansible_host'
+                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
+                END AS ansible_host_variable,
+
+                jsonb_build_object(
+                    'ansible_product_serial', main_host.ansible_facts->>'ansible_product_serial'::TEXT,
+                    'ansible_machine_id', main_host.ansible_facts->>'ansible_machine_id'::TEXT,
+                    'ansible_host',
+                    CASE
+                        WHEN (metrics_utility_is_valid_json(main_host.variables))
+                            THEN main_host.variables::jsonb->>'ansible_host'
+                        ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
+                    END,
+                    'host_name', main_host.name,
+                    'ansible_port',
+                    CASE
+                        WHEN (
+                            CASE
+                                WHEN (metrics_utility_is_valid_json(main_host.variables))
+                                    THEN main_host.variables::jsonb->>'ansible_port'
+                                ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_port' )
+                            END
+                        ) ~ '^[0-9]+$' THEN
+                            (
+                                CASE
+                                    WHEN (metrics_utility_is_valid_json(main_host.variables))
+                                        THEN main_host.variables::jsonb->>'ansible_port'
+                                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_port' )
+                                END
+                            )::INTEGER
+                        ELSE NULL
+                    END
+                ) AS canonical_facts,
+
+                jsonb_build_object(
+                    'ansible_connection_variable',
+                    CASE
+                        WHEN (metrics_utility_is_valid_json(main_host.variables))
+                            THEN main_host.variables::jsonb->>'ansible_connection'
+                        ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
+                    END,
+                    'ansible_virtualization_type',
+                    main_host.ansible_facts->>'ansible_virtualization_type'::TEXT,
+                    'ansible_virtualization_role',
+                    main_host.ansible_facts->>'ansible_virtualization_role'::TEXT,
+                    'ansible_system_vendor',
+                    main_host.ansible_facts->>'ansible_system_vendor'::TEXT,
+                    'ansible_product_name',
+                    main_host.ansible_facts->>'ansible_product_name'::TEXT,
+                    'ansible_architecture',
+                    main_host.ansible_facts->>'ansible_architecture'::TEXT,
+                    'ansible_processor',
+                    main_host.ansible_facts->>'ansible_processor'::TEXT,
+                    'ansible_form_factor',
+                    main_host.ansible_facts->>'ansible_form_factor'::TEXT,
+                    'ansible_bios_vendor',
+                    main_host.ansible_facts->>'ansible_bios_vendor'::TEXT,
+                    'ansible_bios_version',
+                    main_host.ansible_facts->>'ansible_bios_version'::TEXT,
+                    'ansible_board_serial',
+                    main_host.ansible_facts->>'ansible_board_serial'::TEXT
+                ) AS facts
+
+        FROM main_host
+        LEFT JOIN main_inventory
+            ON main_inventory.id = main_host.inventory_id
+        LEFT JOIN main_organization
+            ON main_organization.id = main_inventory.organization_id
+        LEFT JOIN main_unifiedjob
+            ON main_unifiedjob.id = main_host.last_job_id
+        WHERE {where}
+        ORDER BY main_host.id ASC
+    """
+
+
 @register('main_host', '1.0', format='csv', description=_('Inventory data'), fnc_slicing=limit_slicing)
-def main_host_table(since, full_path, until, **kwargs):
+def main_host(since, full_path, until, **kwargs):
     if 'main_host' not in get_optional_collectors():
         return None
 
-    query = """
-        (
-            SELECT main_host.name as host_name,
-                   main_host.id AS host_id,
-                   main_inventory.id AS inventory_remote_id,
-                   main_inventory.name AS inventory_name,
-                   main_organization.id AS organization_remote_id,
-                   main_organization.name AS organization_name,
-                   main_unifiedjob.created AS last_automation,
-
-                   CASE
-                       WHEN (metrics_utility_is_valid_json(main_host.variables))
-                           THEN main_host.variables::jsonb->>'ansible_host'
-                       ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
-                   END AS ansible_host_variable,
-
-                   jsonb_build_object(
-                       'ansible_product_serial', main_host.ansible_facts->>'ansible_product_serial'::TEXT,
-                       'ansible_machine_id', main_host.ansible_facts->>'ansible_machine_id'::TEXT,
-                       'ansible_host',
-                       CASE
-                           WHEN (metrics_utility_is_valid_json(main_host.variables))
-                              THEN main_host.variables::jsonb->>'ansible_host'
-                           ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
-                       END,
-                       'host_name', main_host.name,
-                       'ansible_port',
-                       CASE
-                           WHEN (
-                               CASE
-                                   WHEN (metrics_utility_is_valid_json(main_host.variables))
-                                      THEN main_host.variables::jsonb->>'ansible_port'
-                                   ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_port' )
-                               END
-                           ) ~ '^[0-9]+$' THEN
-                               (
-                                   CASE
-                                       WHEN (metrics_utility_is_valid_json(main_host.variables))
-                                          THEN main_host.variables::jsonb->>'ansible_port'
-                                       ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_port' )
-                                   END
-                               )::INTEGER
-                           ELSE NULL
-                       END
-                   ) AS canonical_facts,
-
-                   jsonb_build_object(
-                       'ansible_connection_variable',
-                       CASE
-                           WHEN (metrics_utility_is_valid_json(main_host.variables))
-                              THEN main_host.variables::jsonb->>'ansible_connection'
-                           ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
-                       END,
-                       'ansible_virtualization_type',
-                       main_host.ansible_facts->>'ansible_virtualization_type'::TEXT,
-                       'ansible_virtualization_role',
-                       main_host.ansible_facts->>'ansible_virtualization_role'::TEXT,
-                       'ansible_system_vendor',
-                       main_host.ansible_facts->>'ansible_system_vendor'::TEXT,
-                       'ansible_product_name',
-                       main_host.ansible_facts->>'ansible_product_name'::TEXT,
-                       'ansible_architecture',
-                       main_host.ansible_facts->>'ansible_architecture'::TEXT,
-                       'ansible_processor',
-                       main_host.ansible_facts->>'ansible_processor'::TEXT,
-                       'ansible_form_factor',
-                       main_host.ansible_facts->>'ansible_form_factor'::TEXT,
-                       'ansible_bios_vendor',
-                       main_host.ansible_facts->>'ansible_bios_vendor'::TEXT,
-                       'ansible_bios_version',
-                       main_host.ansible_facts->>'ansible_bios_version'::TEXT,
-                       'ansible_board_serial',
-                       main_host.ansible_facts->>'ansible_board_serial'::TEXT
-                   ) AS facts
-
-            FROM main_host
-            LEFT JOIN main_inventory
-                ON main_inventory.id = main_host.inventory_id
-            LEFT JOIN main_organization
-                ON main_organization.id = main_inventory.organization_id
-            LEFT JOIN main_unifiedjob
-                ON main_unifiedjob.id = main_host.last_job_id
-            WHERE enabled='t'
-            ORDER BY main_host.id ASC
-        )
-        """
-
+    query = _main_host_query("enabled='t'")
     return _copy_table(
         table='main_host', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=yaml_and_json_parsing_functions()
+    )
+
+
+@register('main_host_daily', '1.0', format='csv', description=_('Inventory data - daily active hosts'), fnc_slicing=daily_slicing)
+def main_host_daily(since, full_path, until, **kwargs):
+    if 'main_host_daily' not in get_optional_collectors():
+        return None
+
+    where = f"""
+        enabled='t'
+        AND ({date_where('main_host.created', since, until)}
+        OR {date_where('main_host.modified', since, until)})
+    """
+
+    query = _main_host_query(where)
+    return _copy_table(
+        table='main_host_daily', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=yaml_and_json_parsing_functions()
     )
 
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
@@ -23,9 +23,11 @@ class DataframeInventoryScope(Base):
             # Generate the monthly dataset for report
             ###############################
 
-            for data in self.extractor.iter_batches(date=date, collections=['main_host'], optional=['config']):
+            for data in self.extractor.iter_batches(date=date, collections=['main_host', 'main_host_daily'], optional=['config']):
                 # If the dataframe is empty, skip additional processing
                 billing_data = data['main_host']
+                if billing_data.empty:
+                    billing_data = data['main_host_daily']
                 if billing_data.empty:
                     continue
 

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -9,6 +9,16 @@ from metrics_utility.exceptions import MetricsException
 from metrics_utility.logger import logger
 
 
+_main_host_sheets = [
+    'inventory_scope',
+    'jobs',
+    'managed_nodes',
+    'managed_nodes_by_organizations',
+    'usage_by_collections',
+    'usage_by_modules',
+    'usage_by_roles',
+]
+
 # csv name => [ sheet_names ]
 CSV_SHEETS = {
     'job_host_summary': [
@@ -19,15 +29,8 @@ CSV_SHEETS = {
         'managed_nodes_by_organizations',
         'usage_by_organizations',
     ],
-    'main_host': [
-        'inventory_scope',
-        'jobs',
-        'managed_nodes',
-        'managed_nodes_by_organizations',
-        'usage_by_collections',
-        'usage_by_modules',
-        'usage_by_roles',
-    ],
+    'main_host': _main_host_sheets,
+    'main_host_daily': _main_host_sheets,
     'main_indirectmanagednodeaudit': [
         'indirectly_managed_nodes',
         'managed_nodes',
@@ -69,6 +72,7 @@ class Base:
             'main_indirectmanagednodeaudit': empty_dataframe,
             'job_host_summary': empty_dataframe,
             'main_host': empty_dataframe,
+            'main_host_daily': empty_dataframe,
             'main_jobevent': empty_dataframe,
         }
 
@@ -89,6 +93,9 @@ class Base:
 
         if self.csv_enabled('main_host'):
             needed_data['main_host'] = self.build_data_batch(temp_dir, 'main_host')
+
+        if self.csv_enabled('main_host_daily'):
+            needed_data['main_host_daily'] = self.build_data_batch(temp_dir, 'main_host_daily')
 
         return needed_data
 

--- a/metrics_utility/library/collectors/controller/__init__.py
+++ b/metrics_utility/library/collectors/controller/__init__.py
@@ -2,7 +2,7 @@ from .config import config
 from .execution_environments import execution_environments
 from .job_host_summary import job_host_summary
 from .job_host_summary_service import job_host_summary_service
-from .main_host import main_host
+from .main_host import main_host, main_host_daily
 from .main_indirectmanagednodeaudit import main_indirectmanagednodeaudit
 from .main_jobevent import main_jobevent
 from .main_jobevent_service import main_jobevent_service
@@ -15,6 +15,7 @@ __all__ = [
     'job_host_summary',
     'job_host_summary_service',
     'main_host',
+    'main_host_daily',
     'main_indirectmanagednodeaudit',
     'main_jobevent',
     'main_jobevent_service',

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -1,9 +1,8 @@
-from ..util import collector, copy_table
+from ..util import collector, copy_table, date_where
 
 
-@collector
-def main_host(*, db=None, output_dir=None):
-    query = """
+def _main_host_query(where):
+    return f"""
         SELECT
             main_host.name as host_name,
             main_host.id AS host_id,
@@ -82,8 +81,23 @@ def main_host(*, db=None, output_dir=None):
         LEFT JOIN main_inventory ON main_inventory.id = main_host.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_inventory.organization_id
         LEFT JOIN main_unifiedjob ON main_unifiedjob.id = main_host.last_job_id
-        WHERE enabled='t'
+        WHERE {where}
         ORDER BY main_host.id ASC
     """
 
+
+@collector
+def main_host(*, db=None, output_dir=None):
+    query = _main_host_query("enabled='t'")
     return copy_table(db=db, table='main_host', query=query, prepend_query=True, output_dir=output_dir)
+
+
+@collector
+def main_host_daily(*, db=None, since=None, until=None, output_dir=None):
+    where = f"""
+        enabled='t'
+        AND ({date_where('main_host.created', since, until)}
+        OR {date_where('main_host.modified', since, until)})
+    """
+    query = _main_host_query(where)
+    return copy_table(db=db, table='main_host_daily', query=query, prepend_query=True, output_dir=output_dir)

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -94,6 +94,8 @@ def main_host(*, db=None, output_dir=None):
 
 @collector
 def main_host_daily(*, db=None, since=None, until=None, output_dir=None):
+    # prefer running with until=False, to not skip hosts that keep being modified
+
     where = f"""
         enabled='t'
         AND ({date_where('main_host.created', since, until)}

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -5,6 +5,11 @@ import tempfile
 from ..csv_file_splitter import CsvFileSplitter
 
 
+# FIXME: psycopg.sql
+def date_where(field, since, until):
+    return f'( {field} >= {since.isoformat()} AND {field} < {until.isoformat()} )'
+
+
 def collector(func):
     """Decorator that creates a collector class and returns a constructor function."""
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -7,7 +7,16 @@ from ..csv_file_splitter import CsvFileSplitter
 
 # FIXME: psycopg.sql
 def date_where(field, since, until):
-    return f'( {field} >= {since.isoformat()} AND {field} < {until.isoformat()} )'
+    if since and until:
+        return f'( "{field}" >= \'{since.isoformat()}\' AND "{field}" < \'{until.isoformat()}\' )'
+
+    if since:
+        return f'( "{field}" >= \'{since.isoformat()}\' )'
+
+    if until:
+        return f'( "{field}" < \'{until.isoformat()}\' )'
+
+    return 'true'
 
 
 def collector(func):

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -20,7 +20,9 @@ ALLOWED_EPHEMERAL_PATTERN = r'^\d+(d|day|days|m|mo|month|months)$'
 # Constants for valid values
 MAX_GATHER_PERIOD_DAYS = 3650  # 10 years maximum
 MAX_GATHER_PERIOD_DAYS_ERROR_MSG = f'Value must be number between 0 to {MAX_GATHER_PERIOD_DAYS}'
+
 VALID_REPORT_TYPES = {'CCSP', 'CCSPv2', 'RENEWAL_GUIDANCE'}
+
 VALID_SHEETS = {
     'CCSP': {
         'ccsp_summary',
@@ -48,15 +50,17 @@ VALID_SHEETS = {
         'managed_nodes_by_organizations',
     },
 }
+
 VALID_COLLECTORS = {
+    'execution_environments',
+    'job_host_summary_service',
     'main_host',
-    'main_jobevent',
+    'main_host_daily',
     'main_indirectmanagednodeaudit',
+    'main_jobevent',
+    'main_jobevent_service',
     'total_workers_vcpu',
     'unified_jobs',
-    'job_host_summary_service',
-    'main_jobevent_service',
-    'execution_environments',
 }
 
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}


### PR DESCRIPTION
The idea is to reduce the amount of hosts we collect from *all the hosts*, ever,
to only hosts active during the collection period, but also to allow collecting inactive hosts too.

We still need inactive host data, just not necessarily daily, so, this becomes 2 different collectors:
* `main_host_daily` (new, optional, daily_slicing) 
* `main_host` (original, optional, limit_slicing)

The suggested way to run this is a daily cronjob with since/until enabled:

```
METRICS_UTILITY_OPTIONAL_COLLECTORS=main_host_daily
```

and then a separate weekly cronjob for just the all-hosts snaphot.

```
METRICS_UTILITY_OPTIONAL_COLLECTORS=main_host
METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR=true
```


Later PRs:

* update generator to allow both snapshots and dailies for main_host ... but also the other collectors