### PR TITLE
Bump versions to 0.6.1dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,7 @@
 - dev: tests set up awx environment by default; more tests
 - dev: perf tests split up to make testing branches easier
 - dev: remove pytz
+
+## 0.6.1dev
+
+- TODO

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ As the project grows, more guides and references will be added to the `/docs` fo
 |-|-|
 |0.4.1|2.4\*|
 |0.5.0|2.5-20250507|
+|0.6.0|2.5.20250924 & 2.6|
 
 ## Contributing
 

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -141,7 +141,7 @@ def config(since, **kwargs):
         'logging_aggregators': settings.LOG_AGGREGATOR_LOGGERS,
         'external_logger_enabled': settings.LOG_AGGREGATOR_ENABLED,
         'external_logger_type': getattr(settings, 'LOG_AGGREGATOR_TYPE', None),
-        'metrics_utility_version': '0.6.0',  # TODO read from setup.cfg
+        'metrics_utility_version': '0.6.1dev',  # TODO read from setup.cfg
         'billing_provider_params': {},  # Is being overwritten in collector.gather by set ENV VARS
     }
 

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -51,7 +51,7 @@ class ManagementUtility(management.ManagementUtility):
         # 'django-admin --help' to work, for backwards compatibility.
         elif subcommand == 'version' or self.argv[1:] == ['--version']:
             # sys.stdout.write(django.get_version() + "\n")
-            sys.stdout.write('0.6.0' + '\n')
+            sys.stdout.write('0.6.1dev' + '\n')
         elif self.argv[1:] in (['--help'], ['-h']):
             sys.stdout.write(self.main_help_text() + '\n')
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.6.0
+version = 0.6.1dev
 
 [options]
 packages = find:


### PR DESCRIPTION
having tagged the 0.6.0 release (#210)
it's time to update the version to distinguish devel from 0.6.0.

---

(Technically, #188 obviates the need to change the version number everywhere, but .. one step at a time :).)