### PR TITLE
sast: added sast using snyk code

### DIFF
--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -1,16 +1,13 @@
 name: SAST Snyk Code
 on:
   schedule:
-    - cron: '23 14 * * *'
-  push:
-    branches:
-      - 'main'
+    - cron: '23 14 * * 6'
   workflow_dispatch:
 jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
 
       - uses: snyk/actions/setup@master
 

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -1,0 +1,22 @@
+name: SAST Snyk Code
+on:
+  schedule:
+    - cron: '23 14 * * *'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: snyk/actions/setup@master
+
+      - name: Generate code vulnerability report
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          snyk code test --project-name="${{ github.repository }}" --report ${{ github.workspace }}
+        continue-on-error: true


### PR DESCRIPTION
Added SAST scan using Snyk Code.
The pipeline will run once a week and the results will be sent to Ansible AAP Snyk organization.

As the product is being built at the moment with CPaaS, there are no automated SAST checks for this repo. With this MR, the codebase is covered on SAST for the SDLC. This won't be blocking as the pipelines won't run at each merge request.

In order for this to work, a `SNYK_TOKEN` secret needs to be created. @robinbobbitt 