### PR TITLE
Delete events in testathon script

### DIFF
--- a/testathon/testathon_data_prepare.py
+++ b/testathon/testathon_data_prepare.py
@@ -706,6 +706,13 @@ def delete_indirect_hosts():
     run(sql)
 
 
+def delete_events():
+    sql = """
+    DELETE FROM main_jobevent;
+    """
+    run(sql)
+
+
 def main():
     if ENVIRONMENT == 'OpenShift':
         oc_login()
@@ -714,6 +721,7 @@ def main():
 
     list_main_jobhostsummary()
 
+    delete_events()
     delete_all_hosts()
     delete_projects()
     delete_job_templates()


### PR DESCRIPTION
Very small fix, testathon script did not had events deletion at the script begining - simply because we did statistics on distinct usage of collections, roles, modules, the error was not discovered.
