### PR TITLE
AAP-54267 - config.json - ensure non-empty billing_provider_data

### DIFF
--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -66,13 +66,6 @@ class Collector(base.Collector):
 
             self._gather_json_collections()
 
-            # Extend the config collection to contain billing specific info:
-            config_collection = self.collections['config']
-            data = json.loads(config_collection.data)
-            data['billing_provider_params'] = billing_provider_params
-            config_collection._save_gathering(data)
-            # End of extension
-
             self._gather_csv_collections()
 
             self._process_packages()
@@ -82,6 +75,18 @@ class Collector(base.Collector):
             self._gather_cleanup()
 
             return self.all_tar_paths()
+
+    def _gather_config(self):
+        if not super()._gather_config():
+            return False
+
+        # Extend the config collection to contain billing specific info:
+        config_collection = self.collections['config']
+        data = json.loads(config_collection.data)
+        data['billing_provider_params'] = self.billing_provider_params
+        config_collection._save_gathering(data)
+
+        return True
 
     def _is_valid_license(self):
         # TODO: which license to check? Any license will do?


### PR DESCRIPTION
Issue: AAP-54267

Introduced in #189, related to #165.

When running gather with...

```
export METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES="true"
export METRICS_UTILITY_OPTIONAL_COLLECTORS="total_workers_vcpu"
```

the `config.json` can be saved to tarball during `_gather_json_collections`,
which happens after `_gather_config`, but before config gets updated with `billing_provider_params`.

But the alteration to config only happened after gather json, which still works with the default set of collectors (job_host_summary being the first one),
but breaks if a json collector becomes the first one, such as when running with the env above.

Fixing so that the alteration happens inside `_gather_config` instead, preventing the timing issue.

---

## Local testing...

(change to make it possible to run with ship target crc without the right certs, and keep the tarball)

```diff
diff --git a/metrics_utility/automation_controller_billing/package/package_crc.py b/metrics_utility/automation_controller_billing/package/package_crc.py
index 5c53904..60c7c68 100644
--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -72,6 +72,7 @@ class PackageCRC(base.Package):
         return True
 
     def _send_data(self, url, files, session):
+        return True
         # TODO: move to base
         if self.shipping_auth_mode() == self.SHIPPING_AUTH_SERVICE_ACCOUNT:
             sso_url = self.get_sso_url()
diff --git a/metrics_utility/base/collector.py b/metrics_utility/base/collector.py
index 5624946..bada9ec 100644
--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -387,8 +387,8 @@ class Collector:
     def _gather_cleanup(self):
         """Deleting temp files"""
         shutil.rmtree(self.tmp_dir, ignore_errors=True)  # clean up individual artifact files
-        if not self.is_dry_run():
-            self.delete_tarballs()
+        # if not self.is_dry_run():
+        #    self.delete_tarballs()
 
     def _init_tmp_dir(self, tmp_root_dir=None):
         self.tmp_dir = pathlib.Path(tmp_root_dir or tempfile.mkdtemp(prefix='awx_analytics-'))
```

(actually run this)

```
export METRICS_UTILITY_BILLING_ACCOUNT_ID="692379310468"
export METRICS_UTILITY_BILLING_PROVIDER="aws"
export METRICS_UTILITY_CLUSTER_NAME="aap-dev"
export METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX="total_workers_vcpu"
export METRICS_UTILITY_CRC_INGRESS_URL="https://cloud.stage.redhat.com/api/ingress/v1/upload"
export METRICS_UTILITY_CRC_SSO_URL="https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
export METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR="true"
export METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES="true"
export METRICS_UTILITY_OPTIONAL_COLLECTORS="total_workers_vcpu"
export METRICS_UTILITY_PRICE_PER_NODE="0"
export METRICS_UTILITY_PROMETHEUS_URL="https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
export METRICS_UTILITY_PROXY_URL="squid.corp.redhat.com:3128"
export METRICS_UTILITY_RED_HAT_ORG_ID="11009103"
export METRICS_UTILITY_REPORT_SKU="MCT4701"
export METRICS_UTILITY_REPORT_TYPE="CCSP"
export METRICS_UTILITY_SERVICE_ACCOUNT_ID="692379310468"
export METRICS_UTILITY_SERVICE_ACCOUNT_SECRET="xxxxx"
export METRICS_UTILITY_SHIP_PATH="/tmp/GATHER"
export METRICS_UTILITY_SHIP_TARGET="crc"
export METRICS_UTILITY_USAGE_BASED_METERING_ENABLED="false"

rm /tmp/*gz -v 2>/dev/null || true

uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force --verbose "$@"

tar xOf /tmp/*-0.tar.gz ./config.json | jq .billing_provider_params
```

The last bit of the output should not be an empty `{}`.