### PR TITLE
Tarball names - add collection name

### DIFF
--- a/metrics_utility/base/package.py
+++ b/metrics_utility/base/package.py
@@ -139,7 +139,7 @@ class Package:
             tarname_base = self._tarname_base()
             path = pathlib.Path(target)
             index = len(list(path.glob(f'{tarname_base}-*.*')))
-            tarname = f'{tarname_base}-{index}.tar.gz'
+            tarname = f'{tarname_base}-{index}-unknown.tar.gz'
 
             with tarfile.open(target.joinpath(tarname), 'w:gz') as f:
                 for collection in self.collections:
@@ -152,6 +152,15 @@ class Package:
                 self._manifest_to_tar(f)
 
                 self.tar_path = f.name
+
+            try:
+                orig_path = self.tar_path
+                new_path = orig_path.replace('-unknown.', f'-{collection.key}.')
+                os.rename(orig_path, new_path)
+                self.tar_path = new_path
+            except Exception as e:
+                logger.error(f'Failed to identify collection type: {e}')
+
             return True
         except Exception as e:
             logger.exception(f'Failed to write analytics archive file: {e}')

--- a/metrics_utility/test/gather/test_gather_ranges.py
+++ b/metrics_utility/test/gather/test_gather_ranges.py
@@ -83,7 +83,7 @@ def test_only_host_scope(cleanup_glob):
         f'./metrics_utility/test/test_data/data/{year}/{month}/{day}/'
         f'00000000-0000-0000-0000-000000000000-'
         f'{year}-{month}-{day}-000000+0000-'
-        f'{year}-{month}-{day}-000000+0000-0.tar.gz'
+        f'{year}-{month}-{day}-000000+0000-0-main_host.tar.gz'
     )
 
     # ensure no other tarballs are present in the directory for current date

--- a/tools/perf/generator.py
+++ b/tools/perf/generator.py
@@ -378,7 +378,7 @@ Environment vars:
         name_base = f'{uuid}-{frm}-{to}'
 
         index = len(list(target.glob(f'{name_base}-*.*')))
-        tarname = f'{name_base}-{index}.tar.gz'
+        tarname = f'{name_base}-{index}-{table}.tar.gz'
 
         filename = target.joinpath(tarname)
         with tarfile.open(filename, 'w:gz') as tar:


### PR DESCRIPTION
Issue: AAP-52666

Update Package & generator to change the generated tarball naming:

```diff
- (base)-(index).tar.gz
+ (base)-(index)-(collection.key).tar.gz
```

This is transparent to the extractor as the extractor reads everything in the directory, ignoring filenames.
(separate PR to change that)

```
out/data/2025/10/03/00000000-0000-0000-0000-000000000000-2025-10-03-000000+0000-2025-10-03-012114+0000-0-job_host_summary.tar.gz
out/data/2025/10/03/00000000-0000-0000-0000-000000000000-2025-10-03-000000+0000-2025-10-03-012114+0000-1-main_jobevent.tar.gz
```

---

The naming comes from the `@register`ed key, but only collections with `fnc_slicing=` set trigger a tarball creation (well, and any remaining collectors at the end), and only the last collector in a tarball gets to name it, but `config` always goes first.

In practice:

* `config` - only if no other collectors ran
* `job_host_summary` - yes
* `main_jobevent` - yes
* `main_indirectmanagednodeaudit` - yes
* `main_host` - yes
* `total_workers_vcpu` - yes
* `unified_jobs` - yes
* `job_host_summary_service` - yes
* `main_jobevent_service` - yes
* `execution_environments` - yes

