### PR TITLE
Extractors, Dataframes - allow filtering tarballs and extracted files by collection name

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_collection_status.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_collection_status.py
@@ -10,7 +10,8 @@ class DataframeCollectionStatus(Base):
         dataframe = None
 
         for date in self.dates():
-            for data in self.extractor.iter_batches(date=date):
+            # collections=None because data_collection_status is in every tarball, and none of them are named after it
+            for data in self.extractor.iter_batches(date=date, collections=None, optional=['data_collection_status']):
                 batch = data['data_collection_status']
                 if batch.empty:
                     continue

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -13,7 +13,7 @@ class DataframeContentUsage(Base):
             ###############################
             # Start a daily rollup code here
             ###############################
-            for data in self.extractor.iter_batches(date=date):
+            for data in self.extractor.iter_batches(date=date, collections=['main_jobevent'], optional=['config']):
                 # If the dataframe is empty, skip additional processing
                 events = data['main_jobevent']
                 if events.empty:

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_inventory_scope.py
@@ -23,7 +23,7 @@ class DataframeInventoryScope(Base):
             # Generate the monthly dataset for report
             ###############################
 
-            for data in self.extractor.iter_batches(date=date):
+            for data in self.extractor.iter_batches(date=date, collections=['main_host'], optional=['config']):
                 # If the dataframe is empty, skip additional processing
                 billing_data = data['main_host']
                 if billing_data.empty:

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -5,7 +5,7 @@ from metrics_utility.automation_controller_billing.helpers import merge_arrays, 
 from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
-# dataframe for job_host_summary / indirect_nodes
+# dataframe for job_host_summary / main_indirectmanagednodeaudit
 class DataframeJobhostSummaryUsage(Base):
     def build_dataframe(self):
         # A daily rollup dataframe
@@ -16,12 +16,16 @@ class DataframeJobhostSummaryUsage(Base):
             # Generate the monthly dataset for report
             ###############################
 
-            for data in self.extractor.iter_batches(date=date):
+            for data in self.extractor.iter_batches(
+                date=date,
+                collections=['job_host_summary', 'main_indirectmanagednodeaudit'],
+                optional=['config'],
+            ):
                 billing_data = data['job_host_summary']
                 managed_node_type = DIRECT
 
                 if billing_data.empty:
-                    billing_data = data['indirect_nodes']
+                    billing_data = data['main_indirectmanagednodeaudit']
                     managed_node_type = INDIRECT
 
                 if billing_data.empty:

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -130,7 +130,12 @@ class Base:
         Checks if any sheets_required item is in METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
         Returns a boolean so we know which sheets to provide in the report.
         """
-        sheet_options = self.extra_params.get('optional_sheets') or []
+        sheet_options = self.extra_params.get('optional_sheets')
+
+        # no optional_sheets in rollups & generator - allow everything
+        if sheet_options is None:
+            return True
+
         return bool(set(sheet_options) & set(sheets_required))
 
     def filter_tarball_paths(self, paths, collections):

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -59,12 +59,12 @@ class Base:
             logger.warning(f'{self.LOG_PREFIX} missing required file under path: {file_path} and date: {self.date}')
 
     def process_tarballs(self, path, temp_dir, enabled_set=None):
-        _safe_extract(path, temp_dir)
+        _safe_extract(path, temp_dir, enabled_set=enabled_set)
         self.enabled_set = enabled_set
 
         empty_dataframe = pd.DataFrame([{}])
         needed_data = {
-            'config': dict(),
+            'config': None,
             'data_collection_status': empty_dataframe,
             'main_indirectmanagednodeaudit': empty_dataframe,
             'job_host_summary': empty_dataframe,
@@ -130,7 +130,7 @@ class Base:
         Checks if any sheets_required item is in METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS
         Returns a boolean so we know which sheets to provide in the report.
         """
-        sheet_options = self.extra_params.get('optional_sheets')
+        sheet_options = self.extra_params.get('optional_sheets') or []
         return bool(set(sheet_options) & set(sheets_required))
 
     def filter_tarball_paths(self, paths, collections):
@@ -182,7 +182,7 @@ def _write_member(member_path, file_obj, max_size, total_extracted_size):
     return total_extracted_size
 
 
-def _safe_extract(tar_path, extract_path, max_files=100, max_size=1024 * 1024 * 1024):
+def _safe_extract(tar_path, extract_path, max_files=100, max_size=1024 * 1024 * 1024, enabled_set=None):
     """
     Safely extract a tar archive from 'tar_path' into 'extract_path' with constraints:
       - Only extract *.json or *.csv files
@@ -190,7 +190,7 @@ def _safe_extract(tar_path, extract_path, max_files=100, max_size=1024 * 1024 * 
       - Limit number of extracted files to 'max_files'
       - Limit total uncompressed size to 'max_size' bytes
     """
-    extracted_files = 0
+    extracted_files = []
     total_extracted_size = 0
 
     # Ensure the extraction directory exists
@@ -198,32 +198,36 @@ def _safe_extract(tar_path, extract_path, max_files=100, max_size=1024 * 1024 * 
 
     with tarfile.open(tar_path, 'r:*') as tar:
         for member in tar.getmembers():
-            # 1) Skip directories and links
+            # Skip directories and links
             if member.isdir():
                 continue
             if member.issym() or member.islnk():
                 logger.warning(f'Skipping link: {member.name}')
                 continue
 
-            # 2) Only allow .json or .csv
+            # Only allow .json or .csv
             if not (member.name.endswith('.json') or member.name.endswith('.csv')):
                 continue
 
-            # 3) Build a fully qualified path for this member
-            #    and ensure it stays within extract_path.
+            # Only files from enabled_set (+ extension)
+            basename = os.path.basename(member.name)
+            if enabled_set:
+                if not any(basename.startswith(item + '.') for item in enabled_set):
+                    continue
+
+            # Build a fully qualified path for this member and ensure it stays within extract_path
             member_path = os.path.abspath(os.path.join(extract_path, member.name))
             extract_path_abs = os.path.abspath(extract_path)
             if not member_path.startswith(extract_path_abs + os.sep):
                 logger.warning(f'Skipping potentially unsafe file (path traversal): {member.name}')
                 continue
 
-            # 4) Limit total files
-            if extracted_files >= max_files:
+            # Limit total files
+            if len(extracted_files) >= max_files:
                 logger.warning(f'Reached max file limit of {max_files}.')
                 break
 
-            # 5) Extract file contents manually, in chunks,
-            #    to avoid trusting the tar's metadata size.
+            # Extract file contents manually in chunks to avoid trusting the tar's metadata size
             file_obj = tar.extractfile(member)
             if file_obj is None:
                 # Could not read the file content for some reason
@@ -235,6 +239,8 @@ def _safe_extract(tar_path, extract_path, max_files=100, max_size=1024 * 1024 * 
             # Write out the file, limiting max size
             total_extracted_size = _write_member(member_path, file_obj, max_size, total_extracted_size)
 
-            extracted_files += 1
+            extracted_files.append(basename)
 
-    logger.debug(f'Extraction complete. Files extracted: {extracted_files}, Total size: {total_extracted_size} bytes.')
+    file_count = len(extracted_files)
+    file_list = '", "'.join(sorted(extracted_files))
+    logger.debug(f'Extraction complete. Files extracted: {file_count} ("{file_list}"), Total size: {total_extracted_size} bytes.')

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -1,9 +1,11 @@
 import json
 import os
+import re
 import tarfile
 
 import pandas as pd
 
+from metrics_utility.exceptions import MetricsException
 from metrics_utility.logger import logger
 
 
@@ -56,19 +58,22 @@ class Base:
         except FileNotFoundError:
             logger.warning(f'{self.LOG_PREFIX} missing required file under path: {file_path} and date: {self.date}')
 
-    def process_tarballs(self, path, temp_dir):
+    def process_tarballs(self, path, temp_dir, enabled_set=None):
         _safe_extract(path, temp_dir)
-        config = self.load_config(os.path.join(temp_dir, 'config.json'))
+        self.enabled_set = enabled_set
 
         empty_dataframe = pd.DataFrame([{}])
         needed_data = {
-            'config': config,
+            'config': dict(),
             'data_collection_status': empty_dataframe,
-            'indirect_nodes': empty_dataframe,
+            'main_indirectmanagednodeaudit': empty_dataframe,
             'job_host_summary': empty_dataframe,
             'main_host': empty_dataframe,
             'main_jobevent': empty_dataframe,
         }
+
+        if self.csv_enabled('config'):
+            needed_data['config'] = self.load_config(os.path.join(temp_dir, 'config.json'))
 
         if self.csv_enabled('data_collection_status'):
             needed_data['data_collection_status'] = self.build_data_batch(temp_dir, 'data_collection_status')
@@ -77,7 +82,7 @@ class Base:
             needed_data['job_host_summary'] = self.build_data_batch(temp_dir, 'job_host_summary')
 
         if self.csv_enabled('main_indirectmanagednodeaudit'):
-            needed_data['indirect_nodes'] = self.build_data_batch(temp_dir, 'main_indirectmanagednodeaudit')
+            needed_data['main_indirectmanagednodeaudit'] = self.build_data_batch(temp_dir, 'main_indirectmanagednodeaudit')
 
         if self.csv_enabled('main_jobevent'):
             needed_data['main_jobevent'] = self.build_data_batch(temp_dir, 'main_jobevent')
@@ -98,8 +103,17 @@ class Base:
             return pd.DataFrame([{}])
 
     def csv_enabled(self, name):
-        """Enable CSV extraction based on list of rendered sheets"""
-        return self.sheet_enabled(CSV_SHEETS[name])
+        """
+        Enable CSV extraction based on list of rendered sheets, but also enabled_set if set
+        Only true if there's both a sheet that needs it and we're called by a dataframe that asks for it
+        """
+        if name in CSV_SHEETS and not self.sheet_enabled(CSV_SHEETS[name]):
+            return False
+
+        if self.enabled_set is None:
+            return True
+
+        return name in self.enabled_set
 
     def get_path_prefix(self, date):
         """Return the data/Y/m/d path"""
@@ -118,6 +132,36 @@ class Base:
         """
         sheet_options = self.extra_params.get('optional_sheets')
         return bool(set(sheet_options) & set(sheets_required))
+
+    def filter_tarball_paths(self, paths, collections):
+        # collections=['main_host', 'foo'] - returns only filenames matching *-main_host.tar.gz or *-foo.tar.gz
+        if collections is None:
+            return paths
+
+        if 'data_collection_status' in collections:
+            raise MetricsException('data_collection_status is not a valid tarball name filter')
+
+        if 'config' in collections:
+            raise MetricsException('config is not a valid tarball name filter')
+
+        def match(s):
+            # should not happen, but make sure we're not ignoring data if it does
+            if s.find('-unknown.') or s.find('-config.'):
+                return True
+
+            # include all files produced by 0.6.0 and lower
+            if re.search(r'-\d+.tar.gz$', s):
+                return True
+
+            # match against collections
+            for key in collections:
+                if s.find(f'-{key}.') != -1:
+                    return True
+
+            return False
+
+        paths = filter(match, paths)
+        return list(paths)
 
 
 def _write_member(member_path, file_obj, max_size, total_extracted_size):

--- a/metrics_utility/automation_controller_billing/extract/base.py
+++ b/metrics_utility/automation_controller_billing/extract/base.py
@@ -150,12 +150,14 @@ class Base:
             raise MetricsException('config is not a valid tarball name filter')
 
         def match(s):
-            # should not happen, but make sure we're not ignoring data if it does
-            if s.find('-unknown.') or s.find('-config.'):
+            # include all files produced by 0.6.0 and lower, and anything with an unexpected name
+            if re.search(r'-\d+.tar.gz$', s):
+                return True
+            if re.search(r'-\d+-\w+.tar.gz$', s) is None:
                 return True
 
-            # include all files produced by 0.6.0 and lower
-            if re.search(r'-\d+.tar.gz$', s):
+            # should not happen, but make sure we're not ignoring data if it does
+            if s.find('-unknown.') or s.find('-config.'):
                 return True
 
             # match against collections

--- a/metrics_utility/automation_controller_billing/extract/extractor_directory.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_directory.py
@@ -8,10 +8,10 @@ from metrics_utility.logger import logger
 class ExtractorDirectory(Base):
     LOG_PREFIX = '[ExtractorDirectory]'
 
-    def iter_batches(self, date, columns=None):
+    def iter_batches(self, date, collections, optional):
         # Read tarball in memory in batches
         logger.debug(f'{self.LOG_PREFIX} Processing {date}')
-        paths = self.fetch_partition_paths(date)
+        paths = self.fetch_partition_paths(date, collections)
 
         for path in paths:
             if not path.endswith('.tar.gz'):
@@ -19,12 +19,12 @@ class ExtractorDirectory(Base):
 
             with tempfile.TemporaryDirectory(prefix='automation_controller_billing_data_') as temp_dir:
                 try:
-                    yield self.process_tarballs(path, temp_dir)
+                    yield self.process_tarballs(path, temp_dir, enabled_set=(collections or []) + (optional or []))
 
                 except Exception as e:
                     logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {path} failed with {e}')
 
-    def fetch_partition_paths(self, date):
+    def fetch_partition_paths(self, date, collections):
         prefix = self.get_path_prefix(date)
 
         try:
@@ -32,4 +32,4 @@ class ExtractorDirectory(Base):
         except FileNotFoundError:
             paths = []
 
-        return paths
+        return self.filter_tarball_paths(paths, collections)

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -31,6 +31,7 @@ class ExtractorS3(Base):
                     logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {s3_path} failed with {e}')
 
     def fetch_partition_paths(self, date, collections):
+        # FIXME: apply collections= filtering, so we don't download files from S3 if we know they don't have the right thing
         prefix = self.get_path_prefix(date)
         paths = self.s3_handler.list_files(prefix)
 

--- a/metrics_utility/automation_controller_billing/extract/extractor_s3.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_s3.py
@@ -14,10 +14,10 @@ class ExtractorS3(Base):
 
         self.s3_handler = S3Handler(params=self.extra_params)
 
-    def iter_batches(self, date, columns=None):
+    def iter_batches(self, date, collections, optional):
         # Read tarball in memory in batches
         logger.debug(f'{self.LOG_PREFIX} Processing {date}')
-        s3_paths = self.fetch_partition_paths(date)
+        s3_paths = self.fetch_partition_paths(date, collections)
 
         for s3_path in s3_paths:
             with tempfile.TemporaryDirectory(prefix='automation_controller_billing_data_') as temp_dir:
@@ -25,13 +25,13 @@ class ExtractorS3(Base):
                     local_path = os.path.join(temp_dir, 'source_tarball')
                     self.s3_handler.download_file(s3_path, local_path)
 
-                    yield self.process_tarballs(local_path, temp_dir)
+                    yield self.process_tarballs(local_path, temp_dir, enabled_set=(collections or []) + (optional or []))
 
                 except Exception as e:
                     logger.exception(f'{self.LOG_PREFIX} ERROR: Extracting {s3_path} failed with {e}')
 
-    def fetch_partition_paths(self, date):
+    def fetch_partition_paths(self, date, collections):
         prefix = self.get_path_prefix(date)
+        paths = self.s3_handler.list_files(prefix)
 
-        paths = [file for file in self.s3_handler.list_files(prefix)]
-        return paths
+        return self.filter_tarball_paths(paths, collections)

--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -19,6 +19,8 @@ export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
+export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS="ccsp_summary,data_collection_status,indirectly_managed_nodes,infrastructure_summary,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles"
+
 TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --month=2024-04 --force "$@"

--- a/tools/perf/generator.py
+++ b/tools/perf/generator.py
@@ -206,11 +206,11 @@ def process_tarballs(path, temp_dir, enabled_set):
             with open(file_path) as f:
                 return json.loads(f.read())
 
-        # extract csv based on generator SELECTED_DATA
-        def csv_enabled(self, name):
-            return name in enabled_set
+        def sheet_enabled(self, _sheets):
+            return True
 
-    return ProcessTarballs(extra_params=dict()).process_tarballs(path, temp_dir)
+    # extract csv based on generator SELECTED_DATA
+    return ProcessTarballs(extra_params=dict()).process_tarballs(path, temp_dir, enabled_set)
 
 
 # metrics_utility.automation_controller_billing.collectors daily_slicing, but without the awx imports
@@ -338,7 +338,7 @@ Environment vars:
 
                 self.concat('job_host_summary', data['job_host_summary'])
                 self.concat('main_host', data['main_host'])
-                self.concat('main_indirectmanagednodeaudit', data['indirect_nodes'])
+                self.concat('main_indirectmanagednodeaudit', data['main_indirectmanagednodeaudit'])
                 self.concat('main_jobevent', data['main_jobevent'])
                 self.config_json = data['config']
 

--- a/tools/perf/generator.py
+++ b/tools/perf/generator.py
@@ -206,9 +206,6 @@ def process_tarballs(path, temp_dir, enabled_set):
             with open(file_path) as f:
                 return json.loads(f.read())
 
-        def sheet_enabled(self, _sheets):
-            return True
-
     # extract csv based on generator SELECTED_DATA
     return ProcessTarballs(extra_params=dict()).process_tarballs(path, temp_dir, enabled_set)
 


### PR DESCRIPTION
Issue: AAP-52666

ExtractorDirectory & ExtractorS3 now take 2 extra arguments to `iter_batches`:
* `collections=`
* `optional=`

both can be `None`, in which case, no change, all files are processed as before and only filtered by enabled sheets.

When `collections` is set, we filter the set of tarballs to extract so that:
* tarballs created by 0.6.0 and earlier all get opened as before
* tarballs marked "-unknown" or "-config" are edge cases from #226 and we open them too
* tarballs ending in `-collection_key.tar.gz` get opened only if `collections` contains that collection
* (anything unrecognized, such as `source_tarball` when downloading from S3 will still get opened too)

When `collections` or `optional` are set, both are put together and passed as `enabled_set=` to `process_tarballs`.

Changed `process_tarballs` to take into account both enabled sheets and what the dataframe requests - so even if we open a tarball with only the wrong collections, we don't parse them.
And make `optional_sheets` optional there, as rollups won't have optional sheets but want all the files the dataframe asks for.

Changed `_safe_extract` to take also use `enabled_sheets` when provided and not even extract the files when not needed (and debug log the filenames too).

And unified the `indirect_nodes` vs `main_indirectmanagednodeaudit` naming, so that the name of the dataframe, the suffix of the tarball, and the collector key always match.

This might give up to 4x speedup for parsing files when multiple dataframes are enabled, by not unpacking the tarballs at all if we don't have to, and not unpacking & parsing all the files inside again and again.

(This helps build_report speeds, but also prepares ground for rollups using the same mechanism - that part will come in a third PR.)