### PR TITLE
old replacement with new collector

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -214,122 +214,6 @@ def yaml_and_json_parsing_functions():
     return query
 
 
-@register('job_host_summary', '1.2', format='csv', description=_('Data for billing'), fnc_slicing=daily_slicing)
-def job_host_summary_table(since, full_path, until, **kwargs):
-    disable_job_host_summary_str = os.getenv('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
-    disable_job_host_summary = False
-    if disable_job_host_summary_str and (disable_job_host_summary_str.lower() == 'true'):
-        disable_job_host_summary = True
-
-    if disable_job_host_summary:
-        return None
-
-    # TODO: controler needs to have an index on main_jobhostsummary.modified
-    prepend_query = """
-        -- Define function for parsing field out of yaml encoded as text
-        CREATE OR REPLACE FUNCTION metrics_utility_parse_yaml_field(
-            str text,
-            field text
-        )
-        RETURNS text AS
-        $$
-        DECLARE
-            line_re text;
-            field_re text;
-        BEGIN
-            field_re := ' *[:=] *(.+?) *$';
-            line_re := '(?n)^' || field || field_re;
-            RETURN trim(both '"' from substring(str from line_re) );
-        END;
-        $$
-        LANGUAGE plpgsql;
-
-        -- Define function to check if field is a valid json
-        CREATE OR REPLACE FUNCTION metrics_utility_is_valid_json(p_json text)
-            returns boolean
-        AS
-        $$
-        BEGIN
-            RETURN (p_json::json is not null);
-        EXCEPTION
-            WHEN others THEN
-                RETURN false;
-        END;
-        $$
-        LANGUAGE plpgsql;
-    """
-    query = f"""
-    WITH
-    filtered_hosts AS (
-        SELECT DISTINCT main_jobhostsummary.host_id
-        FROM main_jobhostsummary
-        WHERE (main_jobhostsummary.modified >= '{since.isoformat()}'
-        AND main_jobhostsummary.modified < '{until.isoformat()}')
-    ),
-    hosts_variables as (
-        SELECT
-            filtered_hosts.host_id,
-            CASE
-                WHEN (metrics_utility_is_valid_json(main_host.variables))
-                        THEN main_host.variables::jsonb->>'ansible_host'
-                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
-                END AS ansible_host_variable,
-                CASE
-                    WHEN (metrics_utility_is_valid_json(main_host.variables))
-                        THEN main_host.variables::jsonb->>'ansible_connection'
-                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
-                END AS ansible_connection_variable
-
-        FROM filtered_hosts
-        LEFT JOIN main_host ON main_host.id = filtered_hosts.host_id)
-
-        SELECT main_jobhostsummary.id,
-            main_jobhostsummary.created,
-            main_jobhostsummary.modified,
-            main_jobhostsummary.host_name,
-            main_jobhostsummary.host_id as host_remote_id,
-            hosts_variables.ansible_host_variable,
-            hosts_variables.ansible_connection_variable,
-            main_jobhostsummary.changed,
-            main_jobhostsummary.dark,
-            main_jobhostsummary.failures,
-            main_jobhostsummary.ok,
-            main_jobhostsummary.processed,
-            main_jobhostsummary.skipped,
-            main_jobhostsummary.failed,
-            main_jobhostsummary.ignored,
-            main_jobhostsummary.rescued,
-            main_unifiedjob.created AS job_created,
-            main_jobhostsummary.job_id AS job_remote_id,
-            main_unifiedjob.unified_job_template_id AS job_template_remote_id,
-            main_unifiedjob.name AS job_template_name,
-            main_inventory.id AS inventory_remote_id,
-            main_inventory.name AS inventory_name,
-            main_organization.id AS organization_remote_id,
-            main_organization.name AS organization_name,
-            main_unifiedjobtemplate_project.id AS project_remote_id,
-            main_unifiedjobtemplate_project.name AS project_name
-            FROM main_jobhostsummary
-            -- connect to main_job, that has connections into inventory and project
-            LEFT JOIN main_job ON main_jobhostsummary.job_id = main_job.unifiedjob_ptr_id
-            -- get project name from project_options
-            LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
-            -- get inventory name from main_inventory
-            LEFT JOIN main_inventory ON main_inventory.id = main_job.inventory_id
-            -- get job name from main_unifiedjob
-            LEFT JOIN main_unifiedjob ON main_unifiedjob.id = main_jobhostsummary.job_id
-            -- get organization name from main_organization
-            LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
-            -- get variables from precomputed hosts_variables
-            LEFT JOIN hosts_variables ON hosts_variables.host_id = main_jobhostsummary.host_id
-            WHERE (main_jobhostsummary.modified >= '{since.isoformat()}'
-            AND main_jobhostsummary.modified < '{until.isoformat()}')
-            ORDER BY main_jobhostsummary.modified ASC
-    """
-
-    return _copy_table(table='main_jobhostsummary', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=prepend_query)
-
-
 @register('main_jobevent', '1.0', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
 def main_jobevent_table(since, full_path, until, **kwargs):
     if 'main_jobevent' not in get_optional_collectors():
@@ -708,9 +592,14 @@ def unified_jobs_table(since, full_path, until, **kwargs):
     return _copy_table(table='unified_jobs', query=unified_job_query, path=full_path)
 
 
-@register('job_host_summary_service', '1.4', format='csv', description=_('Data for billing'), fnc_slicing=daily_slicing)
-def job_host_summary_service_table(since, full_path, until, **kwargs):
-    if 'job_host_summary_service' not in get_optional_collectors():
+@register('job_host_summary', '1.2', format='csv', description=_('Data for billing'), fnc_slicing=daily_slicing)
+def job_host_summary_table(since, full_path, until, **kwargs):
+    disable_job_host_summary_str = os.getenv('METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR', 'false')
+    disable_job_host_summary = False
+    if disable_job_host_summary_str and (disable_job_host_summary_str.lower() == 'true'):
+        disable_job_host_summary = True
+
+    if disable_job_host_summary:
         return None
 
     prepend_query = """

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -885,7 +885,9 @@ def main_jobevent_table(since, full_path, until, **kwargs):
             e.task,
             e.role,
             e.job_id  AS job_remote_id,
+            e.job_id,
             e.host_id AS host_remote_id,
+            e.host_id,
             e.host_name,
 
             -- Warnings and deprecations (json arrays)

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -214,9 +214,10 @@ def yaml_and_json_parsing_functions():
     return query
 
 
-@register('main_jobevent', '1.0', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
-def main_jobevent_table(since, full_path, until, **kwargs):
-    if 'main_jobevent' not in get_optional_collectors():
+# We need to keep older version, so the perf tests have easy access to it, then we can remove it
+@register('main_jobevent_deprecated', '1.0', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
+def main_jobevent_table_deprecated(since, full_path, until, **kwargs):
+    if 'main_jobevent_deprecated' not in get_optional_collectors():
         return None
 
     tbl = 'main_jobevent'
@@ -824,9 +825,9 @@ def job_host_summary_table_deprecated(since, full_path, until, **kwargs):
     return _copy_table(table='main_jobhostsummary', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=prepend_query)
 
 
-@register('main_jobevent_service', '1.4', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
-def main_jobevent_service_table(since, full_path, until, **kwargs):
-    if 'main_jobevent_service' not in get_optional_collectors():
+@register('main_jobevent', '1.0', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
+def main_jobevent_table(since, full_path, until, **kwargs):
+    if 'main_jobevent' not in get_optional_collectors():
         return None
 
     # Use the table alias 'e' here (you alias main_jobevent as e in the FROM)

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -712,6 +712,118 @@ def job_host_summary_table(since, full_path, until, **kwargs):
     return _copy_table(table='main_jobhostsummary', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=prepend_query)
 
 
+# We need to keep older version, so the perf tests have easy access to it, then we can remove it
+@register('job_host_summary_deprecated', '1.2', format='csv', description=_('Data for billing'), fnc_slicing=daily_slicing)
+def job_host_summary_table_deprecated(since, full_path, until, **kwargs):
+    if 'job_host_summary_deprecated' not in get_optional_collectors():
+        return None
+
+    # TODO: controler needs to have an index on main_jobhostsummary.modified
+    prepend_query = """
+        -- Define function for parsing field out of yaml encoded as text
+        CREATE OR REPLACE FUNCTION metrics_utility_parse_yaml_field(
+            str text,
+            field text
+        )
+        RETURNS text AS
+        $$
+        DECLARE
+            line_re text;
+            field_re text;
+        BEGIN
+            field_re := ' *[:=] *(.+?) *$';
+            line_re := '(?n)^' || field || field_re;
+            RETURN trim(both '"' from substring(str from line_re) );
+        END;
+        $$
+        LANGUAGE plpgsql;
+
+        -- Define function to check if field is a valid json
+        CREATE OR REPLACE FUNCTION metrics_utility_is_valid_json(p_json text)
+            returns boolean
+        AS
+        $$
+        BEGIN
+            RETURN (p_json::json is not null);
+        EXCEPTION
+            WHEN others THEN
+                RETURN false;
+        END;
+        $$
+        LANGUAGE plpgsql;
+    """
+    query = f"""
+    WITH
+    filtered_hosts AS (
+        SELECT DISTINCT main_jobhostsummary.host_id
+        FROM main_jobhostsummary
+        WHERE (main_jobhostsummary.modified >= '{since.isoformat()}'
+        AND main_jobhostsummary.modified < '{until.isoformat()}')
+    ),
+    hosts_variables as (
+        SELECT
+            filtered_hosts.host_id,
+            CASE
+                WHEN (metrics_utility_is_valid_json(main_host.variables))
+                        THEN main_host.variables::jsonb->>'ansible_host'
+                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
+                END AS ansible_host_variable,
+                CASE
+                    WHEN (metrics_utility_is_valid_json(main_host.variables))
+                        THEN main_host.variables::jsonb->>'ansible_connection'
+                    ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
+                END AS ansible_connection_variable
+
+        FROM filtered_hosts
+        LEFT JOIN main_host ON main_host.id = filtered_hosts.host_id)
+
+        SELECT main_jobhostsummary.id,
+            main_jobhostsummary.created,
+            main_jobhostsummary.modified,
+            main_jobhostsummary.host_name,
+            main_jobhostsummary.host_id as host_remote_id,
+            hosts_variables.ansible_host_variable,
+            hosts_variables.ansible_connection_variable,
+            main_jobhostsummary.changed,
+            main_jobhostsummary.dark,
+            main_jobhostsummary.failures,
+            main_jobhostsummary.ok,
+            main_jobhostsummary.processed,
+            main_jobhostsummary.skipped,
+            main_jobhostsummary.failed,
+            main_jobhostsummary.ignored,
+            main_jobhostsummary.rescued,
+            main_unifiedjob.created AS job_created,
+            main_jobhostsummary.job_id AS job_remote_id,
+            main_unifiedjob.unified_job_template_id AS job_template_remote_id,
+            main_unifiedjob.name AS job_template_name,
+            main_inventory.id AS inventory_remote_id,
+            main_inventory.name AS inventory_name,
+            main_organization.id AS organization_remote_id,
+            main_organization.name AS organization_name,
+            main_unifiedjobtemplate_project.id AS project_remote_id,
+            main_unifiedjobtemplate_project.name AS project_name
+            FROM main_jobhostsummary
+            -- connect to main_job, that has connections into inventory and project
+            LEFT JOIN main_job ON main_jobhostsummary.job_id = main_job.unifiedjob_ptr_id
+            -- get project name from project_options
+            LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
+            -- get inventory name from main_inventory
+            LEFT JOIN main_inventory ON main_inventory.id = main_job.inventory_id
+            -- get job name from main_unifiedjob
+            LEFT JOIN main_unifiedjob ON main_unifiedjob.id = main_jobhostsummary.job_id
+            -- get organization name from main_organization
+            LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
+            -- get variables from precomputed hosts_variables
+            LEFT JOIN hosts_variables ON hosts_variables.host_id = main_jobhostsummary.host_id
+            WHERE (main_jobhostsummary.modified >= '{since.isoformat()}'
+            AND main_jobhostsummary.modified < '{until.isoformat()}')
+            ORDER BY main_jobhostsummary.modified ASC
+    """
+
+    return _copy_table(table='main_jobhostsummary', query=f'COPY ({query}) TO STDOUT WITH CSV HEADER', path=full_path, prepend_query=prepend_query)
+
+
 @register('main_jobevent_service', '1.4', format='csv', description=_('Content usage'), fnc_slicing=daily_slicing)
 def main_jobevent_service_table(since, full_path, until, **kwargs):
     if 'main_jobevent_service' not in get_optional_collectors():

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -57,6 +57,7 @@ VALID_COLLECTORS = {
     'main_jobevent_service',
     'execution_environments',
     'job_host_summary_deprecated',
+    'main_jobevent_deprecated',
 }
 
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -56,7 +56,7 @@ VALID_COLLECTORS = {
     'unified_jobs',
     'main_jobevent_service',
     'execution_environments',
-    '',
+    'job_host_summary_deprecated',
 }
 
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -58,6 +58,7 @@ VALID_COLLECTORS = {
     'execution_environments',
     'job_host_summary_deprecated',
     'main_jobevent_deprecated',
+    '',
 }
 
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -54,7 +54,6 @@ VALID_COLLECTORS = {
     'main_indirectmanagednodeaudit',
     'total_workers_vcpu',
     'unified_jobs',
-    'job_host_summary_service',
     'main_jobevent_service',
     'execution_environments',
     '',

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -304,19 +304,19 @@ main_jobevent_service_skip_columns = [
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
-def test_main_jobevent_service_command(cleanup_glob):
-    """Build and validate main_jobevent_service.csv contents in the generated tarball."""
+def test_main_jobevent_command(cleanup_glob):
+    """Build and validate main_jobevent.csv contents in the generated tarball."""
     # prepare env
 
     test_env = env_vars.copy()
     test_env['METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR'] = 'true'
-    test_env['METRICS_UTILITY_OPTIONAL_COLLECTORS'] = 'main_jobevent_service'
+    test_env['METRICS_UTILITY_OPTIONAL_COLLECTORS'] = 'main_jobevent'
 
     # run the gather command
     run_gather_ext(test_env, ['--ship', '--force', '--since=2025-06-12', '--until=2025-06-14'])
 
     # validate CSV inside generated tarball(s)
-    validate_csv_in_tarballs(file_paths, 'main_jobevent_service.csv', main_jobevent_service_lines, main_jobevent_service_skip_columns)
+    validate_csv_in_tarballs(file_paths, 'main_jobevent.csv', main_jobevent_service_lines, main_jobevent_service_skip_columns)
 
 
 execution_environments_lines = [

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -231,7 +231,7 @@ def test_job_host_summary_command(cleanup_glob):
 main_jobevent_service_lines = [
     'id,created,modified,job_created,job_finished,uuid,parent_uuid,event,'
     'task_action,resolved_action,resolved_role,duration,start,end,task_uuid,failed,'
-    'changed,playbook,play,task,role,job_remote_id,host_remote_id,'
+    'changed,playbook,play,task,role,job_remote_id,job_id,host_remote_id,host_id'
     'host_name,warnings,deprecations,playbook_on_stats,job_failed,job_started',
     '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
@@ -300,6 +300,8 @@ main_jobevent_service_skip_columns = [
     'id',
     'job_remote_id',
     'host_remote_id',
+    'job_id',
+    'host_id',
 ]
 
 

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -215,19 +215,17 @@ jobs_host_summary_service_skip_columns = [
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
-def test_job_host_summary_service_command(cleanup_glob):
-    """Build and validate jobs_host_summary_service.csv contents in the generated tarball."""
+def test_job_host_summary_command(cleanup_glob):
+    """Build and validate jobs_host_summary.csv contents in the generated tarball."""
     # prepare env
 
     test_env = env_vars.copy()
-    test_env['METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR'] = 'true'
-    test_env['METRICS_UTILITY_OPTIONAL_COLLECTORS'] = 'job_host_summary_service'
 
     # run the gather command
     run_gather_ext(test_env, ['--ship', '--force', '--since=2025-06-12', '--until=2025-06-14'])
 
     # validate CSV inside generated tarball(s)
-    validate_csv_in_tarballs(file_paths, 'job_host_summary_service.csv', jobs_host_summary_service_lines, jobs_host_summary_service_skip_columns)
+    validate_csv_in_tarballs(file_paths, 'job_host_summary.csv', jobs_host_summary_service_lines, jobs_host_summary_service_skip_columns)
 
 
 main_jobevent_service_lines = [


### PR DESCRIPTION
[AAP-54269]

## Description

Collectors were replaced by new ones, but old ones kept as deprecated. After perf tests, they can be removed completely.

## Testing

uv run pytest -s

More in depth test:
run awx in your local machine

in your standalone metrics-utility, run:
cd testathon
python3 testathon_data_prepare.py

Data will be pushed into awx DB.

Now attach to awx container and run gather command (with span over todays date), then build command from it. You should see the report.

# Cursor analysis

# Replace Deprecated Collectors with New Versions

## 🔄 What Changed
Replaced deprecated collectors:

- `main_jobevent` → replaces **main_jobevent_deprecated**  
- `job_host_summary` → replaces **job_host_summary_deprecated**

---

## 🧩 Schema Changes

### **main_jobevent**

**Removed:**
- `main_jobhostsummary_id`
- `main_jobhostsummary_created`

**Added:**
- `job_finished`
- `uuid`
- `parent_uuid`
- `start`
- `end`
- `task_uuid`
- `warnings`
- `deprecations`
- `playbook_on_stats`
- `job_failed`
- `job_started`

**Unchanged core fields:**
`id`, `created`, `modified`, `job_created`, `event`, `task_action`,  
`resolved_action`, `resolved_role`, `duration`, `failed`, `changed`,  
`playbook`, `play`, `task`, `role`, `job_remote_id`, `host_remote_id`, `host_name`

---

### **job_host_summary**

**Columns:**  
Same effective set as before:
- IDs and timestamps
- `host_name`
- Counters (`dark`, `failures`, `ok`, `skipped`, `ignored`, `rescued`)
- `job_*` fields
- `organization`, `inventory`, `project`
- `ansible_host_variable`, `ansible_connection_variable`

**Selection strategy change:**  
Now filters by jobs that **finished in the window** (`main_unifiedjob.finished`)  
instead of using summary **modified timestamps**.

---

## 📊 Impact on Build Report

### **main_jobevent → DataframeContentUsage**

**Uses:**
- `host_name`
- `task_action` / `resolved_action` / `resolved_role`
- `duration`
- `role`
- `job_remote_id`

✅ **No breakage**  
Removed fields were unused; added fields are ignored.  
Grouping and renaming remain unchanged.

---

### **job_host_summary → DataframeJobhostSummaryUsage**

**Uses:**
- `host_name` (normalized via `ansible_host_variable`)
- Counters: `dark`, `failures`, `ok`, `skipped`, `ignored`, `rescued`
- `created`
- `organization_name`
- `job_template_name`
- `job_remote_id`
- Optionally: `job_created`

✅ **No breakage**  
All required columns exist; extra fields are ignored.  
Aggregation logic remains the same.

---

## ⚙️ Behavioral Differences & Risks

### **Time-Window Semantics**
- `main_jobevent`: Events tied to **jobs finished** within the window.  
- `job_host_summary`: Driven by **finished window** instead of **modified**.

📌 *Possible slight shifts in row inclusion at boundaries.*  
Does **not** affect dataframe logic.

---

## ⚡ Performance
Both collectors now **filter by finished jobs first**,  
reducing scanned rows on large instances.

---

## 🧱 Backward Compatibility
- **Build report flows (CCSP, CCSPv2):** Continue to work.  
- Added columns → harmless.  
- Removed columns → weren’t used.

⚠️ *External tools depending on*  
`main_jobevent.main_jobhostsummary_id` or  
`main_jobevent.main_jobhostsummary_created`  
*will need updates.*

---

## 🧪 Test Coverage
Gather tests now:
- Assert **exact headers** of `main_jobevent.csv` and `job_host_summary.csv`
- Aligned with the **new schemas**
- Ensures full compatibility with the **build process**

# Performance Analysis for Job Event

## ✅ New Version (`main_jobevent`)
**Pros**
- Uses constant `(job_id, job_created)` pairs → strong **partition pruning**.
- **Removes expensive join** to `main_jobhostsummary`, significantly reducing I/O.
- Limits scope to **finished jobs** within the time window.
- Generally **faster** for typical daily/hourly slices (hundreds of jobs).
- Simpler and more predictable query plan.

**Cons**
- If the time window contains **thousands of jobs**, the large
  `IN (VALUES …)` clause increases **planning time** and query text size.
- Currently missing the `event IN (...)` filter used in the old version,
  which could reduce the number of scanned rows.

---

## ⚠️ Deprecated Version (`main_jobevent_deprecated`)
**Pros**
- Already filters events (`runner_*`), limiting output size.
- Uses `main_jobhostsummary.modified` (which is indexed) for slicing.

**Cons**
- Joins to `main_jobhostsummary`, which can be a **large table**, causing:
  - Heavy **join cost** (I/O, memory, and CPU).
  - Broader scans due to extra table lookups.
- **Weaker partition pruning** because filtering happens through a join/CTE
  rather than constant predicates on `job_created`.
- Touches unnecessary data when only job event details are needed.

---

