### PR TITLE
Milan add analytics events columns

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -883,7 +883,9 @@ def main_jobevent_service_table(since, full_path, until, **kwargs):
             e.task,
             e.role,
             e.job_id  AS job_remote_id,
+            e.job_id,
             e.host_id AS host_remote_id,
+            e.host_id,
             e.host_name,
 
             -- Warnings and deprecations (json arrays)

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -238,62 +238,62 @@ main_jobevent_service_lines = [
     '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,1_default_host_1_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,1,31,'
+    'default_playbook.yml,default_play,default_task,default_role,1,1,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00,',
     '2,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,1_default_host_1_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,1,31,'
+    'default_playbook.yml,default_play,default_task,default_role,1,1,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '3,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,1_default_host_2_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,1,32,'
+    'default_playbook.yml,default_play,default_task,default_role,1,1,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '4,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,1_default_host_2_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,1,32,'
+    'default_playbook.yml,default_play,default_task,default_role,1,1,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '5,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,2_default_host_1_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,2,31,'
+    'default_playbook.yml,default_play,default_task,default_role,2,2,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '6,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,2_default_host_1_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,2,31,'
+    'default_playbook.yml,default_play,default_task,default_role,2,2,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '7,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,2_default_host_2_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,2,32,'
+    'default_playbook.yml,default_play,default_task,default_role,2,2,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '8,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,2_default_host_2_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,2,32,'
+    'default_playbook.yml,default_play,default_task,default_role,2,2,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '9,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,3_default_host_1_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,3,31,'
+    'default_playbook.yml,default_play,default_task,default_role,3,3,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '10,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,3_default_host_1_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,3,31,'
+    'default_playbook.yml,default_play,default_task,default_role,3,3,31,31,'
     'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '11,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_start,ansible.builtin.yum,,,,,,3_default_host_2_2025-06-13_1,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,3,32,'
+    'default_playbook.yml,default_play,default_task,default_role,3,3,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
     '12,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     'UUID,,runner_on_ok,amazon.aws.s3_bucket,,,,,,3_default_host_2_2025-06-13_2,f,f,'
-    'default_playbook.yml,default_play,default_task,default_role,3,32,'
+    'default_playbook.yml,default_play,default_task,default_role,3,3,32,32,'
     'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
 ]
 

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -233,7 +233,7 @@ def test_job_host_summary_service_command(cleanup_glob):
 main_jobevent_service_lines = [
     'id,created,modified,job_created,job_finished,uuid,parent_uuid,event,'
     'task_action,resolved_action,resolved_role,duration,start,end,task_uuid,failed,'
-    'changed,playbook,play,task,role,job_remote_id,host_remote_id,'
+    'changed,playbook,play,task,role,job_remote_id,job_id,host_remote_id,host_id,'
     'host_name,warnings,deprecations,playbook_on_stats,job_failed,job_started',
     '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
     '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'


### PR DESCRIPTION
Analytics event collector has job_id and host_id and our metrics collector has job_remote_id and host_remote_id, both are the same, but since we will have to merge both collectors into one in the future, I created this PR in advance, so it is not forgotten later, because it can be very easily missed.

It is small change, so I suppose it does not break anything, all test passed, those are extra columns and CCSP events dataframe builder ignores extra columns. So does the anonymized rollups.
