### PR TITLE
Bump version to 0.7.0dev, add 0.6.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@
 - dev: perf tests split up to make testing branches easier
 - dev: remove pytz
 
-## 0.6.1dev
+## 0.6.1
+
+- vcpu collector - use prometheus
+- gather: fix empty config.json when `job_host_summary` disabled
+- dev: future optional collectors
+
+## 0.7.0dev
 
 - TODO

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.6.1dev
+version = 0.7.0dev
 
 [options]
 packages = find:


### PR DESCRIPTION
Release [0.6.1](https://github.com/ansible/metrics-utility/releases/tag/0.6.1) mostly exists to release #198 & #217,
so doing it from that commit, in `stable-0.6`, instead of the current devel branch.

(https://github.com/ansible/metrics-utility/compare/0.6.0...0.6.1, https://github.com/ansible/metrics-utility/commits/stable-0.6)