### PR TITLE
Add conf_setting data to db mocks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Import SQL dump"
         run: |
-          cat tools/docker/{roles,latest,main_hostmetric,main_jobhostsummary}.sql | sudo su - postgres -c psql
+          cat tools/docker/{roles,latest,conf_setting,main_hostmetric,main_jobhostsummary}.sql | sudo su - postgres -c psql
 
       - name: "Set up minio"
         env:

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -5,37 +5,14 @@ cd "`dirname "$0"`"
 export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="directory"
 
+if ! pg_isready -h localhost; then
+  echo "run-s3-gather-build: DB not ready, run make compose first"
+  exit 1
+fi
+
 TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
-
-SCHEMA=`realpath "tools/docker/latest.sql"`
-ROLES=`realpath "tools/docker/roles.sql"`
-NAME=ccsp2-gather-`basename "$SCHEMA" .sql`
-
-echo "$NAME"
-pg_isready -h localhost ||
-podman run --name "$NAME" --replace \
-    -e POSTGRES_USER="myuser" \
-    -e POSTGRES_PASSWORD="mypassword" \
-    -e POSTGRES_DB="awx" \
-    -v "$ROLES":/docker-entrypoint-initdb.d/init-roles.sql:ro \
-    -v "$SCHEMA":/docker-entrypoint-initdb.d/init-schema.sql:ro \
-    -p 5432:5432 \
-    -d mirror.gcr.io/postgres
-
-tries=5
-until pg_isready -h localhost; do
-  [ "$tries" -lt 1 ] && break
-
-  echo "Waiting for PostgreSQL to be ready...($tries)"
-  sleep "$tries"
-
-  tries=`expr "$tries" - 1`
-done
-
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"
-
-podman stop "$NAME"
 
 set -x
 ls -lR out/data/`date +%Y`/

--- a/run-renewal
+++ b/run-renewal
@@ -6,37 +6,14 @@ export METRICS_UTILITY_REPORT_TYPE="RENEWAL_GUIDANCE"
 export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="controller_db"
 
+if ! pg_isready -h localhost; then
+  echo "run-s3-gather-build: DB not ready, run make compose first"
+  exit 1
+fi
+
 TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
-
-SCHEMA=`realpath "tools/docker/latest.sql"`
-ROLES=`realpath "tools/docker/roles.sql"`
-NAME=renewal-`basename "$SCHEMA" .sql`
-
-echo "$NAME"
-pg_isready -h localhost ||
-podman run --name "$NAME" --replace \
-    -e POSTGRES_USER="myuser" \
-    -e POSTGRES_PASSWORD="mypassword" \
-    -e POSTGRES_DB="awx" \
-    -v "$ROLES":/docker-entrypoint-initdb.d/init-roles.sql:ro \
-    -v "$SCHEMA":/docker-entrypoint-initdb.d/init-schema.sql:ro \
-    -p 5432:5432 \
-    -d mirror.gcr.io/postgres
-
-tries=5
-until pg_isready -h localhost; do
-  [ "$tries" -lt 1 ] && break
-
-  echo "Waiting for PostgreSQL to be ready...($tries)"
-  sleep "$tries"
-
-  tries=`expr "$tries" - 1`
-done
-
 $TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --since=12months --ephemeral=1month --force "$@"
-
-podman stop "$NAME"
 
 set -x
 ls -lR out/reports/`date +%Y`/

--- a/tools/docker/conf_setting.sql
+++ b/tools/docker/conf_setting.sql
@@ -6,9 +6,4 @@ INSERT INTO public.conf_setting (created, modified, key, value) VALUES
   (now(), now(), 'INSTALL_UUID', '"00000000-0000-0000-0000-000000000000"'),
   (now(), now(), 'LICENSE', '{"license_type": "UNLICENSED", "product_name": "AWX", "subscription_name": null, "valid_key": false}'),
   (now(), now(), 'TOWER_URL_BASE', '"https://platformhost"'),
-  -- Test version data
-  (now(), now(), 'VERSION', '"24.6.0"'),
-  (now(), now(), 'VERSION', '"4.7.5"'),
-  (now(), now(), 'VERSION', '"4.7.5"'),
-  -- Test analytics data
   (now(), now(), 'AUTOMATION_ANALYTICS_LAST_ENTRIES', '{"config": "2024-01-01T10:00:00Z", "jobs": "2024-01-02T15:30:00Z"}');

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -44,9 +44,9 @@ services:
     volumes:
       - ./roles.sql:/docker-entrypoint-initdb.d/init-0-roles.sql
       - ./latest.sql:/docker-entrypoint-initdb.d/init-1-schema.sql
-      - ./conf_settings.sql:/docker-entrypoint-initdb.d/init-4-conf_settings.sql
-      - ./main_hostmetric.sql:/docker-entrypoint-initdb.d/init-2-hostmetric.sql
-      - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-3-main_jobhostsummary.sql
+      - ./conf_setting.sql:/docker-entrypoint-initdb.d/init-2-conf_setting.sql
+      - ./main_hostmetric.sql:/docker-entrypoint-initdb.d/init-3-main_hostmetric.sql
+      - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-4-main_jobhostsummary.sql
 
   postgres-wait:
     image: "mirror.gcr.io/postgres"


### PR DESCRIPTION
Adding a `tools/docker/conf_setting.sql`, with:
* `LICENSE` - matching the mock `mock_awx/awx/conf/license/__init__.py` license, which was itself based on https://github.com/ansible/awx/blob/devel/awx/main/utils/licensing.py#L88
* `INSTAL_UUID` & `TOWER_URL_BASE` - matching the mock `mock_awx/settings/__init__.py` settings.

(And wiring into `make compose` & the github CI.)

This should help with testing #242 which switches from asking awx to looking for these in the db.

---

And update `run-*` scripts to no longer try to create their own db environment, instead using the `make compose` one.
(They no longer matched because only compose is getting the table data; `run-s3-gather-build` already went that way.)