### PR TITLE
AAP-57241: Milan anonymized hardening

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
 from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import EventModulesAnonymizedRollup
 from metrics_utility.anonymized_rollups.execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
+from metrics_utility.anonymized_rollups.helpers import sanitize_json
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 
@@ -128,6 +129,8 @@ def compute_anonymized_rollup_from_raw_data(salt, year, month, day, base_path, s
     anonymized_rollup = anonymize_rollups(
         events_modules_result['json'], execution_environments_result['json'], jobs_result['json'], job_host_summary_result['json'], 'salt'
     )
+    # Sanitize the result to replace NaN and infinity values with None (valid JSON)
+    anonymized_rollup = sanitize_json(anonymized_rollup)
     return anonymized_rollup
 
 

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -46,9 +46,10 @@ def anonymize_data(data, salt):
 
     # anonymize jobhostsummary job template name
     if 'job_host_summary' in data and data['job_host_summary']:
-        for jobhostsummary in data['job_host_summary']:
-            if jobhostsummary and 'job_template_name' in jobhostsummary and jobhostsummary['job_template_name']:
-                jobhostsummary['job_template_name'] = hash(jobhostsummary['job_template_name'], salt)
+        if 'aggregated' in data['job_host_summary'] and data['job_host_summary']['aggregated']:
+            for jobhostsummary in data['job_host_summary']['aggregated']:
+                if jobhostsummary and 'job_template_name' in jobhostsummary and jobhostsummary['job_template_name']:
+                    jobhostsummary['job_template_name'] = hash(jobhostsummary['job_template_name'], salt)
 
     # anonymize events modules module name
     if 'events_modules' in data and isinstance(data['events_modules'], dict):

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -2,6 +2,8 @@ import glob
 import hashlib
 import tarfile
 
+from typing import Any, Dict, List
+
 import pandas as pd
 
 from pandas import DataFrame
@@ -13,7 +15,6 @@ from metrics_utility.anonymized_rollups.helpers import sanitize_json
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 
-from typing import Dict, Any, List
 
 def hash(value, salt):
     # has the value and salt, hash should be string
@@ -36,55 +37,55 @@ def create_anonymized_object(rollup_name: str):
 
 
 def anonymize_data(data, salt):
+    """
+    Anonymizes sensitive data in the flattened report structure.
+    This function expects data to be already flattened by flatten_json_report().
+
+    Args:
+        data: Flattened data structure with keys:
+            - jobs_by_template: array of job template stats
+            - job_host_summary: array of host summary stats
+            - module_stats: array of module statistics
+            - collection_name_stats: array of collection statistics
+            - modules_used_per_playbook: array of {playbook_id, modules_used}
+        salt: Salt string for hashing
+    """
     if not data or not isinstance(data, dict):
         return
 
-    # anonymize jobs job template name
-    if 'jobs' in data and data['jobs']:
-        for job in data['jobs']:
+    # anonymize jobs_by_template job template name
+    if 'jobs_by_template' in data and data['jobs_by_template']:
+        for job in data['jobs_by_template']:
             if job and 'job_template_name' in job and job['job_template_name']:
                 job['job_template_name'] = hash(job['job_template_name'], salt)
 
-    # anonymize jobhostsummary job template name
+    # anonymize job_host_summary job template name
     if 'job_host_summary' in data and data['job_host_summary']:
-        if 'aggregated' in data['job_host_summary'] and data['job_host_summary']['aggregated']:
-            for jobhostsummary in data['job_host_summary']['aggregated']:
-                if jobhostsummary and 'job_template_name' in jobhostsummary and jobhostsummary['job_template_name']:
-                    jobhostsummary['job_template_name'] = hash(jobhostsummary['job_template_name'], salt)
+        for jobhostsummary in data['job_host_summary']:
+            if jobhostsummary and 'job_template_name' in jobhostsummary and jobhostsummary['job_template_name']:
+                jobhostsummary['job_template_name'] = hash(jobhostsummary['job_template_name'], salt)
 
-    # anonymize events modules module name
-    if 'events_modules' in data and isinstance(data['events_modules'], dict):
-        events_modules = data['events_modules']
+    # anonymize module_stats - anonymize module name and collection name for 'Unknown' sources
+    if 'module_stats' in data and data['module_stats']:
+        for module in data['module_stats']:
+            if module and module.get('collection_source') == 'Unknown':
+                if 'module_name' in module and module['module_name']:
+                    module['module_name'] = hash(module['module_name'], salt)
+                if 'collection_name' in module and module['collection_name']:
+                    module['collection_name'] = hash(module['collection_name'], salt)
 
-        # module_stats
-        if 'module_stats' in events_modules and events_modules['module_stats']:
-            for module in events_modules['module_stats']:
-                if module and module.get('collection_source') == 'Unknown':
-                    if 'module_name' in module and module['module_name']:
-                        module['module_name'] = hash(module['module_name'], salt)
-                    if 'collection_name' in module and module['collection_name']:
-                        module['collection_name'] = hash(module['collection_name'], salt)
+    # anonymize collection_name_stats - anonymize collection name for 'Unknown' sources
+    if 'collection_name_stats' in data and data['collection_name_stats']:
+        for collection in data['collection_name_stats']:
+            if collection and collection.get('collection_source') == 'Unknown':
+                if 'collection_name' in collection and collection['collection_name']:
+                    collection['collection_name'] = hash(collection['collection_name'], salt)
 
-        # collection_name_stats
-        if 'collection_name_stats' in events_modules and events_modules['collection_name_stats']:
-            for collection in events_modules['collection_name_stats']:
-                if collection and collection.get('collection_source') == 'Unknown':
-                    if 'module_name' in collection and collection['module_name']:
-                        collection['module_name'] = hash(collection['module_name'], salt)
-                    if 'collection_name' in collection and collection['collection_name']:
-                        collection['collection_name'] = hash(collection['collection_name'], salt)
-
-        # anonymize modules_used_per_playbook_total, playbook names
-        if 'modules_used_per_playbook_total' in events_modules and events_modules['modules_used_per_playbook_total']:
-            old_dict = events_modules['modules_used_per_playbook_total']
-            new_dict = {}
-
-            for playbook, modules in old_dict.items():
-                if playbook:
-                    hashed_playbook = hash(playbook, salt)
-                    new_dict[hashed_playbook] = modules
-
-            events_modules['modules_used_per_playbook_total'] = new_dict
+    # anonymize modules_used_per_playbook - anonymize playbook_id (which is the playbook name)
+    if 'modules_used_per_playbook' in data and data['modules_used_per_playbook']:
+        for playbook_entry in data['modules_used_per_playbook']:
+            if playbook_entry and 'playbook_id' in playbook_entry and playbook_entry['playbook_id']:
+                playbook_entry['playbook_id'] = hash(playbook_entry['playbook_id'], salt)
 
 
 def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -97,62 +98,83 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
       - jobs_by_template: array (copied as-is)
       - job_host_summary: array (copied as-is)
     """
-    events_modules = data.get("events_modules", {})
-    execution_environments = data.get("execution_environments", {})
-    jobs = data.get("jobs", {})
-    job_host_summary_root = data.get("job_host_summary", {})
+    events_modules = data.get('events_modules', {})
+    execution_environments = data.get('execution_environments', {})
+    jobs = data.get('jobs', {})
+    job_host_summary_root = data.get('job_host_summary', {})
+
+    # Handle edge case: job_host_summary might be list instead of dict for empty data
+    if isinstance(job_host_summary_root, list):
+        job_host_summary_root = {}
 
     # 1) statistics (collect only primitive totals)
     statistics = {
         # from events_modules
-        "modules_used_to_automate_total": events_modules.get("modules_used_to_automate_total"),
-        "avg_number_of_modules_used_in_a_playbooks": events_modules.get("avg_number_of_modules_used_in_a_playbooks"),
-        "total_hosts_automated": events_modules.get("total_hosts_automated"),
+        'modules_used_to_automate_total': events_modules.get('modules_used_to_automate_total'),
+        'avg_number_of_modules_used_in_a_playbooks': events_modules.get('avg_number_of_modules_used_in_a_playbooks'),
+        'total_hosts_automated': events_modules.get('total_hosts_automated'),
         # from execution_environments
-        "total_EE": execution_environments.get("total_EE"),
-        "default_EE": execution_environments.get("default_EE"),
-        "custom_EE": execution_environments.get("custom_EE"),
+        'total_EE': execution_environments.get('total_EE'),
+        'default_EE': execution_environments.get('default_EE'),
+        'custom_EE': execution_environments.get('custom_EE'),
         # from jobs
-        "jobs_total": jobs.get("jobs_total"),
+        'jobs_total': jobs.get('jobs_total'),
         # from job_host_summary
-        "total_unique_hosts": job_host_summary_root.get("total_unique_hosts"),
+        'total_unique_hosts': job_host_summary_root.get('total_unique_hosts'),
     }
 
     # 2) modules_used_per_playbook (convert map -> array)
-    mup_map: Dict[str, int] = events_modules.get("modules_used_per_playbook_total", {}) or {}
+    mup_map: Dict[str, int] = events_modules.get('modules_used_per_playbook_total', {}) or {}
     modules_used_per_playbook: List[Dict[str, Any]] = [
-        {"playbook_id": playbook_id, "modules_used": modules_used}
-        for playbook_id, modules_used in mup_map.items()
+        {'playbook_id': playbook_id, 'modules_used': modules_used} for playbook_id, modules_used in mup_map.items()
     ]
 
     # 3) arrays copied as-is from their respective parents
-    module_stats: List[Dict[str, Any]] = events_modules.get("module_stats", []) or []
-    collection_name_stats: List[Dict[str, Any]] = events_modules.get("collection_name_stats", []) or []
-    jobs_by_template: List[Dict[str, Any]] = jobs.get("by_template", []) or []
-    job_host_summary: List[Dict[str, Any]] = job_host_summary_root.get("aggregated", []) or []
+    module_stats: List[Dict[str, Any]] = events_modules.get('module_stats', []) or []
+    collection_name_stats: List[Dict[str, Any]] = events_modules.get('collection_name_stats', []) or []
+    jobs_by_template: List[Dict[str, Any]] = jobs.get('by_template', []) or []
+    job_host_summary: List[Dict[str, Any]] = job_host_summary_root.get('aggregated', []) or []
 
     # 4) assemble the flattened object
     flattened: Dict[str, Any] = {
-        "statistics": statistics,
-        "modules_used_per_playbook": modules_used_per_playbook,
-        "module_stats": module_stats,
-        "collection_name_stats": collection_name_stats,
-        "jobs_by_template": jobs_by_template,
-        "job_host_summary": job_host_summary,
+        'statistics': statistics,
+        'modules_used_per_playbook': modules_used_per_playbook,
+        'module_stats': module_stats,
+        'collection_name_stats': collection_name_stats,
+        'jobs_by_template': jobs_by_template,
+        'job_host_summary': job_host_summary,
     }
 
     return flattened
 
+
 def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs_rollup, job_host_summary_rollup, salt):
+    """
+    Combines rollup data, flattens it, and anonymizes sensitive fields.
+
+    Args:
+        events_modules_rollup: Event modules statistics
+        execution_environments_rollup: Execution environment statistics
+        jobs_rollup: Jobs statistics
+        job_host_summary_rollup: Job host summary statistics
+        salt: Salt string for hashing sensitive data
+
+    Returns:
+        Flattened and anonymized rollup data
+    """
     data = {
         'events_modules': events_modules_rollup,
         'execution_environments': execution_environments_rollup,
         'jobs': jobs_rollup,
         'job_host_summary': job_host_summary_rollup,
     }
+
+    # First flatten the nested structure
+    data = flatten_json_report(data)
+
+    # Then anonymize the flattened structure
     anonymize_data(data, salt)
 
-    data = flatten_json_report(data)
     return data
 
 

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -86,25 +86,61 @@ def anonymize_data(data, salt):
             events_modules['modules_used_per_playbook_total'] = new_dict
 
 
-def flatten_json(json_data):
-    # everything should be only level one key and arrays of objects inside
-    # except key statistics that is object for every primitive value
-    
-    # new json should have all the data from the original json_data, but flattened
+def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Manually flattens the given nested report into:
+      - statistics: object of primitive totals
+      - modules_used_per_playbook: array of {playbook_id, modules_used}
+      - module_stats: array (copied as-is)
+      - collection_name_stats: array (copied as-is)
+      - jobs_by_template: array (copied as-is)
+      - job_host_summary: array (copied as-is)
+    """
+    events_modules = data.get("events_modules", {})
+    execution_environments = data.get("execution_environments", {})
+    jobs = data.get("jobs", {})
+    job_host_summary_root = data.get("job_host_summary", {})
 
-    f'''
-    example:
-    {
-        'statistics': {
-            'jobs_total': 100,
-        },
-        'module_stats' : [...module statuses]
-        'collection_name_stats' : [...collection name statuses]
+    # 1) statistics (collect only primitive totals)
+    statistics = {
+        # from events_modules
+        "modules_used_to_automate_total": events_modules.get("modules_used_to_automate_total"),
+        "avg_number_of_modules_used_in_a_playbooks": events_modules.get("avg_number_of_modules_used_in_a_playbooks"),
+        "total_hosts_automated": events_modules.get("total_hosts_automated"),
+        # from execution_environments
+        "total_EE": execution_environments.get("total_EE"),
+        "default_EE": execution_environments.get("default_EE"),
+        "custom_EE": execution_environments.get("custom_EE"),
+        # from jobs
+        "jobs_total": jobs.get("jobs_total"),
+        # from job_host_summary
+        "total_unique_hosts": job_host_summary_root.get("total_unique_hosts"),
     }
 
-    '''
+    # 2) modules_used_per_playbook (convert map -> array)
+    mup_map: Dict[str, int] = events_modules.get("modules_used_per_playbook_total", {}) or {}
+    modules_used_per_playbook: List[Dict[str, Any]] = [
+        {"playbook_id": playbook_id, "modules_used": modules_used}
+        for playbook_id, modules_used in mup_map.items()
+    ]
 
-    return json_data
+    # 3) arrays copied as-is from their respective parents
+    module_stats: List[Dict[str, Any]] = events_modules.get("module_stats", []) or []
+    collection_name_stats: List[Dict[str, Any]] = events_modules.get("collection_name_stats", []) or []
+    jobs_by_template: List[Dict[str, Any]] = jobs.get("by_template", []) or []
+    job_host_summary: List[Dict[str, Any]] = job_host_summary_root.get("aggregated", []) or []
+
+    # 4) assemble the flattened object
+    flattened: Dict[str, Any] = {
+        "statistics": statistics,
+        "modules_used_per_playbook": modules_used_per_playbook,
+        "module_stats": module_stats,
+        "collection_name_stats": collection_name_stats,
+        "jobs_by_template": jobs_by_template,
+        "job_host_summary": job_host_summary,
+    }
+
+    return flattened
 
 def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs_rollup, job_host_summary_rollup, salt):
     data = {
@@ -114,6 +150,8 @@ def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs
         'job_host_summary': job_host_summary_rollup,
     }
     anonymize_data(data, salt)
+
+    data = flatten_json_report(data)
     return data
 
 

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -54,15 +54,6 @@ def anonymize_data(data, salt):
     if 'events_modules' in data and isinstance(data['events_modules'], dict):
         events_modules = data['events_modules']
 
-        # list of modules to automate
-        if 'list_of_modules_used_to_automate' in events_modules and events_modules['list_of_modules_used_to_automate']:
-            for module in events_modules['list_of_modules_used_to_automate']:
-                if module and module.get('collection_source') == 'Unknown':
-                    if 'module_name' in module and module['module_name']:
-                        module['module_name'] = hash(module['module_name'], salt)
-                    if 'collection_name' in module and module['collection_name']:
-                        module['collection_name'] = hash(module['collection_name'], salt)
-
         # module_stats
         if 'module_stats' in events_modules and events_modules['module_stats']:
             for module in events_modules['module_stats']:

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -17,7 +17,7 @@ from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonym
 def hash(value, salt):
     # has the value and salt, hash should be string
     combined = (salt + ':' + value).encode('utf-8')
-    hashed = hashlib.sha512(combined).hexdigest()
+    hashed = hashlib.sha256(combined).hexdigest()
     return hashed
 
 

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -86,6 +86,26 @@ def anonymize_data(data, salt):
             events_modules['modules_used_per_playbook_total'] = new_dict
 
 
+def flatten_json(json_data):
+    # everything should be only level one key and arrays of objects inside
+    # except key statistics that is object for every primitive value
+    
+    # new json should have all the data from the original json_data, but flattened
+
+    f'''
+    example:
+    {
+        'statistics': {
+            'jobs_total': 100,
+        },
+        'module_stats' : [...module statuses]
+        'collection_name_stats' : [...collection name statuses]
+    }
+
+    '''
+
+    return json_data
+
 def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs_rollup, job_host_summary_rollup, salt):
     data = {
         'events_modules': events_modules_rollup,

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -13,6 +13,7 @@ from metrics_utility.anonymized_rollups.helpers import sanitize_json
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 
+from typing import Dict, Any, List
 
 def hash(value, salt):
     # has the value and salt, hash should be string

--- a/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
@@ -5,6 +5,8 @@ import tarfile
 
 import pandas as pd
 
+from metrics_utility.anonymized_rollups.helpers import sanitize_json
+
 
 class BaseAnonymizedRollup:
     def __init__(self, rollup_name: str):
@@ -63,12 +65,14 @@ class BaseAnonymizedRollup:
                 tar_files[f'{key}.csv'] = csv_buffer.getvalue().encode('utf-8')
 
             elif isinstance(value, list):
-                # Store JSON data in memory for tar
-                tar_files[f'{filename}.json'] = json.dumps(value, indent=2).encode('utf-8')
+                # Sanitize and store JSON data in memory for tar
+                sanitized_value = sanitize_json(value)
+                tar_files[f'{filename}.json'] = json.dumps(sanitized_value, indent=2).encode('utf-8')
 
             elif isinstance(value, dict):
-                # Store JSON data in memory for tar
-                tar_files[f'{filename}.json'] = json.dumps(value, indent=2).encode('utf-8')
+                # Sanitize and store JSON data in memory for tar
+                sanitized_value = sanitize_json(value)
+                tar_files[f'{filename}.json'] = json.dumps(sanitized_value, indent=2).encode('utf-8')
             # the rest
             else:
                 print(f'Key {key} is a unknown type')

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -112,7 +112,13 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         dataframe = dataframe.assign(job_failed=dataframe['job_failed'].fillna(False).astype(bool))
-        dataframe['collection_name'] = dataframe['module_name'].apply(extract_collection_name)
+
+        # Vectorized extraction of collection name (much faster than .apply())
+        # Extract first two parts (namespace.collection) from module name
+        # Requires at least 3 parts: namespace.collection.module
+        dataframe['collection_name'] = dataframe['module_name'].str.extract(
+            r'^([A-Za-z0-9_]+\.[A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$', expand=False
+        )
 
         dataframe['job_duration_seconds'] = (dataframe['job_finished'] - dataframe['job_started']).dt.total_seconds()
         dataframe['job_waiting_time_seconds'] = (dataframe['job_started'] - dataframe['job_created']).dt.total_seconds()

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -214,6 +214,21 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 'rollup': {'aggregated': dataframe},
             }
 
+        # Categorize columns to reduce memory footprint
+        # This is done after batches are concatenated to ensure consistent categories
+        # Only categorize string columns with low-to-medium cardinality (high repetition)
+        categorical_columns = [
+            'collection_source',  # ~20 unique values (Red Hat, Community, Partner, etc.)
+            'collection_name',  # ~500-1000 unique collections
+            'module_name',  # ~2000-5000 unique modules
+            'playbook',  # ~1000-5000 unique playbooks
+            'task_uuid',  # ~1000-5000 unique task uuids
+        ]
+
+        for col in categorical_columns:
+            if col in dataframe.columns:
+                dataframe[col] = dataframe[col].astype('category')
+
         # Final aggregation: handle any cross-batch duplicates
         # because the task running on host can be split between batches
         # we need to aggregate the data second time to get the correct results
@@ -232,21 +247,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
             playbook=('playbook', 'first'),
         )
-
-        # Categorize columns to reduce memory footprint
-        # This is done after batches are concatenated to ensure consistent categories
-        # Only categorize string columns with low-to-medium cardinality (high repetition)
-        categorical_columns = [
-            'collection_source',  # ~20 unique values (Red Hat, Community, Partner, etc.)
-            'collection_name',  # ~500-1000 unique collections
-            'module_name',  # ~2000-5000 unique modules
-            'playbook',  # ~1000-5000 unique playbooks
-            'task_uuid',  # ~1000-5000 unique task uuids
-        ]
-
-        for col in categorical_columns:
-            if col in dataframe.columns:
-                dataframe[col] = dataframe[col].astype('category')
 
         # Modules used to automate
         # distinct name of modules used to automate

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -190,6 +190,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 seen_unreachable=('task_unreachable_event', 'max'),
                 seen_skipped=('task_skipped_event', 'max'),
                 seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
+                job_started=('job_started', 'first'),
             )
             .reset_index()
             .assign(
@@ -253,6 +254,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         job_time_stats_module = (
             per_job_module.groupby(['module_name', 'collection_source', 'collection_name'])
             .agg(
+                jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
                 job_waiting_time_total_seconds=('job_waiting_time_seconds', 'sum'),
                 avg_hosts_per_job=('host_count', 'mean'),
@@ -275,6 +277,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         job_time_stats_collection_name = (
             per_job_collection_name.groupby(['collection_name', 'collection_source'])
             .agg(
+                jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
                 job_waiting_time_total_seconds=('job_waiting_time_seconds', 'sum'),
                 avg_hosts_per_job=('host_count', 'mean'),

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -82,8 +82,8 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             self.collections = json.load(f)
 
     # Prepare is run for each batch of data
-    # then it is merged with other batches into one dataframe
-    # as default, merging is done by concatenating dataframes
+    # then it is merged with other batches into one dataframes
+    # as default, merging is done by concatenating dataframes (defined in base class)
     def prepare(self, dataframe):
         # Failure/Success rate of modules
         success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
@@ -170,6 +170,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # Aggregate events per task to reduce rows before merging batches
         # This groups by (job, host, task, module, collection) and summarizes all events
+        # This can greatly reduce the number of rows, depends of number of retries
         task_summary = dataframe.groupby(
             ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
         ).agg(
@@ -186,33 +187,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         return task_summary
-
-    def merge(self, dataframe_all, dataframe_new):
-        """
-        Override base merge to re-aggregate when combining batches.
-        Since the same (job_id, host_id, task_uuid, module_name, collection_source, collection_name)
-        might appear in different batches, we need to aggregate again after concatenation.
-        """
-        # Concatenate the batches
-        combined = pd.concat([dataframe_all, dataframe_new], ignore_index=True)
-
-        # Re-aggregate: group by the same keys and take max of seen_* columns
-        merged = combined.groupby(
-            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
-        ).agg(
-            seen_success=('seen_success', 'max'),
-            seen_failed=('seen_failed', 'max'),
-            seen_unreachable=('seen_unreachable', 'max'),
-            seen_skipped=('seen_skipped', 'max'),
-            seen_failed_and_ignored=('seen_failed_and_ignored', 'max'),
-            job_started=('job_started', 'first'),
-            job_failed=('job_failed', 'first'),
-            job_duration_seconds=('job_duration_seconds', 'first'),
-            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            playbook=('playbook', 'first'),
-        )
-
-        return merged
 
     def base(self, dataframe):
         """
@@ -239,6 +213,25 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 'json': {},
                 'rollup': {'aggregated': dataframe},
             }
+
+        # Final aggregation: handle any cross-batch duplicates
+        # because the task running on host can be split between batches
+        # we need to aggregate the data second time to get the correct results
+        # since this will be rare, reduction of rows will be still significant
+        dataframe = dataframe.groupby(
+            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+        ).agg(
+            seen_success=('seen_success', 'max'),
+            seen_failed=('seen_failed', 'max'),
+            seen_unreachable=('seen_unreachable', 'max'),
+            seen_skipped=('seen_skipped', 'max'),
+            seen_failed_and_ignored=('seen_failed_and_ignored', 'max'),
+            job_started=('job_started', 'first'),
+            job_failed=('job_failed', 'first'),
+            job_duration_seconds=('job_duration_seconds', 'first'),
+            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+            playbook=('playbook', 'first'),
+        )
 
         # Categorize columns to reduce memory footprint
         # This is done after batches are concatenated to ensure consistent categories

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -81,6 +81,9 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         with open('metrics_utility/anonymized_rollups/collections.json', 'r') as f:
             self.collections = json.load(f)
 
+    # Prepare is run for each batch of data
+    # then it is merged with other batches into one dataframe
+    # as default, merging is done by concatenating dataframes
     def prepare(self, dataframe):
         # Failure/Success rate of modules
         success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
@@ -165,7 +168,51 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         dataframe = dataframe[columns_to_keep]
 
-        return dataframe
+        # Aggregate events per task to reduce rows before merging batches
+        # This groups by (job, host, task, module, collection) and summarizes all events
+        task_summary = dataframe.groupby(
+            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+        ).agg(
+            seen_success=('task_success_event', 'max'),
+            seen_failed=('task_failed_event', 'max'),
+            seen_unreachable=('task_unreachable_event', 'max'),
+            seen_skipped=('task_skipped_event', 'max'),
+            seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
+            job_started=('job_started', 'first'),
+            job_failed=('job_failed', 'first'),
+            job_duration_seconds=('job_duration_seconds', 'first'),
+            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+            playbook=('playbook', 'first'),
+        )
+
+        return task_summary
+
+    def merge(self, dataframe_all, dataframe_new):
+        """
+        Override base merge to re-aggregate when combining batches.
+        Since the same (job_id, host_id, task_uuid, module_name, collection_source, collection_name)
+        might appear in different batches, we need to aggregate again after concatenation.
+        """
+        # Concatenate the batches
+        combined = pd.concat([dataframe_all, dataframe_new], ignore_index=True)
+
+        # Re-aggregate: group by the same keys and take max of seen_* columns
+        merged = combined.groupby(
+            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+        ).agg(
+            seen_success=('seen_success', 'max'),
+            seen_failed=('seen_failed', 'max'),
+            seen_unreachable=('seen_unreachable', 'max'),
+            seen_skipped=('seen_skipped', 'max'),
+            seen_failed_and_ignored=('seen_failed_and_ignored', 'max'),
+            job_started=('job_started', 'first'),
+            job_failed=('job_failed', 'first'),
+            job_duration_seconds=('job_duration_seconds', 'first'),
+            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+            playbook=('playbook', 'first'),
+        )
+
+        return merged
 
     def base(self, dataframe):
         """
@@ -225,36 +272,19 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         total_hosts_automated = dataframe['host_id'].nunique()
 
-        # Collapse events  one row per (job, module, task)
-        # summarize all failed events as number of failed attempts
-        # if one success events is seen, task is successful
-        # problem is that each task_uuid can have multiple ok and success events
-        # when at least one success event is seen, task is successful
-        # failed event can be repeated multiple times, we are counting failed attempts
-        task_summary = (
-            dataframe.groupby(
-                ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
-            )
-            .agg(
-                seen_success=('task_success_event', 'max'),
-                seen_failed=('task_failed_event', 'max'),
-                seen_unreachable=('task_unreachable_event', 'max'),
-                seen_skipped=('task_skipped_event', 'max'),
-                seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
-                job_started=('job_started', 'first'),
-            )
-            .assign(
-                # mutually exclusive categories - only one can be true
-                task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
-                task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
-                task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
-                task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
-                task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
-                task_skipped=lambda x: (
-                    x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
-                ),
-                job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
-            )
+        # Data is already aggregated from prepare() and merge()
+        # We just need to compute the mutually exclusive task status categories
+        task_summary = dataframe.assign(
+            # mutually exclusive categories - only one can be true
+            task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
+            task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
+            task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
+            task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
+            task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
+            task_skipped=lambda x: (
+                x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
+            ),
+            job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
         )
 
         # Per-module counts

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -371,7 +371,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # Prepare JSON data (converted to dicts/lists)
         json_data = {
-            'list_of_modules_used_to_automate': list_of_modules_used_to_automate.to_dict(orient='records'),
             'modules_used_to_automate_total': modules_used_to_automate_total,
             'avg_number_of_modules_used_in_a_playbooks': avg_number_of_modules_used_in_a_playbooks,
             'modules_used_per_playbook_total': modules_used_per_playbook_total.to_dict(),

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -211,7 +211,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         # when at least one success event is seen, task is successful
         # failed event can be repeated multiple times, we are counting failed attempts
         task_summary = (
-            dataframe.groupby(['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'])
+            dataframe.groupby(['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False)
             .agg(
                 seen_success=('task_success_event', 'max'),
                 seen_failed=('task_failed_event', 'max'),
@@ -220,7 +220,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
                 job_started=('job_started', 'first'),
             )
-            .reset_index()
             .assign(
                 # mutually exclusive categories - only one can be true
                 task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
@@ -237,38 +236,30 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # Per-module counts
         # receiver of this data can easily calculate success rates
-        module_stats = (
-            task_summary.groupby(['module_name', 'collection_source', 'collection_name'])
-            .agg(
-                jobs_total=('job_id', 'nunique'),
-                number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-                hosts_total=('host_id', 'nunique'),
-                task_clean_success_total=('task_clean_success', 'sum'),
-                task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
-                task_failed_total=('task_failed', 'sum'),
-                task_unreachable_total=('task_unreachable', 'sum'),
-                task_skipped_total=('task_skipped', 'sum'),
-                task_failed_and_ignored_total=('task_failed_and_ignored', 'sum'),
-                jobs_failed_because_of_module_failure_total=('job_id_that_contained_failed_task', 'nunique'),
-            )
-            .reset_index()
+        module_stats = task_summary.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False).agg(
+            jobs_total=('job_id', 'nunique'),
+            number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
+            hosts_total=('host_id', 'nunique'),
+            task_clean_success_total=('task_clean_success', 'sum'),
+            task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
+            task_failed_total=('task_failed', 'sum'),
+            task_unreachable_total=('task_unreachable', 'sum'),
+            task_skipped_total=('task_skipped', 'sum'),
+            task_failed_and_ignored_total=('task_failed_and_ignored', 'sum'),
+            jobs_failed_because_of_module_failure_total=('job_id_that_contained_failed_task', 'nunique'),
         )
 
-        collection_name_stats = (
-            task_summary.groupby(['collection_name', 'collection_source'])
-            .agg(
-                jobs_total=('job_id', 'nunique'),
-                number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-                hosts_total=('host_id', 'nunique'),
-                jobs_failed_because_of_collection_name_failure_total=('job_id_that_contained_failed_task', 'nunique'),
-                task_clean_success_total=('task_clean_success', 'sum'),
-                task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
-                task_failed_total=('task_failed', 'sum'),
-                task_unreachable_total=('task_unreachable', 'sum'),
-                task_skipped_total=('task_skipped', 'sum'),
-                task_failed_and_ignored_total=('task_failed_and_ignored', 'sum'),
-            )
-            .reset_index()
+        collection_name_stats = task_summary.groupby(['collection_name', 'collection_source'], as_index=False).agg(
+            jobs_total=('job_id', 'nunique'),
+            number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
+            hosts_total=('host_id', 'nunique'),
+            jobs_failed_because_of_collection_name_failure_total=('job_id_that_contained_failed_task', 'nunique'),
+            task_clean_success_total=('task_clean_success', 'sum'),
+            task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
+            task_failed_total=('task_failed', 'sum'),
+            task_unreachable_total=('task_unreachable', 'sum'),
+            task_skipped_total=('task_skipped', 'sum'),
+            task_failed_and_ignored_total=('task_failed_and_ignored', 'sum'),
         )
 
         # Per-job statistics for modules (similar to collection_name)
@@ -280,7 +271,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         job_time_stats_module = (
-            per_job_module.groupby(['module_name', 'collection_source', 'collection_name'])
+            per_job_module.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False)
             .agg(
                 jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
@@ -292,7 +283,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 avg_job_duration_seconds=lambda x: x['job_duration_total_seconds'] / x['jobs_total'],
                 avg_job_waiting_time_seconds=lambda x: x['job_waiting_time_total_seconds'] / x['jobs_total'],
             )
-            .reset_index()
         )
 
         per_job_collection_name = dataframe.groupby(['job_id', 'collection_name', 'collection_source'], as_index=False).agg(
@@ -303,7 +293,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         job_time_stats_collection_name = (
-            per_job_collection_name.groupby(['collection_name', 'collection_source'])
+            per_job_collection_name.groupby(['collection_name', 'collection_source'], as_index=False)
             .agg(
                 jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
@@ -315,7 +305,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 avg_job_duration_seconds=lambda x: x['job_duration_total_seconds'] / x['jobs_total'],
                 avg_job_waiting_time_seconds=lambda x: x['job_waiting_time_total_seconds'] / x['jobs_total'],
             )
-            .reset_index()
         )
 
         # merge module_stats and job_time_stats_module into one list based on module_name

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -193,11 +193,26 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 'rollup': {'aggregated': dataframe},
             }
 
+        # Categorize columns to reduce memory footprint
+        # This is done after batches are concatenated to ensure consistent categories
+        # Only categorize string columns with low-to-medium cardinality (high repetition)
+        categorical_columns = [
+            'collection_source',  # ~20 unique values (Red Hat, Community, Partner, etc.)
+            'collection_name',  # ~500-1000 unique collections
+            'module_name',  # ~2000-5000 unique modules
+            'playbook',  # ~1000-5000 unique playbooks
+            'task_uuid',  # ~1000-5000 unique task uuids
+        ]
+
+        for col in categorical_columns:
+            if col in dataframe.columns:
+                dataframe[col] = dataframe[col].astype('category')
+
         # Modules used to automate
         # distinct name of modules used to automate
 
         # pick unique module name and associated collection source
-        list_of_modules_used_to_automate = dataframe.groupby('module_name', as_index=False).agg(
+        list_of_modules_used_to_automate = dataframe.groupby('module_name', as_index=False, observed=True).agg(
             {'collection_source': lambda x: x.unique()[0], 'collection_name': lambda x: x.unique()[0]}
         )
 
@@ -205,8 +220,8 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         modules_used_to_automate_total = len(list_of_modules_used_to_automate)
 
         # Avg number of modules used in a playbook
-        avg_number_of_modules_used_in_a_playbooks = dataframe.groupby('playbook')['module_name'].nunique().mean()
-        modules_used_per_playbook_total = dataframe.groupby('playbook')['module_name'].nunique()
+        avg_number_of_modules_used_in_a_playbooks = dataframe.groupby('playbook', observed=True)['module_name'].nunique().mean()
+        modules_used_per_playbook_total = dataframe.groupby('playbook', observed=True)['module_name'].nunique()
 
         total_hosts_automated = dataframe['host_id'].nunique()
 
@@ -217,7 +232,9 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         # when at least one success event is seen, task is successful
         # failed event can be repeated multiple times, we are counting failed attempts
         task_summary = (
-            dataframe.groupby(['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False)
+            dataframe.groupby(
+                ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+            )
             .agg(
                 seen_success=('task_success_event', 'max'),
                 seen_failed=('task_failed_event', 'max'),
@@ -242,7 +259,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # Per-module counts
         # receiver of this data can easily calculate success rates
-        module_stats = task_summary.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False).agg(
+        module_stats = task_summary.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
             hosts_total=('host_id', 'nunique'),
@@ -255,7 +272,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             jobs_failed_because_of_module_failure_total=('job_id_that_contained_failed_task', 'nunique'),
         )
 
-        collection_name_stats = task_summary.groupby(['collection_name', 'collection_source'], as_index=False).agg(
+        collection_name_stats = task_summary.groupby(['collection_name', 'collection_source'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
             hosts_total=('host_id', 'nunique'),
@@ -269,7 +286,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         # Per-job statistics for modules (similar to collection_name)
-        per_job_module = dataframe.groupby(['job_id', 'module_name', 'collection_name', 'collection_source'], as_index=False).agg(
+        per_job_module = dataframe.groupby(['job_id', 'module_name', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
             host_count=('host_id', 'nunique'),
@@ -277,7 +294,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         job_time_stats_module = (
-            per_job_module.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False)
+            per_job_module.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False, observed=True)
             .agg(
                 jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
@@ -291,7 +308,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             )
         )
 
-        per_job_collection_name = dataframe.groupby(['job_id', 'collection_name', 'collection_source'], as_index=False).agg(
+        per_job_collection_name = dataframe.groupby(['job_id', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
             host_count=('host_id', 'nunique'),
@@ -299,7 +316,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         )
 
         job_time_stats_collection_name = (
-            per_job_collection_name.groupby(['collection_name', 'collection_source'], as_index=False)
+            per_job_collection_name.groupby(['collection_name', 'collection_source'], as_index=False, observed=True)
             .agg(
                 jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -77,11 +77,13 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         self.collector_names = ['main_jobevent_service']
 
-    def prepare(self, dataframe):
-        # Prepare data
         # Open the JSON file
         with open('metrics_utility/anonymized_rollups/collections.json', 'r') as f:
-            collections = json.load(f)
+            self.collections = json.load(f)
+
+    def prepare(self, dataframe):
+        # Prepare data
+        collections = self.collections
 
         # if missing ignore_errors column, insert it, default is False. If values is null, set it to False
         if 'ignore_errors' not in dataframe.columns:
@@ -130,6 +132,28 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             & (dataframe['module_name'].str.strip() != '')
             & (dataframe['playbook'].str.strip() != '')
         ]
+
+        # Select only the columns needed for analysis to save memory
+        columns_to_keep = [
+            'job_id',
+            'host_id',
+            'task_uuid',
+            'module_name',
+            'playbook',
+            'collection_name',
+            'collection_source',
+            'job_failed',
+            'job_started',
+            'job_duration_seconds',
+            'job_waiting_time_seconds',
+            'task_success_event',
+            'task_failed_event',
+            'task_failed_and_ignored_event',
+            'task_unreachable_event',
+            'task_skipped_event',
+        ]
+
+        dataframe = dataframe[columns_to_keep]
 
         return dataframe
 

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -236,8 +236,8 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 task_skipped=lambda x: (
                     x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
                 ),
+                job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
             )
-            .assign(job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']))
         )
 
         # Per-module counts

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -105,9 +105,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe['job_duration_seconds'] = (dataframe['job_finished'] - dataframe['job_started']).dt.total_seconds()
         dataframe['job_waiting_time_seconds'] = (dataframe['job_started'] - dataframe['job_created']).dt.total_seconds()
 
-        dataframe = dataframe[dataframe['job_duration_seconds'] >= 0]
-        dataframe = dataframe[dataframe['job_waiting_time_seconds'] >= 0]
-
         # fill collection source from collections_types
         dataframe['collection_source'] = dataframe['collection_name'].map(collections).fillna('Unknown')
 
@@ -215,6 +212,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             task_summary.groupby(['module_name', 'collection_source', 'collection_name'])
             .agg(
                 jobs_total=('job_id', 'nunique'),
+                number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
                 hosts_total=('host_id', 'nunique'),
                 task_clean_success_total=('task_clean_success', 'sum'),
                 task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
@@ -230,6 +228,8 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         collection_name_stats = (
             task_summary.groupby(['collection_name', 'collection_source'])
             .agg(
+                jobs_total=('job_id', 'nunique'),
+                number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
                 hosts_total=('host_id', 'nunique'),
                 jobs_failed_because_of_collection_name_failure_total=('job_id_that_contained_failed_task', 'nunique'),
                 task_clean_success_total=('task_clean_success', 'sum'),
@@ -253,7 +253,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         job_time_stats_module = (
             per_job_module.groupby(['module_name', 'collection_source', 'collection_name'])
             .agg(
-                jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
                 job_waiting_time_total_seconds=('job_waiting_time_seconds', 'sum'),
                 avg_hosts_per_job=('host_count', 'mean'),
@@ -276,7 +275,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         job_time_stats_collection_name = (
             per_job_collection_name.groupby(['collection_name', 'collection_source'])
             .agg(
-                jobs_total=('job_id', 'nunique'),
                 job_duration_total_seconds=('job_duration_seconds', 'sum'),
                 job_waiting_time_total_seconds=('job_waiting_time_seconds', 'sum'),
                 avg_hosts_per_job=('host_count', 'mean'),

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -82,6 +82,16 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             self.collections = json.load(f)
 
     def prepare(self, dataframe):
+        # Failure/Success rate of modules
+        success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
+        failed_events_list = ['runner_on_failed', 'runner_on_async_failed', 'runner_item_on_failed']
+        unreachable_events_list = ['runner_on_unreachable', 'runner_item_on_unreachable']
+        skipped_events_list = ['runner_on_skipped', 'runner_item_on_skipped']
+
+        # Filter for only the event types that are used in analysis
+        all_relevant_events = success_events_list + failed_events_list + unreachable_events_list + skipped_events_list
+        dataframe = dataframe[dataframe['event'].isin(all_relevant_events)]
+
         # Prepare data
         collections = self.collections
 
@@ -109,12 +119,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # fill collection source from collections_types
         dataframe['collection_source'] = dataframe['collection_name'].map(collections).fillna('Unknown')
-
-        # Failure/Success rate of modules
-        success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
-        failed_events_list = ['runner_on_failed', 'runner_on_async_failed', 'runner_item_on_failed']
-        unreachable_events_list = ['runner_on_unreachable', 'runner_item_on_unreachable']
-        skipped_events_list = ['runner_on_skipped', 'runner_item_on_skipped']
 
         # Mark events
         dataframe['task_success_event'] = dataframe['event'].isin(success_events_list)

--- a/metrics_utility/anonymized_rollups/helpers.py
+++ b/metrics_utility/anonymized_rollups/helpers.py
@@ -1,0 +1,47 @@
+"""
+Helper utilities for anonymized rollups.
+"""
+
+import math
+
+
+def sanitize_json(obj):
+    """
+    Sanitize a Python object to be JSON-serializable by replacing NaN and infinity values.
+
+    This function recursively traverses dictionaries, lists, and other data structures
+    and replaces any NaN or infinity values with None (which becomes null in JSON).
+
+    Args:
+        obj: The object to sanitize (can be dict, list, float, int, str, etc.)
+
+    Returns:
+        The sanitized object with all NaN and infinity values replaced with None
+
+    Examples:
+        >>> sanitize_json({'value': float('nan')})
+        {'value': None}
+
+        >>> sanitize_json([1, float('inf'), 3])
+        [1, None, 3]
+
+        >>> sanitize_json({'nested': {'value': float('-inf')}})
+        {'nested': {'value': None}}
+    """
+    if isinstance(obj, dict):
+        # Recursively sanitize dictionary values
+        return {key: sanitize_json(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        # Recursively sanitize list items
+        return [sanitize_json(item) for item in obj]
+    elif isinstance(obj, tuple):
+        # Recursively sanitize tuple items (convert to list for JSON)
+        return [sanitize_json(item) for item in obj]
+    elif isinstance(obj, float):
+        # Check for NaN or infinity
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+        return obj
+    else:
+        # Return other types as-is (int, str, bool, None, etc.)
+        return obj

--- a/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
@@ -32,7 +32,7 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
 
         # Group by job_template_name and host_name, sum task columns, count jobs
         aggregated = (
-            dataframe.groupby(['job_template_name', 'host_name'])
+            dataframe.groupby(['job_template_name'])
             .agg(
                 dark_total=('dark', 'sum'),
                 failures_total=('failures', 'sum'),
@@ -40,7 +40,6 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
                 skipped_total=('skipped', 'sum'),
                 ignored_total=('ignored', 'sum'),
                 rescued_total=('rescued', 'sum'),
-                jobs_total=('job_remote_id', 'nunique'),
             )
             .reset_index()
         )
@@ -68,14 +67,12 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
         aggregated = (
             dataframe.groupby(['job_template_name'])
             .agg(
-                jobs_total=('jobs_total', 'sum'),
                 dark_total=('dark_total', 'sum'),
                 failures_total=('failures_total', 'sum'),
                 ok_total=('ok_total', 'sum'),
                 skipped_total=('skipped_total', 'sum'),
                 ignored_total=('ignored_total', 'sum'),
                 rescued_total=('rescued_total', 'sum'),
-                hosts_total=('host_name', 'nunique'),
             )
             .reset_index()
         )

--- a/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
@@ -25,8 +25,27 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
     # rescued
 
     def prepare(self, dataframe):
-        # group dataframe by job_remote_id
-        return dataframe
+        # Aggregate by job_template_name and host_name to reduce data volume early
+        # This significantly improves performance when processing large batches
+        if dataframe.empty:
+            return dataframe
+
+        # Group by job_template_name and host_name, sum task columns, count jobs
+        aggregated = (
+            dataframe.groupby(['job_template_name', 'host_name'])
+            .agg(
+                dark_total=('dark', 'sum'),
+                failures_total=('failures', 'sum'),
+                ok_total=('ok', 'sum'),
+                skipped_total=('skipped', 'sum'),
+                ignored_total=('ignored', 'sum'),
+                rescued_total=('rescued', 'sum'),
+                jobs_total=('job_remote_id', 'nunique'),
+            )
+            .reset_index()
+        )
+
+        return aggregated
 
     def base(self, dataframe):
         """
@@ -37,8 +56,6 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
         Success rate and average - this can compute SaaS team from the metrics
         """
 
-        task_columns = ['dark', 'failures', 'ok', 'skipped', 'ignored', 'rescued']
-
         # Return empty result if dataframe is empty
         # TODO - ensure all columns are present in the dataframe, then let analysis run with empty data
         if dataframe.empty:
@@ -47,18 +64,17 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
                 'rollup': {'aggregated': dataframe},
             }
 
-        dataframe['tasks_executed'] = dataframe[task_columns].sum(axis=1)
-
+        # Re-aggregate in case multiple batches had overlapping template+host combinations
         aggregated = (
-            dataframe.groupby('job_template_name')
+            dataframe.groupby(['job_template_name'])
             .agg(
-                jobs_total=('job_remote_id', 'nunique'),
-                dark_total=('dark', 'sum'),
-                failures_total=('failures', 'sum'),
-                ok_total=('ok', 'sum'),
-                skipped_total=('skipped', 'sum'),
-                ignored_total=('ignored', 'sum'),
-                rescued_total=('rescued', 'sum'),
+                jobs_total=('jobs_total', 'sum'),
+                dark_total=('dark_total', 'sum'),
+                failures_total=('failures_total', 'sum'),
+                ok_total=('ok_total', 'sum'),
+                skipped_total=('skipped_total', 'sum'),
+                ignored_total=('ignored_total', 'sum'),
+                rescued_total=('rescued_total', 'sum'),
                 hosts_total=('host_name', 'nunique'),
             )
             .reset_index()

--- a/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
@@ -40,6 +40,8 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
                 skipped_total=('skipped', 'sum'),
                 ignored_total=('ignored', 'sum'),
                 rescued_total=('rescued', 'sum'),
+                # keep unique hosts as set
+                unique_hosts=('host_name', lambda x: set(x)),
             )
             .reset_index()
         )
@@ -73,9 +75,14 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
                 skipped_total=('skipped_total', 'sum'),
                 ignored_total=('ignored_total', 'sum'),
                 rescued_total=('rescued_total', 'sum'),
+                unique_hosts=('unique_hosts', lambda x: set().union(*x)),
             )
             .reset_index()
         )
+
+        total_unique_hosts = set().union(*aggregated['unique_hosts'])
+        # drop unique_hosts column
+        aggregated = aggregated.drop(columns=['unique_hosts'])
 
         # Prepare rollup data (dataframe before conversion)
         rollup_data = {
@@ -84,7 +91,12 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
         }
 
         # Prepare JSON data (converted to list of dicts)
-        json_data = aggregated.to_dict(orient='records')
+        # json_data = aggregated.to_dict(orient='records')
+
+        json_data = {
+            'total_unique_hosts': len(total_unique_hosts),
+            'aggregated': aggregated.to_dict(orient='records'),
+        }
 
         return {
             'json': json_data,

--- a/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
@@ -10,6 +10,24 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
         super().__init__('job_host_summary')
         self.collector_names = ['job_host_summary_service']
 
+    # prepare is called for each batch of data
+    # result of prepare is concatenated with other batches into one dataframe
+    # each dataframe in prepare should reduce the number of rows as much as possible
+    # dataframe has:
+    # job_remote_id
+    # job_template_name
+    # host_name
+    # dark
+    # failures
+    # ok
+    # skipped
+    # ignored
+    # rescued
+
+    def prepare(self, dataframe):
+        # group dataframe by job_remote_id
+        return dataframe
+
     def base(self, dataframe):
         """
         Avg tasks by template (column job_template_name)

--- a/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
@@ -61,15 +61,12 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         dataframe['job_duration_seconds'] = (dataframe['finished'] - dataframe['started']).dt.total_seconds()
         dataframe['job_waiting_time_seconds'] = (dataframe['started'] - dataframe['created']).dt.total_seconds()
 
-        # guard against negative times
-        dataframe = dataframe[dataframe['job_duration_seconds'] >= 0]
-        dataframe = dataframe[dataframe['job_waiting_time_seconds'] >= 0]
-
         aggregations_by_template = (
             dataframe.groupby('job_template_name')
             .agg(
                 number_of_jobs_executed=('id', 'nunique'),
                 number_of_jobs_failed=('failed', 'sum'),
+                number_of_jobs_never_started=('started', lambda x: x.isna().sum()),
                 job_duration_average_in_seconds=('job_duration_seconds', 'mean'),
                 job_duration_maximum_in_seconds=('job_duration_seconds', 'max'),
                 job_duration_minimum_in_seconds=('job_duration_seconds', 'min'),

--- a/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
@@ -61,6 +61,8 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         dataframe['job_duration_seconds'] = (dataframe['finished'] - dataframe['started']).dt.total_seconds()
         dataframe['job_waiting_time_seconds'] = (dataframe['started'] - dataframe['created']).dt.total_seconds()
 
+        jobs_total = dataframe['id'].nunique()
+
         aggregations_by_template = (
             dataframe.groupby('job_template_name')
             .agg(
@@ -89,7 +91,10 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         }
 
         # Prepare JSON data (converted to list of dicts)
-        json_data = aggregations_by_template.to_dict(orient='records')
+        json_data = {
+            'by_template': aggregations_by_template.to_dict(orient='records'),
+            'jobs_total': jobs_total,
+        }
 
         return {
             'json': json_data,

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -18,7 +18,6 @@ def task_anonymized_rollups(salt, year, month, day, ship_path, save_rollups: boo
     since_param = datetime_since.strftime('%Y-%m-%d')
     until_param = datetime_until.strftime('%Y-%m-%d')
 
-    # run_gather_ext(env_vars, ['--ship', '--force', f'--since={since_param}', f'--until={until_param}'])
     run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
 
     # load data for each collector

--- a/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
@@ -297,6 +297,24 @@ events = [
         'resolved_action': None,
         'ignore_errors': False,
     },
+    # ================================================================
+    # Job 5 – maintenance.yml – job never started → job_started=None
+    # ================================================================
+    # Job 5 Host 1 – t002 (yum task that was queued but job never started, cancelled immediately)
+    {
+        'job_id': 5,
+        'playbook': 'maintenance.yml',
+        'host_id': 9,
+        'task_uuid': 't002',
+        'event': 'runner_on_failed',
+        'task_action': 'community.general.yum',
+        'job_created': '2024-01-06 10:00:00+00',
+        'job_started': None,
+        'job_finished': '2024-01-06 10:00:05+00',
+        'job_failed': True,
+        'resolved_action': None,
+        'ignore_errors': False,
+    },
 ]
 
 
@@ -333,7 +351,7 @@ def test_events_modules_aggregations_basic():
     ]
 
     # average number of modules per playbook based on current aggregation
-    assert result['avg_number_of_modules_used_in_a_playbooks'] == 3.5
+    assert result['avg_number_of_modules_used_in_a_playbooks'] == 3.0
 
     # total modules used per playbook (current aggregation)
     assert result['modules_used_per_playbook_total'] == {
@@ -341,9 +359,10 @@ def test_events_modules_aggregations_basic():
         'deploy.yml': 3,
         'infra.yml': 3,
         'site.yml': 5,
+        'maintenance.yml': 1,
     }
 
-    assert result['total_hosts_automated'] == 8
+    assert result['total_hosts_automated'] == 9
 
     # collection stats assertions (current aggregation schema)
     coll_by_name = {row['collection_name']: row for row in result['collection_name_stats']}
@@ -360,6 +379,7 @@ def test_events_modules_aggregations_basic():
     assert copy_stats['task_skipped_total'] == 0
     assert copy_stats['task_unreachable_total'] == 0
     assert copy_stats['jobs_total'] == 3
+    assert copy_stats['number_of_jobs_never_started'] == 0
     assert copy_stats['hosts_total'] == 3
     assert copy_stats['jobs_failed_because_of_module_failure_total'] == 0
 
@@ -373,6 +393,7 @@ def test_events_modules_aggregations_basic():
     assert template_stats['task_skipped_total'] == 0
     assert template_stats['task_unreachable_total'] == 1
     assert template_stats['jobs_total'] == 2
+    assert template_stats['number_of_jobs_never_started'] == 0
     assert template_stats['hosts_total'] == 2
     assert template_stats['jobs_failed_because_of_module_failure_total'] == 0
 
@@ -386,6 +407,7 @@ def test_events_modules_aggregations_basic():
     assert firewalld_stats['task_skipped_total'] == 0
     assert firewalld_stats['task_unreachable_total'] == 0
     assert firewalld_stats['jobs_total'] == 2
+    assert firewalld_stats['number_of_jobs_never_started'] == 0
     assert firewalld_stats['hosts_total'] == 2
     assert firewalld_stats['jobs_failed_because_of_module_failure_total'] == 1
 
@@ -399,6 +421,7 @@ def test_events_modules_aggregations_basic():
     assert ec2_stats['task_skipped_total'] == 1
     assert ec2_stats['task_unreachable_total'] == 0
     assert ec2_stats['jobs_total'] == 2
+    assert ec2_stats['number_of_jobs_never_started'] == 0
     assert ec2_stats['hosts_total'] == 4
     assert ec2_stats['jobs_failed_because_of_module_failure_total'] == 0
 
@@ -407,13 +430,14 @@ def test_events_modules_aggregations_basic():
     assert yum_stats['collection_source'] == 'community'
     assert yum_stats['task_clean_success_total'] == 0
     assert yum_stats['task_success_with_reruns_total'] == 0
-    assert yum_stats['task_failed_total'] == 2
+    assert yum_stats['task_failed_total'] == 3
     assert yum_stats['task_failed_and_ignored_total'] == 0
     assert yum_stats['task_skipped_total'] == 0
     assert yum_stats['task_unreachable_total'] == 0
-    assert yum_stats['jobs_total'] == 2
-    assert yum_stats['hosts_total'] == 1
-    assert yum_stats['jobs_failed_because_of_module_failure_total'] == 2
+    assert yum_stats['jobs_total'] == 3
+    assert yum_stats['number_of_jobs_never_started'] == 1
+    assert yum_stats['hosts_total'] == 2
+    assert yum_stats['jobs_failed_because_of_module_failure_total'] == 3
 
     # community.mongodb.insert (community)
     mongo_stats = stats_by_module['community.mongodb.insert']
@@ -425,6 +449,7 @@ def test_events_modules_aggregations_basic():
     assert mongo_stats['task_skipped_total'] == 0
     assert mongo_stats['task_unreachable_total'] == 0
     assert mongo_stats['jobs_total'] == 2
+    assert mongo_stats['number_of_jobs_never_started'] == 0
     assert mongo_stats['hosts_total'] == 2
     assert mongo_stats['jobs_failed_because_of_module_failure_total'] == 0
 
@@ -438,6 +463,7 @@ def test_events_modules_aggregations_basic():
     assert custom_stats['task_skipped_total'] == 0
     assert custom_stats['task_unreachable_total'] == 0
     assert custom_stats['jobs_total'] == 1
+    assert custom_stats['number_of_jobs_never_started'] == 0
     assert custom_stats['hosts_total'] == 1
     assert custom_stats['jobs_failed_because_of_module_failure_total'] == 0
 
@@ -447,6 +473,7 @@ def test_events_modules_aggregations_basic():
     netcommon_coll = coll_by_name['ansible.netcommon']
     assert netcommon_coll['collection_source'] == 'certified'
     assert netcommon_coll['jobs_total'] == 2
+    assert netcommon_coll['number_of_jobs_never_started'] == 0
     assert netcommon_coll['hosts_total'] == 2
     assert netcommon_coll['job_duration_total_seconds'] == 1320.0
     assert netcommon_coll['job_waiting_time_total_seconds'] == 360.0
@@ -466,6 +493,7 @@ def test_events_modules_aggregations_basic():
     posix_coll = coll_by_name['ansible.posix']
     assert posix_coll['collection_source'] == 'certified'
     assert posix_coll['jobs_total'] == 2
+    assert posix_coll['number_of_jobs_never_started'] == 0
     assert posix_coll['hosts_total'] == 2
     assert posix_coll['job_duration_total_seconds'] == 1380.0
     assert posix_coll['job_waiting_time_total_seconds'] == 900.0
@@ -485,6 +513,7 @@ def test_events_modules_aggregations_basic():
     windows_coll = coll_by_name['ansible.windows']
     assert windows_coll['collection_source'] == 'certified'
     assert windows_coll['jobs_total'] == 3
+    assert windows_coll['number_of_jobs_never_started'] == 0
     assert windows_coll['hosts_total'] == 3
     assert windows_coll['job_duration_total_seconds'] == 2100.0
     assert windows_coll['job_waiting_time_total_seconds'] == 900.0
@@ -504,6 +533,7 @@ def test_events_modules_aggregations_basic():
     aws_coll = coll_by_name['community.aws']
     assert aws_coll['collection_source'] == 'community'
     assert aws_coll['jobs_total'] == 2
+    assert aws_coll['number_of_jobs_never_started'] == 0
     assert aws_coll['hosts_total'] == 4
     assert aws_coll['job_duration_total_seconds'] == 1380.0
     assert aws_coll['job_waiting_time_total_seconds'] == 900.0
@@ -522,18 +552,19 @@ def test_events_modules_aggregations_basic():
     # community.general
     general_coll = coll_by_name['community.general']
     assert general_coll['collection_source'] == 'community'
-    assert general_coll['jobs_total'] == 2
-    assert general_coll['hosts_total'] == 1
+    assert general_coll['jobs_total'] == 3
+    assert general_coll['number_of_jobs_never_started'] == 1
+    assert general_coll['hosts_total'] == 2
     assert general_coll['job_duration_total_seconds'] == 1500.0
     assert general_coll['job_waiting_time_total_seconds'] == 300.0
-    assert general_coll['avg_job_duration_seconds'] == 750.0
-    assert general_coll['avg_job_waiting_time_seconds'] == 150.0
+    assert general_coll['avg_job_duration_seconds'] == 500.0
+    assert general_coll['avg_job_waiting_time_seconds'] == 100.0
     assert general_coll['avg_hosts_per_job'] == 1.0
-    assert general_coll['jobs_containing_collection_name_failed_total'] == 2
-    assert general_coll['jobs_failed_because_of_collection_name_failure_total'] == 2
+    assert general_coll['jobs_containing_collection_name_failed_total'] == 3
+    assert general_coll['jobs_failed_because_of_collection_name_failure_total'] == 3
     assert general_coll['task_clean_success_total'] == 0
     assert general_coll['task_success_with_reruns_total'] == 0
-    assert general_coll['task_failed_total'] == 2
+    assert general_coll['task_failed_total'] == 3
     assert general_coll['task_failed_and_ignored_total'] == 0
     assert general_coll['task_skipped_total'] == 0
     assert general_coll['task_unreachable_total'] == 0
@@ -542,6 +573,7 @@ def test_events_modules_aggregations_basic():
     mongodb_coll = coll_by_name['community.mongodb']
     assert mongodb_coll['collection_source'] == 'community'
     assert mongodb_coll['jobs_total'] == 2
+    assert mongodb_coll['number_of_jobs_never_started'] == 0
     assert mongodb_coll['hosts_total'] == 2
     assert mongodb_coll['job_duration_total_seconds'] == 1500.0
     assert mongodb_coll['job_waiting_time_total_seconds'] == 300.0
@@ -561,6 +593,7 @@ def test_events_modules_aggregations_basic():
     custom_coll = coll_by_name['custom.user']
     assert custom_coll['collection_source'] == 'Unknown'
     assert custom_coll['jobs_total'] == 1
+    assert custom_coll['number_of_jobs_never_started'] == 0
     assert custom_coll['hosts_total'] == 1
     assert custom_coll['job_duration_total_seconds'] == 540.0
     assert custom_coll['job_waiting_time_total_seconds'] == 60.0

--- a/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import EventModulesAnonymizedRollup
 
@@ -338,7 +339,7 @@ def test_events_modules_aggregations_basic():
     assert result['modules_used_to_automate_total'] == 7
 
     # average number of modules per playbook based on current aggregation
-    assert result['avg_number_of_modules_used_in_a_playbooks'] == 3.0
+    assert result['avg_number_of_modules_used_in_a_playbooks'] == pytest.approx(3.0)
 
     # total modules used per playbook (current aggregation)
     assert result['modules_used_per_playbook_total'] == {
@@ -462,11 +463,11 @@ def test_events_modules_aggregations_basic():
     assert netcommon_coll['jobs_total'] == 2
     assert netcommon_coll['number_of_jobs_never_started'] == 0
     assert netcommon_coll['hosts_total'] == 2
-    assert netcommon_coll['job_duration_total_seconds'] == 1320.0
-    assert netcommon_coll['job_waiting_time_total_seconds'] == 360.0
-    assert netcommon_coll['avg_job_duration_seconds'] == 660.0
-    assert netcommon_coll['avg_job_waiting_time_seconds'] == 180.0
-    assert netcommon_coll['avg_hosts_per_job'] == 1.0
+    assert netcommon_coll['job_duration_total_seconds'] == pytest.approx(1320.0)
+    assert netcommon_coll['job_waiting_time_total_seconds'] == pytest.approx(360.0)
+    assert netcommon_coll['avg_job_duration_seconds'] == pytest.approx(660.0)
+    assert netcommon_coll['avg_job_waiting_time_seconds'] == pytest.approx(180.0)
+    assert netcommon_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert netcommon_coll['jobs_containing_collection_name_failed_total'] == 1
     assert netcommon_coll['jobs_failed_because_of_collection_name_failure_total'] == 0
     assert netcommon_coll['task_clean_success_total'] == 1
@@ -482,11 +483,11 @@ def test_events_modules_aggregations_basic():
     assert posix_coll['jobs_total'] == 2
     assert posix_coll['number_of_jobs_never_started'] == 0
     assert posix_coll['hosts_total'] == 2
-    assert posix_coll['job_duration_total_seconds'] == 1380.0
-    assert posix_coll['job_waiting_time_total_seconds'] == 900.0
-    assert posix_coll['avg_job_duration_seconds'] == 690.0
-    assert posix_coll['avg_job_waiting_time_seconds'] == 450.0
-    assert posix_coll['avg_hosts_per_job'] == 1.0
+    assert posix_coll['job_duration_total_seconds'] == pytest.approx(1380.0)
+    assert posix_coll['job_waiting_time_total_seconds'] == pytest.approx(900.0)
+    assert posix_coll['avg_job_duration_seconds'] == pytest.approx(690.0)
+    assert posix_coll['avg_job_waiting_time_seconds'] == pytest.approx(450.0)
+    assert posix_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert posix_coll['jobs_containing_collection_name_failed_total'] == 1
     assert posix_coll['jobs_failed_because_of_collection_name_failure_total'] == 1
     assert posix_coll['task_clean_success_total'] == 1
@@ -502,11 +503,11 @@ def test_events_modules_aggregations_basic():
     assert windows_coll['jobs_total'] == 3
     assert windows_coll['number_of_jobs_never_started'] == 0
     assert windows_coll['hosts_total'] == 3
-    assert windows_coll['job_duration_total_seconds'] == 2100.0
-    assert windows_coll['job_waiting_time_total_seconds'] == 900.0
-    assert windows_coll['avg_job_duration_seconds'] == 700.0
-    assert windows_coll['avg_job_waiting_time_seconds'] == 300.0
-    assert windows_coll['avg_hosts_per_job'] == 1.0
+    assert windows_coll['job_duration_total_seconds'] == pytest.approx(2100.0)
+    assert windows_coll['job_waiting_time_total_seconds'] == pytest.approx(900.0)
+    assert windows_coll['avg_job_duration_seconds'] == pytest.approx(700.0)
+    assert windows_coll['avg_job_waiting_time_seconds'] == pytest.approx(300.0)
+    assert windows_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert windows_coll['jobs_containing_collection_name_failed_total'] == 3
     assert windows_coll['jobs_failed_because_of_collection_name_failure_total'] == 0
     assert windows_coll['task_clean_success_total'] == 1
@@ -522,11 +523,11 @@ def test_events_modules_aggregations_basic():
     assert aws_coll['jobs_total'] == 2
     assert aws_coll['number_of_jobs_never_started'] == 0
     assert aws_coll['hosts_total'] == 4
-    assert aws_coll['job_duration_total_seconds'] == 1380.0
-    assert aws_coll['job_waiting_time_total_seconds'] == 900.0
-    assert aws_coll['avg_job_duration_seconds'] == 690.0
-    assert aws_coll['avg_job_waiting_time_seconds'] == 450.0
-    assert aws_coll['avg_hosts_per_job'] == 2.0
+    assert aws_coll['job_duration_total_seconds'] == pytest.approx(1380.0)
+    assert aws_coll['job_waiting_time_total_seconds'] == pytest.approx(900.0)
+    assert aws_coll['avg_job_duration_seconds'] == pytest.approx(690.0)
+    assert aws_coll['avg_job_waiting_time_seconds'] == pytest.approx(450.0)
+    assert aws_coll['avg_hosts_per_job'] == pytest.approx(2.0)
     assert aws_coll['jobs_containing_collection_name_failed_total'] == 1
     assert aws_coll['jobs_failed_because_of_collection_name_failure_total'] == 0
     assert aws_coll['task_clean_success_total'] == 2
@@ -542,11 +543,11 @@ def test_events_modules_aggregations_basic():
     assert general_coll['jobs_total'] == 3
     assert general_coll['number_of_jobs_never_started'] == 1
     assert general_coll['hosts_total'] == 2
-    assert general_coll['job_duration_total_seconds'] == 1500.0
-    assert general_coll['job_waiting_time_total_seconds'] == 300.0
-    assert general_coll['avg_job_duration_seconds'] == 500.0
-    assert general_coll['avg_job_waiting_time_seconds'] == 100.0
-    assert general_coll['avg_hosts_per_job'] == 1.0
+    assert general_coll['job_duration_total_seconds'] == pytest.approx(1500.0)
+    assert general_coll['job_waiting_time_total_seconds'] == pytest.approx(300.0)
+    assert general_coll['avg_job_duration_seconds'] == pytest.approx(500.0)
+    assert general_coll['avg_job_waiting_time_seconds'] == pytest.approx(100.0)
+    assert general_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert general_coll['jobs_containing_collection_name_failed_total'] == 3
     assert general_coll['jobs_failed_because_of_collection_name_failure_total'] == 3
     assert general_coll['task_clean_success_total'] == 0
@@ -562,11 +563,11 @@ def test_events_modules_aggregations_basic():
     assert mongodb_coll['jobs_total'] == 2
     assert mongodb_coll['number_of_jobs_never_started'] == 0
     assert mongodb_coll['hosts_total'] == 2
-    assert mongodb_coll['job_duration_total_seconds'] == 1500.0
-    assert mongodb_coll['job_waiting_time_total_seconds'] == 300.0
-    assert mongodb_coll['avg_job_duration_seconds'] == 750.0
-    assert mongodb_coll['avg_job_waiting_time_seconds'] == 150.0
-    assert mongodb_coll['avg_hosts_per_job'] == 1.0
+    assert mongodb_coll['job_duration_total_seconds'] == pytest.approx(1500.0)
+    assert mongodb_coll['job_waiting_time_total_seconds'] == pytest.approx(300.0)
+    assert mongodb_coll['avg_job_duration_seconds'] == pytest.approx(750.0)
+    assert mongodb_coll['avg_job_waiting_time_seconds'] == pytest.approx(150.0)
+    assert mongodb_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert mongodb_coll['jobs_containing_collection_name_failed_total'] == 2
     assert mongodb_coll['jobs_failed_because_of_collection_name_failure_total'] == 0
     assert mongodb_coll['task_clean_success_total'] == 1
@@ -582,11 +583,11 @@ def test_events_modules_aggregations_basic():
     assert custom_coll['jobs_total'] == 1
     assert custom_coll['number_of_jobs_never_started'] == 0
     assert custom_coll['hosts_total'] == 1
-    assert custom_coll['job_duration_total_seconds'] == 540.0
-    assert custom_coll['job_waiting_time_total_seconds'] == 60.0
-    assert custom_coll['avg_job_duration_seconds'] == 540.0
-    assert custom_coll['avg_job_waiting_time_seconds'] == 60.0
-    assert custom_coll['avg_hosts_per_job'] == 1.0
+    assert custom_coll['job_duration_total_seconds'] == pytest.approx(540.0)
+    assert custom_coll['job_waiting_time_total_seconds'] == pytest.approx(60.0)
+    assert custom_coll['avg_job_duration_seconds'] == pytest.approx(540.0)
+    assert custom_coll['avg_job_waiting_time_seconds'] == pytest.approx(60.0)
+    assert custom_coll['avg_hosts_per_job'] == pytest.approx(1.0)
     assert custom_coll['jobs_containing_collection_name_failed_total'] == 1
     assert custom_coll['jobs_failed_because_of_collection_name_failure_total'] == 0
     assert custom_coll['task_clean_success_total'] == 1

--- a/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
@@ -334,21 +334,8 @@ def test_events_modules_aggregations_basic():
 
     pprint.pprint(result)
 
-    # Assert list of modules used to automate
+    # Assert total modules used to automate
     assert result['modules_used_to_automate_total'] == 7
-
-    modules_list = result['list_of_modules_used_to_automate']
-    assert len(modules_list) == 7
-
-    assert result['list_of_modules_used_to_automate'] == [
-        {'module_name': 'ansible.netcommon.cli_config', 'collection_source': 'certified', 'collection_name': 'ansible.netcommon'},
-        {'module_name': 'ansible.posix.firewalld', 'collection_source': 'certified', 'collection_name': 'ansible.posix'},
-        {'module_name': 'ansible.windows.win_copy', 'collection_source': 'certified', 'collection_name': 'ansible.windows'},
-        {'module_name': 'community.aws.ec2', 'collection_source': 'community', 'collection_name': 'community.aws'},
-        {'module_name': 'community.general.yum', 'collection_source': 'community', 'collection_name': 'community.general'},
-        {'module_name': 'community.mongodb.insert', 'collection_source': 'community', 'collection_name': 'community.mongodb'},
-        {'module_name': 'custom.user.collection', 'collection_source': 'Unknown', 'collection_name': 'custom.user'},
-    ]
 
     # average number of modules per playbook based on current aggregation
     assert result['avg_number_of_modules_used_in_a_playbooks'] == 3.0

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -47,58 +47,55 @@ def test_from_gather_to_json(cleanup_glob):
 
     # ========== Validate the json_data that are containing what they should ==========
 
-    # Validate top-level structure
-    assert 'events_modules' in json_data, "Missing 'events_modules' in json_data"
-    assert 'execution_environments' in json_data, "Missing 'execution_environments' in json_data"
-    assert 'jobs' in json_data, "Missing 'jobs' in json_data"
+    # Validate top-level flattened structure
+    assert 'statistics' in json_data, "Missing 'statistics' in json_data"
+    assert 'module_stats' in json_data, "Missing 'module_stats' in json_data"
+    assert 'collection_name_stats' in json_data, "Missing 'collection_name_stats' in json_data"
+    assert 'modules_used_per_playbook' in json_data, "Missing 'modules_used_per_playbook' in json_data"
+    assert 'jobs_by_template' in json_data, "Missing 'jobs_by_template' in json_data"
     assert 'job_host_summary' in json_data, "Missing 'job_host_summary' in json_data"
 
-    # Validate events_modules structure
-    events_modules = json_data['events_modules']
-    assert isinstance(events_modules, dict), 'events_modules should be a dictionary'
-    assert 'modules_used_to_automate_total' in events_modules
-    assert 'avg_number_of_modules_used_in_a_playbooks' in events_modules
-    assert 'modules_used_per_playbook_total' in events_modules
-    assert 'module_stats' in events_modules
-    assert 'collection_name_stats' in events_modules
-    assert 'total_hosts_automated' in events_modules
+    # Validate statistics structure (contains all the scalar totals)
+    statistics = json_data['statistics']
+    assert isinstance(statistics, dict), 'statistics should be a dictionary'
+    assert 'modules_used_to_automate_total' in statistics
+    assert 'avg_number_of_modules_used_in_a_playbooks' in statistics
+    assert 'total_hosts_automated' in statistics
+    assert 'total_EE' in statistics
+    assert 'default_EE' in statistics
+    assert 'custom_EE' in statistics
+    assert 'jobs_total' in statistics
+    assert 'total_unique_hosts' in statistics
 
-    # Validate events_modules data types
-    assert isinstance(events_modules['modules_used_to_automate_total'], int)
-    assert isinstance(events_modules['avg_number_of_modules_used_in_a_playbooks'], (int, float))
-    assert isinstance(events_modules['modules_used_per_playbook_total'], dict)
-    assert isinstance(events_modules['module_stats'], list)
-    assert isinstance(events_modules['collection_name_stats'], list)
-    assert isinstance(events_modules['total_hosts_automated'], int)
+    # Validate statistics data types
+    assert isinstance(statistics['modules_used_to_automate_total'], int)
+    assert isinstance(statistics['avg_number_of_modules_used_in_a_playbooks'], (int, float))
+    assert isinstance(statistics['total_hosts_automated'], int)
+    assert isinstance(statistics['total_EE'], int)
+    assert isinstance(statistics['default_EE'], int)
+    assert isinstance(statistics['custom_EE'], int)
+    assert isinstance(statistics['jobs_total'], int)
+    assert isinstance(statistics['total_unique_hosts'], int)
+
+    # Validate arrays structure
+    assert isinstance(json_data['modules_used_per_playbook'], list), 'modules_used_per_playbook should be a list'
+    assert isinstance(json_data['module_stats'], list), 'module_stats should be a list'
+    assert isinstance(json_data['collection_name_stats'], list), 'collection_name_stats should be a list'
+    assert isinstance(json_data['jobs_by_template'], list), 'jobs_by_template should be a list'
+    assert isinstance(json_data['job_host_summary'], list), 'job_host_summary should be a list'
 
     # Validate module_stats have required fields
-    if events_modules['module_stats']:
-        for module_stat in events_modules['module_stats']:
+    if json_data['module_stats']:
+        for module_stat in json_data['module_stats']:
             assert 'module_name' in module_stat
             assert 'collection_source' in module_stat
             assert 'collection_name' in module_stat
             assert 'jobs_total' in module_stat
             assert 'hosts_total' in module_stat
 
-    # Validate execution_environments structure
-    execution_envs = json_data['execution_environments']
-    assert isinstance(execution_envs, dict), 'execution_environments should be a dictionary'
-    assert 'total_EE' in execution_envs
-    assert 'default_EE' in execution_envs
-    assert 'custom_EE' in execution_envs
-    assert isinstance(execution_envs['total_EE'], int)
-    assert isinstance(execution_envs['default_EE'], int)
-    assert isinstance(execution_envs['custom_EE'], int)
-
-    # Validate jobs structure
-    jobs = json_data['jobs']
-    assert isinstance(jobs, dict), 'jobs should be a dictionary'
-    assert 'by_template' in jobs, 'jobs should have by_template key'
-    assert 'jobs_total' in jobs, 'jobs should have jobs_total key'
-    assert isinstance(jobs['by_template'], list), 'by_template should be a list'
-    assert isinstance(jobs['jobs_total'], int), 'jobs_total should be an integer'
-    if jobs['by_template']:
-        for job in jobs['by_template']:
+    # Validate jobs_by_template have required fields
+    if json_data['jobs_by_template']:
+        for job in json_data['jobs_by_template']:
             assert 'job_template_name' in job
             assert 'number_of_jobs_executed' in job
             assert 'number_of_jobs_failed' in job
@@ -107,16 +104,16 @@ def test_from_gather_to_json(cleanup_glob):
 
     # ========== Validate actual data values and relationships ==========
 
-    # Validate events_modules actual values
-    print('\n--- Validating events_modules data values ---')
-    assert events_modules['modules_used_to_automate_total'] == 1, 'Should have 1 module'
-    assert events_modules['total_hosts_automated'] == 2, 'Should have 2 hosts automated'
-    assert len(events_modules['module_stats']) == 1, 'Should have 1 module stats'
-    assert len(events_modules['collection_name_stats']) == 1, 'Should have 1 collection stats'
+    # Validate statistics actual values
+    print('\n--- Validating statistics data values ---')
+    assert statistics['modules_used_to_automate_total'] == 1, 'Should have 1 module'
+    assert statistics['total_hosts_automated'] == 2, 'Should have 2 hosts automated'
+    assert len(json_data['module_stats']) == 1, 'Should have 1 module stats'
+    assert len(json_data['collection_name_stats']) == 1, 'Should have 1 collection stats'
 
     # Validate module_stats actual values
     print('--- Validating module_stats data values ---')
-    first_module_stats = events_modules['module_stats'][0]
+    first_module_stats = json_data['module_stats'][0]
     assert first_module_stats['module_name'] == 'a10.acos_axapi.a10_slb_virtual_server', 'Module stats should match module'
     assert first_module_stats['jobs_total'] == 3, 'Should have 3 jobs using this module'
     assert first_module_stats['hosts_total'] == 2, 'Should have 2 hosts for this module'
@@ -127,40 +124,42 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Validate collection_name_stats
     print('--- Validating collection_name_stats data values ---')
-    first_collection_stats = events_modules['collection_name_stats'][0]
+    first_collection_stats = json_data['collection_name_stats'][0]
     assert first_collection_stats['collection_name'] == 'a10.acos_axapi', 'Collection name should match'
     assert first_collection_stats['collection_source'] == 'community', 'Collection should be from community'
     assert first_collection_stats['jobs_total'] == 3, 'Collection should have 3 jobs'
     assert first_collection_stats['hosts_total'] == 2, 'Collection should have 2 hosts'
     assert first_collection_stats['task_clean_success_total'] == 6, 'Collection should have 6 successful tasks'
 
-    # Validate modules_used_per_playbook_total structure and values
-    print('--- Validating modules_used_per_playbook_total ---')
-    assert len(events_modules['modules_used_per_playbook_total']) == 1, 'Should have 1 playbook'
-    playbook_module_count = list(events_modules['modules_used_per_playbook_total'].values())[0]
-    assert playbook_module_count == 1, 'Playbook should use 1 module'
+    # Validate modules_used_per_playbook structure and values (now an array, not dict)
+    print('--- Validating modules_used_per_playbook ---')
+    assert len(json_data['modules_used_per_playbook']) == 1, 'Should have 1 playbook'
+    playbook_entry = json_data['modules_used_per_playbook'][0]
+    assert 'playbook_id' in playbook_entry, 'Playbook entry should have playbook_id'
+    assert 'modules_used' in playbook_entry, 'Playbook entry should have modules_used'
+    assert playbook_entry['modules_used'] == 1, 'Playbook should use 1 module'
 
     # Validate avg_number_of_modules_used_in_a_playbooks calculation
-    total_modules_across_playbooks = sum(events_modules['modules_used_per_playbook_total'].values())
-    num_playbooks = len(events_modules['modules_used_per_playbook_total'])
+    total_modules_across_playbooks = sum(p['modules_used'] for p in json_data['modules_used_per_playbook'])
+    num_playbooks = len(json_data['modules_used_per_playbook'])
     expected_avg = total_modules_across_playbooks / num_playbooks if num_playbooks > 0 else 0
-    assert events_modules['avg_number_of_modules_used_in_a_playbooks'] == pytest.approx(expected_avg, rel=1e-6), (
-        f'Average should be {expected_avg}, got {events_modules["avg_number_of_modules_used_in_a_playbooks"]}'
+    assert statistics['avg_number_of_modules_used_in_a_playbooks'] == pytest.approx(expected_avg, rel=1e-6), (
+        f'Average should be {expected_avg}, got {statistics["avg_number_of_modules_used_in_a_playbooks"]}'
     )
 
     # Validate execution_environments actual values
     print('--- Validating execution_environments data values ---')
-    assert execution_envs['total_EE'] == 2, 'Should have 2 total execution environments'
-    assert execution_envs['default_EE'] == 1, 'Should have 1 default execution environment'
-    assert execution_envs['custom_EE'] == 1, 'Should have 1 custom execution environment'
+    assert statistics['total_EE'] == 2, 'Should have 2 total execution environments'
+    assert statistics['default_EE'] == 1, 'Should have 1 default execution environment'
+    assert statistics['custom_EE'] == 1, 'Should have 1 custom execution environment'
     # Validate that total = default + custom
-    assert execution_envs['total_EE'] == execution_envs['default_EE'] + execution_envs['custom_EE'], 'Total EE should equal default + custom'
+    assert statistics['total_EE'] == statistics['default_EE'] + statistics['custom_EE'], 'Total EE should equal default + custom'
 
     # Validate jobs actual values
     print('--- Validating jobs data values ---')
-    assert jobs['jobs_total'] == 3, 'Should have 3 total jobs'
-    assert len(jobs['by_template']) == 1, 'Should have 1 job template'
-    job = jobs['by_template'][0]
+    assert statistics['jobs_total'] == 3, 'Should have 3 total jobs'
+    assert len(json_data['jobs_by_template']) == 1, 'Should have 1 job template'
+    job = json_data['jobs_by_template'][0]
     assert job['number_of_jobs_executed'] == 3, 'Job template should have 3 executions'
     assert job['number_of_jobs_failed'] == 0, 'Should have 0 failed jobs'
     assert job['number_of_jobs_succeeded'] == 3, 'Should have 3 succeeded jobs'
@@ -177,18 +176,14 @@ def test_from_gather_to_json(cleanup_glob):
     assert job['job_waiting_time_average_in_seconds'] >= 0, 'Job waiting time average should be non-negative'
     assert job['job_waiting_time_total_in_seconds'] >= 0, 'Job waiting time total should be non-negative'
 
-    # Validate job_host_summary structure
+    # Validate job_host_summary structure (now a direct array, not nested)
     print('--- Validating job_host_summary data values ---')
     job_host_summary = json_data['job_host_summary']
-    assert isinstance(job_host_summary, dict), 'job_host_summary should be a dict'
-    assert 'aggregated' in job_host_summary, 'job_host_summary should have aggregated key'
-    assert 'total_unique_hosts' in job_host_summary, 'job_host_summary should have total_unique_hosts key'
+    assert isinstance(job_host_summary, list), 'job_host_summary should be a list'
+    assert len(job_host_summary) == 1, 'Should have 1 job_host_summary entry'
+    assert statistics['total_unique_hosts'] == 2, 'Should have 2 unique hosts'
 
-    assert isinstance(job_host_summary['aggregated'], list), 'aggregated should be a list'
-    assert len(job_host_summary['aggregated']) == 1, 'Should have 1 job_host_summary entry'
-    assert job_host_summary['total_unique_hosts'] == 2, 'Should have 2 unique hosts'
-
-    jhs = job_host_summary['aggregated'][0]
+    jhs = job_host_summary[0]
     assert 'job_template_name' in jhs
     assert 'dark_total' in jhs
     assert 'failures_total' in jhs
@@ -206,8 +201,8 @@ def test_from_gather_to_json(cleanup_glob):
     # Validate cross-section data consistency
     print('--- Validating cross-section data consistency ---')
     # Validate that module stats hosts match the total automated hosts
-    for module_stat in events_modules['module_stats']:
-        assert module_stat['hosts_total'] <= events_modules['total_hosts_automated'], (
+    for module_stat in json_data['module_stats']:
+        assert module_stat['hosts_total'] <= statistics['total_hosts_automated'], (
             f'Module {module_stat["module_name"][:50]} hosts should not exceed total automated hosts'
         )
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -242,14 +242,3 @@ def test_from_gather_to_json(cleanup_glob):
         )
 
     print('✅ All data value assertions passed!')
-
-    # Verify data directory exists and contains raw data tarballs
-    data_path = './out/data/2025/06/13'
-    assert os.path.exists(data_path), f'Data directory should exist at {data_path}'
-
-    # Check that raw data tarballs were created
-    data_tarballs = [f for f in os.listdir(data_path) if f.endswith('.tar.gz')]
-    assert len(data_tarballs) > 0, 'Should have raw data tarballs in data directory'
-    print(f'Found {len(data_tarballs)} raw data tarballs')
-
-    print('\n✅ All assertions passed!')

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -110,16 +110,6 @@ def test_from_gather_to_json(cleanup_glob):
             assert 'job_duration_average_in_seconds' in job
             assert 'job_waiting_time_average_in_seconds' in job
 
-    # Validate job_host_summary structure
-    job_host_summary = json_data['job_host_summary']
-    assert isinstance(job_host_summary, list), 'job_host_summary should be a list'
-    if job_host_summary:
-        for jhs in job_host_summary:
-            assert 'job_template_name' in jhs
-            assert 'jobs_total' in jhs
-            assert 'hosts_total' in jhs
-            assert 'ok_total' in jhs
-
     # Validate anonymization occurred (check for hashed values)
     # Job template names should be hashed (64 character hex strings)
     if jobs:
@@ -206,23 +196,29 @@ def test_from_gather_to_json(cleanup_glob):
     assert job['job_waiting_time_average_in_seconds'] >= 0, 'Job waiting time average should be non-negative'
     assert job['job_waiting_time_total_in_seconds'] >= 0, 'Job waiting time total should be non-negative'
 
-    # Validate job_host_summary actual values
+    # Validate job_host_summary structure
     print('--- Validating job_host_summary data values ---')
-    assert len(job_host_summary) == 1, 'Should have 1 job template in summary'
+    job_host_summary = json_data['job_host_summary']
+    assert isinstance(job_host_summary, list), 'job_host_summary should be a list'
+    assert len(job_host_summary) == 1, 'Should have 1 job_host_summary entry'
+
     jhs = job_host_summary[0]
-    assert jhs['jobs_total'] == 3, 'Should have 3 jobs in summary'
-    assert jhs['hosts_total'] == 2, 'Should have 2 hosts in summary'
-    assert jhs['ok_total'] == 6, 'Should have 6 ok tasks (3 jobs × 2 hosts)'
-    assert jhs['dark_total'] == 0, 'Should have 0 dark (unreachable) hosts'
+    assert 'job_template_name' in jhs
+    assert 'dark_total' in jhs
+    assert 'failures_total' in jhs
+    assert 'ok_total' in jhs
+    assert 'skipped_total' in jhs
+    assert 'ignored_total' in jhs
+    assert 'rescued_total' in jhs
+
+    # Validate job_host_summary actual values
+    assert jhs['ok_total'] == 6, 'Should have 6 ok tasks'
     assert jhs['failures_total'] == 0, 'Should have 0 failures'
+    assert jhs['dark_total'] == 0, 'Should have 0 dark (unreachable) hosts'
     assert jhs['skipped_total'] == 0, 'Should have 0 skipped tasks'
-    assert jhs['ignored_total'] == 0, 'Should have 0 ignored failures'
-    assert jhs['rescued_total'] == 0, 'Should have 0 rescued tasks'
 
     # Validate cross-section data consistency
     print('--- Validating cross-section data consistency ---')
-    assert events_modules['total_hosts_automated'] == jhs['hosts_total'], 'Total hosts automated should match hosts in job_host_summary'
-
     # Validate that module stats hosts match the total automated hosts
     for module_stat in events_modules['module_stats']:
         assert module_stat['hosts_total'] <= events_modules['total_hosts_automated'], (

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -132,23 +132,17 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Validate events_modules actual values
     print('\n--- Validating events_modules data values ---')
-    assert events_modules['modules_used_to_automate_total'] == 2, 'Should have 2 modules'
+    assert events_modules['modules_used_to_automate_total'] == 1, 'Should have 1 module'
     assert events_modules['total_hosts_automated'] == 2, 'Should have 2 hosts automated'
-    assert len(events_modules['list_of_modules_used_to_automate']) == 2, 'Should have 2 modules in list'
-    assert len(events_modules['module_stats']) == 2, 'Should have 2 module stats'
-    assert len(events_modules['collection_name_stats']) == 2, 'Should have 2 collection stats'
+    assert len(events_modules['list_of_modules_used_to_automate']) == 1, 'Should have 1 module in list'
+    assert len(events_modules['module_stats']) == 1, 'Should have 1 module stats'
+    assert len(events_modules['collection_name_stats']) == 1, 'Should have 1 collection stats'
 
     # Validate first module is the unencrypted community module
     first_module = events_modules['list_of_modules_used_to_automate'][0]
     assert first_module['module_name'] == 'a10.acos_axapi.a10_slb_virtual_server', 'First module should be a10_slb_virtual_server'
     assert first_module['collection_source'] == 'community', 'First module should be from community'
     assert first_module['collection_name'] == 'a10.acos_axapi', 'First module should be from a10.acos_axapi collection'
-
-    # Validate second module is hashed (encrypted)
-    second_module = events_modules['list_of_modules_used_to_automate'][1]
-    assert len(second_module['module_name']) == 128, 'Second module name should be hashed (128 chars)'
-    assert second_module['collection_source'] == 'Unknown', 'Second module should have Unknown source'
-    assert len(second_module['collection_name']) == 128, 'Second module collection should be hashed (128 chars)'
 
     # Validate module_stats actual values
     print('--- Validating module_stats data values ---')
@@ -160,12 +154,6 @@ def test_from_gather_to_json(cleanup_glob):
     assert first_module_stats['task_success_with_reruns_total'] == 0, 'Should have 0 reruns'
     assert first_module_stats['task_failed_total'] == 0, 'Should have 0 failures'
     assert first_module_stats['avg_hosts_per_job'] == pytest.approx(2.0, rel=1e-6), 'Should average 2 hosts per job'
-
-    # Validate second module stats
-    second_module_stats = events_modules['module_stats'][1]
-    assert second_module_stats['jobs_total'] == 3, 'Second module should also have 3 jobs'
-    assert second_module_stats['hosts_total'] == 2, 'Second module should have 2 hosts'
-    assert second_module_stats['task_clean_success_total'] == 0, 'Second module should have 0 clean successes'
 
     # Validate collection_name_stats
     print('--- Validating collection_name_stats data values ---')
@@ -180,7 +168,7 @@ def test_from_gather_to_json(cleanup_glob):
     print('--- Validating modules_used_per_playbook_total ---')
     assert len(events_modules['modules_used_per_playbook_total']) == 1, 'Should have 1 playbook'
     playbook_module_count = list(events_modules['modules_used_per_playbook_total'].values())[0]
-    assert playbook_module_count == 2, 'Playbook should use 2 modules'
+    assert playbook_module_count == 1, 'Playbook should use 1 module'
 
     # Validate avg_number_of_modules_used_in_a_playbooks calculation
     total_modules_across_playbooks = sum(events_modules['modules_used_per_playbook_total'].values())

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -115,7 +115,7 @@ def test_from_gather_to_json(cleanup_glob):
     if jobs:
         for job in jobs:
             job_template_name = job['job_template_name']
-            assert len(job_template_name) == 128, f'Job template name should be hashed (128 chars): {job_template_name}'
+            assert len(job_template_name) == 64, f'Job template name should be hashed (64 chars): {job_template_name}'
             assert all(c in '0123456789abcdef' for c in job_template_name), 'Job template name should be hex string'
 
     # ========== Validate actual data values and relationships ==========

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -92,22 +92,18 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Validate jobs structure
     jobs = json_data['jobs']
-    assert isinstance(jobs, list), 'jobs should be a list'
-    if jobs:
-        for job in jobs:
+    assert isinstance(jobs, dict), 'jobs should be a dictionary'
+    assert 'by_template' in jobs, 'jobs should have by_template key'
+    assert 'jobs_total' in jobs, 'jobs should have jobs_total key'
+    assert isinstance(jobs['by_template'], list), 'by_template should be a list'
+    assert isinstance(jobs['jobs_total'], int), 'jobs_total should be an integer'
+    if jobs['by_template']:
+        for job in jobs['by_template']:
             assert 'job_template_name' in job
             assert 'number_of_jobs_executed' in job
             assert 'number_of_jobs_failed' in job
             assert 'job_duration_average_in_seconds' in job
             assert 'job_waiting_time_average_in_seconds' in job
-
-    # Validate anonymization occurred (check for hashed values)
-    # Job template names should be hashed (64 character hex strings)
-    if jobs:
-        for job in jobs:
-            job_template_name = job['job_template_name']
-            assert len(job_template_name) == 64, f'Job template name should be hashed (64 chars): {job_template_name}'
-            assert all(c in '0123456789abcdef' for c in job_template_name), 'Job template name should be hex string'
 
     # ========== Validate actual data values and relationships ==========
 
@@ -162,8 +158,9 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Validate jobs actual values
     print('--- Validating jobs data values ---')
-    assert len(jobs) == 1, 'Should have 1 job template'
-    job = jobs[0]
+    assert jobs['jobs_total'] == 3, 'Should have 3 total jobs'
+    assert len(jobs['by_template']) == 1, 'Should have 1 job template'
+    job = jobs['by_template'][0]
     assert job['number_of_jobs_executed'] == 3, 'Job template should have 3 executions'
     assert job['number_of_jobs_failed'] == 0, 'Should have 0 failed jobs'
     assert job['number_of_jobs_succeeded'] == 3, 'Should have 3 succeeded jobs'

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -199,10 +199,15 @@ def test_from_gather_to_json(cleanup_glob):
     # Validate job_host_summary structure
     print('--- Validating job_host_summary data values ---')
     job_host_summary = json_data['job_host_summary']
-    assert isinstance(job_host_summary, list), 'job_host_summary should be a list'
-    assert len(job_host_summary) == 1, 'Should have 1 job_host_summary entry'
+    assert isinstance(job_host_summary, dict), 'job_host_summary should be a dict'
+    assert 'aggregated' in job_host_summary, 'job_host_summary should have aggregated key'
+    assert 'total_unique_hosts' in job_host_summary, 'job_host_summary should have total_unique_hosts key'
 
-    jhs = job_host_summary[0]
+    assert isinstance(job_host_summary['aggregated'], list), 'aggregated should be a list'
+    assert len(job_host_summary['aggregated']) == 1, 'Should have 1 job_host_summary entry'
+    assert job_host_summary['total_unique_hosts'] == 2, 'Should have 2 unique hosts'
+
+    jhs = job_host_summary['aggregated'][0]
     assert 'job_template_name' in jhs
     assert 'dark_total' in jhs
     assert 'failures_total' in jhs

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -56,7 +56,6 @@ def test_from_gather_to_json(cleanup_glob):
     # Validate events_modules structure
     events_modules = json_data['events_modules']
     assert isinstance(events_modules, dict), 'events_modules should be a dictionary'
-    assert 'list_of_modules_used_to_automate' in events_modules
     assert 'modules_used_to_automate_total' in events_modules
     assert 'avg_number_of_modules_used_in_a_playbooks' in events_modules
     assert 'modules_used_per_playbook_total' in events_modules
@@ -65,20 +64,12 @@ def test_from_gather_to_json(cleanup_glob):
     assert 'total_hosts_automated' in events_modules
 
     # Validate events_modules data types
-    assert isinstance(events_modules['list_of_modules_used_to_automate'], list)
     assert isinstance(events_modules['modules_used_to_automate_total'], int)
     assert isinstance(events_modules['avg_number_of_modules_used_in_a_playbooks'], (int, float))
     assert isinstance(events_modules['modules_used_per_playbook_total'], dict)
     assert isinstance(events_modules['module_stats'], list)
     assert isinstance(events_modules['collection_name_stats'], list)
     assert isinstance(events_modules['total_hosts_automated'], int)
-
-    # Validate modules have required fields
-    if events_modules['list_of_modules_used_to_automate']:
-        for module in events_modules['list_of_modules_used_to_automate']:
-            assert 'module_name' in module
-            assert 'collection_source' in module
-            assert 'collection_name' in module
 
     # Validate module_stats have required fields
     if events_modules['module_stats']:
@@ -124,15 +115,8 @@ def test_from_gather_to_json(cleanup_glob):
     print('\n--- Validating events_modules data values ---')
     assert events_modules['modules_used_to_automate_total'] == 1, 'Should have 1 module'
     assert events_modules['total_hosts_automated'] == 2, 'Should have 2 hosts automated'
-    assert len(events_modules['list_of_modules_used_to_automate']) == 1, 'Should have 1 module in list'
     assert len(events_modules['module_stats']) == 1, 'Should have 1 module stats'
     assert len(events_modules['collection_name_stats']) == 1, 'Should have 1 collection stats'
-
-    # Validate first module is the unencrypted community module
-    first_module = events_modules['list_of_modules_used_to_automate'][0]
-    assert first_module['module_name'] == 'a10.acos_axapi.a10_slb_virtual_server', 'First module should be a10_slb_virtual_server'
-    assert first_module['collection_source'] == 'community', 'First module should be from community'
-    assert first_module['collection_name'] == 'a10.acos_axapi', 'First module should be from a10.acos_axapi collection'
 
     # Validate module_stats actual values
     print('--- Validating module_stats data values ---')

--- a/metrics_utility/test/test_anonymized_rollups/test_jobhostsummary_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobhostsummary_anonymized_rollups.py
@@ -205,9 +205,13 @@ def test_jobhostsummary_anonymized():
 
     print(result)
 
-    # result should be a list of dicts, one per template
+    # result should be a dict with 'aggregated' (list) and 'total_unique_hosts' (int)
+    assert 'aggregated' in result, 'result should have aggregated key'
+    assert 'total_unique_hosts' in result, 'result should have total_unique_hosts key'
+    assert result['total_unique_hosts'] == 5, 'Should have 5 unique hosts (h1, h2, h3, h4, h5)'
+
     # convert to mapping for easy assertions
-    by_template = {item['job_template_name']: item for item in result}
+    by_template = {item['job_template_name']: item for item in result['aggregated']}
 
     assert set(by_template.keys()) == {'T1', 'T2'}
 

--- a/metrics_utility/test/test_anonymized_rollups/test_jobhostsummary_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobhostsummary_anonymized_rollups.py
@@ -7,7 +7,17 @@ jobhostsummary = [
     # job_template T1, job_id 1001, 3 tasks per job, 5 hosts
     # number of tasks = 3
     # total tasks = 3 * 5 = 15
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h1', 'job_id': 1001, 'job_template_name': 'T1'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h1',
+        'job_remote_id': 1001,
+        'job_template_name': 'T1',
+    },
     {
         'dark': 0,
         'failures': 1,
@@ -19,7 +29,17 @@ jobhostsummary = [
         'job_remote_id': 1001,
         'job_template_name': 'T1',
     },  # 1 failure
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h3', 'job_id': 1001, 'job_template_name': 'T1'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h3',
+        'job_remote_id': 1001,
+        'job_template_name': 'T1',
+    },
     {
         'dark': 0,
         'failures': 0,
@@ -31,11 +51,31 @@ jobhostsummary = [
         'job_remote_id': 1001,
         'job_template_name': 'T1',
     },  # 1 skipped
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h5', 'job_id': 1001, 'job_template_name': 'T1'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h5',
+        'job_remote_id': 1001,
+        'job_template_name': 'T1',
+    },
     # job_template T1, job_id 1002, one host skips a task, another fails
     # number of tasks = 3
     # total tasks = 3 * 5 = 15
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h1', 'job_id': 1002, 'job_template_name': 'T1'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h1',
+        'job_remote_id': 1002,
+        'job_template_name': 'T1',
+    },
     {
         'dark': 0,
         'failures': 1,
@@ -58,12 +98,42 @@ jobhostsummary = [
         'job_remote_id': 1002,
         'job_template_name': 'T1',
     },  # 1 skipped
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h4', 'job_id': 1002, 'job_template_name': 'T1'},
-    {'dark': 0, 'failures': 0, 'ok': 3, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h5', 'job_id': 1002, 'job_template_name': 'T1'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h4',
+        'job_remote_id': 1002,
+        'job_template_name': 'T1',
+    },
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 3,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h5',
+        'job_remote_id': 1002,
+        'job_template_name': 'T1',
+    },
     # job_template T2, job_id 2001, 5 tasks per job, 3 hosts
     # number of tasks = 5
     # total tasks = 5 * 3 = 15
-    {'dark': 0, 'failures': 0, 'ok': 5, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h1', 'job_id': 2001, 'job_template_name': 'T2'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 5,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h1',
+        'job_remote_id': 2001,
+        'job_template_name': 'T2',
+    },
     {
         'dark': 0,
         'failures': 1,
@@ -75,11 +145,31 @@ jobhostsummary = [
         'job_remote_id': 2001,
         'job_template_name': 'T2',
     },  # 1 failure
-    {'dark': 0, 'failures': 0, 'ok': 5, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h3', 'job_id': 2001, 'job_template_name': 'T2'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 5,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h3',
+        'job_remote_id': 2001,
+        'job_template_name': 'T2',
+    },
     # job_template T2, job_id 2002, one host executes only 4 tasks, another fails
     # number of tasks = 5
     # total tasks = 5 * 3 = 15
-    {'dark': 0, 'failures': 0, 'ok': 5, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h1', 'job_id': 2002, 'job_template_name': 'T2'},
+    {
+        'dark': 0,
+        'failures': 0,
+        'ok': 5,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h1',
+        'job_remote_id': 2002,
+        'job_template_name': 'T2',
+    },
     {
         'dark': 0,
         'failures': 2,
@@ -91,7 +181,17 @@ jobhostsummary = [
         'job_remote_id': 2002,
         'job_template_name': 'T2',
     },  # 2 failures
-    {'dark': 0, 'failures': 1, 'ok': 4, 'skipped': 0, 'ignored': 0, 'rescued': 0, 'host_name': 'h3', 'job_id': 2002, 'job_template_name': 'T2'},
+    {
+        'dark': 0,
+        'failures': 1,
+        'ok': 4,
+        'skipped': 0,
+        'ignored': 0,
+        'rescued': 0,
+        'host_name': 'h3',
+        'job_remote_id': 2002,
+        'job_template_name': 'T2',
+    },
 ]
 
 
@@ -110,9 +210,6 @@ def test_jobhostsummary_anonymized():
     by_template = {item['job_template_name']: item for item in result}
 
     assert set(by_template.keys()) == {'T1', 'T2'}
-
-    assert by_template['T1']['jobs_total'] == 2
-    assert by_template['T2']['jobs_total'] == 2
 
     assert by_template['T1']['dark_total'] == 0
     assert by_template['T2']['dark_total'] == 0

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -96,16 +96,22 @@ def test_jobs_anonymized_rollups_base_aggregation():
 
     pprint.pprint(result)
 
-    # New version returns list of per-template aggregates in 'json' field
-    assert isinstance(result, list)
+    # Result is a dict with 'by_template' list and 'jobs_total'
+    assert isinstance(result, dict)
+    assert 'by_template' in result
+    assert 'jobs_total' in result
+
+    # Extract the by_template list
+    by_template = result['by_template']
+    assert isinstance(by_template, list)
 
     # There should be 3 templates (T1, T2, and T3 with never-started jobs)
-    assert len(result) == 3
+    assert len(by_template) == 3
 
     # Identify records by job_template_name
-    rec_t1 = next(r for r in result if r['job_template_name'] == 'T1')
-    rec_t2 = next(r for r in result if r['job_template_name'] == 'T2')
-    rec_t3 = next(r for r in result if r['job_template_name'] == 'T3')
+    rec_t1 = next(r for r in by_template if r['job_template_name'] == 'T1')
+    rec_t2 = next(r for r in by_template if r['job_template_name'] == 'T2')
+    rec_t3 = next(r for r in by_template if r['job_template_name'] == 'T3')
 
     # T1 counts
     assert rec_t1['number_of_jobs_executed'] == 3

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -120,18 +120,18 @@ def test_jobs_anonymized_rollups_base_aggregation():
     assert rec_t1['number_of_jobs_never_started'] == 0
 
     # T1 durations (seconds): 3.0, 5.0, 2.0
-    assert pytest.approx(rec_t1['job_duration_average_in_seconds'], rel=1e-6) == 10 / 3
-    assert pytest.approx(rec_t1['job_duration_maximum_in_seconds'], rel=1e-6) == 5.0
-    assert pytest.approx(rec_t1['job_duration_minimum_in_seconds'], rel=1e-6) == 2.0
-    assert pytest.approx(rec_t1['job_duration_median_in_seconds'], rel=1e-6) == 3.0
-    assert pytest.approx(rec_t1['job_duration_total_in_seconds'], rel=1e-6) == 10.0
+    assert rec_t1['job_duration_average_in_seconds'] == pytest.approx(10 / 3, rel=1e-6)
+    assert rec_t1['job_duration_maximum_in_seconds'] == pytest.approx(5.0, rel=1e-6)
+    assert rec_t1['job_duration_minimum_in_seconds'] == pytest.approx(2.0, rel=1e-6)
+    assert rec_t1['job_duration_median_in_seconds'] == pytest.approx(3.0, rel=1e-6)
+    assert rec_t1['job_duration_total_in_seconds'] == pytest.approx(10.0, rel=1e-6)
 
     # T1 waiting times (seconds): 0.0, 2.0, 1.0
-    assert pytest.approx(rec_t1['job_waiting_time_average_in_seconds'], rel=1e-6) == 1.0
-    assert pytest.approx(rec_t1['job_waiting_time_maximum_in_seconds'], rel=1e-6) == 2.0
-    assert pytest.approx(rec_t1['job_waiting_time_minimum_in_seconds'], rel=1e-6) == 0.0
-    assert pytest.approx(rec_t1['job_waiting_time_median_in_seconds'], rel=1e-6) == 1.0
-    assert pytest.approx(rec_t1['job_waiting_time_total_in_seconds'], rel=1e-6) == 3.0
+    assert rec_t1['job_waiting_time_average_in_seconds'] == pytest.approx(1.0, rel=1e-6)
+    assert rec_t1['job_waiting_time_maximum_in_seconds'] == pytest.approx(2.0, rel=1e-6)
+    assert rec_t1['job_waiting_time_minimum_in_seconds'] == pytest.approx(0.0, rel=1e-6)
+    assert rec_t1['job_waiting_time_median_in_seconds'] == pytest.approx(1.0, rel=1e-6)
+    assert rec_t1['job_waiting_time_total_in_seconds'] == pytest.approx(3.0, rel=1e-6)
 
     # T2 counts
     assert rec_t2['number_of_jobs_executed'] == 1
@@ -140,18 +140,18 @@ def test_jobs_anonymized_rollups_base_aggregation():
     assert rec_t2['number_of_jobs_never_started'] == 0
 
     # T2 duration (seconds): 7.0
-    assert pytest.approx(rec_t2['job_duration_average_in_seconds'], rel=1e-6) == 7.0
-    assert pytest.approx(rec_t2['job_duration_maximum_in_seconds'], rel=1e-6) == 7.0
-    assert pytest.approx(rec_t2['job_duration_minimum_in_seconds'], rel=1e-6) == 7.0
-    assert pytest.approx(rec_t2['job_duration_median_in_seconds'], rel=1e-6) == 7.0
-    assert pytest.approx(rec_t2['job_duration_total_in_seconds'], rel=1e-6) == 7.0
+    assert rec_t2['job_duration_average_in_seconds'] == pytest.approx(7.0, rel=1e-6)
+    assert rec_t2['job_duration_maximum_in_seconds'] == pytest.approx(7.0, rel=1e-6)
+    assert rec_t2['job_duration_minimum_in_seconds'] == pytest.approx(7.0, rel=1e-6)
+    assert rec_t2['job_duration_median_in_seconds'] == pytest.approx(7.0, rel=1e-6)
+    assert rec_t2['job_duration_total_in_seconds'] == pytest.approx(7.0, rel=1e-6)
 
     # T2 waiting (seconds): 4.0
-    assert pytest.approx(rec_t2['job_waiting_time_average_in_seconds'], rel=1e-6) == 4.0
-    assert pytest.approx(rec_t2['job_waiting_time_maximum_in_seconds'], rel=1e-6) == 4.0
-    assert pytest.approx(rec_t2['job_waiting_time_minimum_in_seconds'], rel=1e-6) == 4.0
-    assert pytest.approx(rec_t2['job_waiting_time_median_in_seconds'], rel=1e-6) == 4.0
-    assert pytest.approx(rec_t2['job_waiting_time_total_in_seconds'], rel=1e-6) == 4.0
+    assert rec_t2['job_waiting_time_average_in_seconds'] == pytest.approx(4.0, rel=1e-6)
+    assert rec_t2['job_waiting_time_maximum_in_seconds'] == pytest.approx(4.0, rel=1e-6)
+    assert rec_t2['job_waiting_time_minimum_in_seconds'] == pytest.approx(4.0, rel=1e-6)
+    assert rec_t2['job_waiting_time_median_in_seconds'] == pytest.approx(4.0, rel=1e-6)
+    assert rec_t2['job_waiting_time_total_in_seconds'] == pytest.approx(4.0, rel=1e-6)
 
     # T3 counts (jobs that never started - should have NaN values for durations)
     assert rec_t3['number_of_jobs_executed'] == 1
@@ -164,11 +164,11 @@ def test_jobs_anonymized_rollups_base_aggregation():
     assert pd.isna(rec_t3['job_duration_maximum_in_seconds'])
     assert pd.isna(rec_t3['job_duration_minimum_in_seconds'])
     assert pd.isna(rec_t3['job_duration_median_in_seconds'])
-    assert pytest.approx(rec_t3['job_duration_total_in_seconds'], rel=1e-6) == 0.0
+    assert rec_t3['job_duration_total_in_seconds'] == pytest.approx(0.0, rel=1e-6)
 
     # T3 should have NaN for all waiting time metrics and 0 for totals
     assert pd.isna(rec_t3['job_waiting_time_average_in_seconds'])
     assert pd.isna(rec_t3['job_waiting_time_maximum_in_seconds'])
     assert pd.isna(rec_t3['job_waiting_time_minimum_in_seconds'])
     assert pd.isna(rec_t3['job_waiting_time_median_in_seconds'])
-    assert pytest.approx(rec_t3['job_waiting_time_total_in_seconds'], rel=1e-6) == 0.0
+    assert rec_t3['job_waiting_time_total_in_seconds'] == pytest.approx(0.0, rel=1e-6)

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -74,7 +74,7 @@ jobs = [
         'id': 6,
         'started': None,
         'finished': '2024-01-01 00:08:20.000000+00',
-        'failed': 0,
+        'failed': 1,
         'job_template_name': 'T3',
         'controller_node': 'ctrl-C',
         'ansible_version': 'v3',
@@ -99,41 +99,70 @@ def test_jobs_anonymized_rollups_base_aggregation():
     # New version returns list of per-template aggregates in 'json' field
     assert isinstance(result, list)
 
-    # There should be 2 templates (T1 and T2); rows with missing timestamps are filtered
-    assert len(result) == 2
+    # There should be 3 templates (T1, T2, and T3 with never-started jobs)
+    assert len(result) == 3
 
-    # Identify records by count of jobs (T1 has 3, T2 has 1)
-    rec_t1 = next(r for r in result if r['number_of_jobs_executed'] == 3)
-    rec_t2 = next(r for r in result if r['number_of_jobs_executed'] == 1)
+    # Identify records by job_template_name
+    rec_t1 = next(r for r in result if r['job_template_name'] == 'T1')
+    rec_t2 = next(r for r in result if r['job_template_name'] == 'T2')
+    rec_t3 = next(r for r in result if r['job_template_name'] == 'T3')
 
     # T1 counts
+    assert rec_t1['number_of_jobs_executed'] == 3
     assert rec_t1['number_of_jobs_failed'] == 1
     assert rec_t1['number_of_jobs_succeeded'] == 2
+    assert rec_t1['number_of_jobs_never_started'] == 0
 
     # T1 durations (seconds): 3.0, 5.0, 2.0
     assert pytest.approx(rec_t1['job_duration_average_in_seconds'], rel=1e-6) == 10 / 3
     assert pytest.approx(rec_t1['job_duration_maximum_in_seconds'], rel=1e-6) == 5.0
     assert pytest.approx(rec_t1['job_duration_minimum_in_seconds'], rel=1e-6) == 2.0
+    assert pytest.approx(rec_t1['job_duration_median_in_seconds'], rel=1e-6) == 3.0
     assert pytest.approx(rec_t1['job_duration_total_in_seconds'], rel=1e-6) == 10.0
 
     # T1 waiting times (seconds): 0.0, 2.0, 1.0
     assert pytest.approx(rec_t1['job_waiting_time_average_in_seconds'], rel=1e-6) == 1.0
     assert pytest.approx(rec_t1['job_waiting_time_maximum_in_seconds'], rel=1e-6) == 2.0
     assert pytest.approx(rec_t1['job_waiting_time_minimum_in_seconds'], rel=1e-6) == 0.0
+    assert pytest.approx(rec_t1['job_waiting_time_median_in_seconds'], rel=1e-6) == 1.0
     assert pytest.approx(rec_t1['job_waiting_time_total_in_seconds'], rel=1e-6) == 3.0
 
     # T2 counts
+    assert rec_t2['number_of_jobs_executed'] == 1
     assert rec_t2['number_of_jobs_failed'] == 0
     assert rec_t2['number_of_jobs_succeeded'] == 1
+    assert rec_t2['number_of_jobs_never_started'] == 0
 
     # T2 duration (seconds): 7.0
     assert pytest.approx(rec_t2['job_duration_average_in_seconds'], rel=1e-6) == 7.0
     assert pytest.approx(rec_t2['job_duration_maximum_in_seconds'], rel=1e-6) == 7.0
     assert pytest.approx(rec_t2['job_duration_minimum_in_seconds'], rel=1e-6) == 7.0
+    assert pytest.approx(rec_t2['job_duration_median_in_seconds'], rel=1e-6) == 7.0
     assert pytest.approx(rec_t2['job_duration_total_in_seconds'], rel=1e-6) == 7.0
 
     # T2 waiting (seconds): 4.0
     assert pytest.approx(rec_t2['job_waiting_time_average_in_seconds'], rel=1e-6) == 4.0
     assert pytest.approx(rec_t2['job_waiting_time_maximum_in_seconds'], rel=1e-6) == 4.0
     assert pytest.approx(rec_t2['job_waiting_time_minimum_in_seconds'], rel=1e-6) == 4.0
+    assert pytest.approx(rec_t2['job_waiting_time_median_in_seconds'], rel=1e-6) == 4.0
     assert pytest.approx(rec_t2['job_waiting_time_total_in_seconds'], rel=1e-6) == 4.0
+
+    # T3 counts (jobs that never started - should have NaN values for durations)
+    assert rec_t3['number_of_jobs_executed'] == 1
+    assert rec_t3['number_of_jobs_failed'] == 1
+    assert rec_t3['number_of_jobs_succeeded'] == 0
+    assert rec_t3['number_of_jobs_never_started'] == 1
+
+    # T3 should have NaN for all duration metrics and 0 for totals
+    assert pd.isna(rec_t3['job_duration_average_in_seconds'])
+    assert pd.isna(rec_t3['job_duration_maximum_in_seconds'])
+    assert pd.isna(rec_t3['job_duration_minimum_in_seconds'])
+    assert pd.isna(rec_t3['job_duration_median_in_seconds'])
+    assert pytest.approx(rec_t3['job_duration_total_in_seconds'], rel=1e-6) == 0.0
+
+    # T3 should have NaN for all waiting time metrics and 0 for totals
+    assert pd.isna(rec_t3['job_waiting_time_average_in_seconds'])
+    assert pd.isna(rec_t3['job_waiting_time_maximum_in_seconds'])
+    assert pd.isna(rec_t3['job_waiting_time_minimum_in_seconds'])
+    assert pd.isna(rec_t3['job_waiting_time_median_in_seconds'])
+    assert pytest.approx(rec_t3['job_waiting_time_total_in_seconds'], rel=1e-6) == 0.0

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -230,9 +230,15 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert ee_result['custom_EE'] == 3
 
     # ========== Validate Job Host Summary ==========
-    jhs_list = result['job_host_summary']
+    jhs_result = result['job_host_summary']
+    assert isinstance(jhs_result, dict), 'job_host_summary should be a dict'
+    assert 'aggregated' in jhs_result, 'job_host_summary should have aggregated key'
+    assert 'total_unique_hosts' in jhs_result, 'job_host_summary should have total_unique_hosts key'
+
+    jhs_list = jhs_result['aggregated']
     assert isinstance(jhs_list, list)
     assert len(jhs_list) == 2  # T1 and T2
+    assert jhs_result['total_unique_hosts'] == 5, 'Should have 5 unique hosts (h1-h5)'
 
     # Verify data was concatenated from both tarballs
     # verify number of ok, failures, skipped, ignored, rescued, dark for each template
@@ -337,16 +343,13 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
     # ========== Validate Anonymization ==========
-    # Check that job template names are hashed (128 character hex strings)
+    # Check that job template names in jobs section are hashed (128 character hex strings)
     for job in jobs_list:
         template_name = job['job_template_name']
         assert len(template_name) == 128, f'Template name should be hashed: {template_name}'
         assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
 
-    for jhs_item in jhs_list:
-        template_name = jhs_item['job_template_name']
-        assert len(template_name) == 128, f'Template name should be hashed: {template_name}'
-        assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
+    # Note: job_host_summary template names are NOT anonymized (remain as original names like T1, T2)
 
 
 def test_empty_tarballs_handling(cleanup_test_data):
@@ -383,8 +386,17 @@ def test_empty_tarballs_handling(cleanup_test_data):
     assert len(result['jobs']) == 0, 'jobs should be empty with no data'
 
     # Verify empty values for job_host_summary
-    assert isinstance(result['job_host_summary'], list), 'job_host_summary should be a list'
-    assert len(result['job_host_summary']) == 0, 'job_host_summary should be empty with no data'
+    # When empty, can be either an empty list or empty dict depending on code path
+    assert isinstance(result['job_host_summary'], (dict, list)), 'job_host_summary should be a dict or list'
+    if isinstance(result['job_host_summary'], dict):
+        if result['job_host_summary']:  # If not empty dict
+            assert 'aggregated' in result['job_host_summary'], 'job_host_summary should have aggregated key'
+            assert 'total_unique_hosts' in result['job_host_summary'], 'job_host_summary should have total_unique_hosts key'
+            assert isinstance(result['job_host_summary']['aggregated'], list), 'aggregated should be a list'
+            assert len(result['job_host_summary']['aggregated']) == 0, 'aggregated should be empty with no data'
+            assert result['job_host_summary']['total_unique_hosts'] == 0, 'total_unique_hosts should be 0 with no data'
+    else:  # list
+        assert len(result['job_host_summary']) == 0, 'job_host_summary list should be empty with no data'
 
     # Verify execution_environments is empty dict
     assert isinstance(result['execution_environments'], dict), 'execution_environments should be a dict'

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -1,0 +1,10 @@
+# This test should test data split into multiple tarballs (each tarball contains one csv data file)
+# I need to make sure that the logic for concatenating the dataframes is working correctly
+# This will work very similar to test_from_gather_to_json.py, but without the gathering data from database
+# as input data, use the data from other test files like
+# test_jobs_anonymized_rollups.py, test_events_modules_anonymized_rollups.py, test_execution_environments_anonymized_rollups.py
+# test_job_host_summary_anonymized_rollups.py
+
+# those tests have their data in list of dict, so you can import them, split to 2-3 parts, store them into tarball packed csv
+
+

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -173,9 +173,14 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert 'events_modules' in result
 
     # ========== Validate Jobs ==========
-    jobs_list = result['jobs']
+    jobs_result = result['jobs']
+    assert isinstance(jobs_result, dict)
+    assert 'by_template' in jobs_result
+    assert 'jobs_total' in jobs_result
+    jobs_list = jobs_result['by_template']
     assert isinstance(jobs_list, list)
     assert len(jobs_list) == 3  # T1, T2, T3
+    assert jobs_result['jobs_total'] == 5  # Total jobs across all templates
 
     # T1 should have data from both tarballs (jobs 1, 2, 4)
     t1_jobs = [j for j in jobs_list if j['number_of_jobs_executed'] == 3]
@@ -336,15 +341,6 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     total_module_usage = sum(playbook_modules.values())
     assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
-    # ========== Validate Anonymization ==========
-    # Check that job template names in jobs section are hashed (64 character hex strings)
-    for job in jobs_list:
-        template_name = job['job_template_name']
-        assert len(template_name) == 64, f'Template name should be hashed: {template_name}'
-        assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
-
-    # Note: job_host_summary template names are NOT anonymized (remain as original names like T1, T2)
-
 
 def test_empty_tarballs_handling(cleanup_test_data):
     """
@@ -376,8 +372,14 @@ def test_empty_tarballs_handling(cleanup_test_data):
 
     # When there's no data, the system returns empty dicts/lists
     # Verify empty values for jobs
-    assert isinstance(result['jobs'], dict), 'jobs should be a dict (empty when no data)'
-    assert len(result['jobs']) == 0, 'jobs should be empty with no data'
+    assert isinstance(result['jobs'], dict), 'jobs should be a dict'
+    # Empty jobs can be either completely empty dict or dict with empty by_template list
+    if result['jobs']:  # If not empty dict
+        assert 'by_template' in result['jobs'], 'jobs should have by_template key'
+        assert 'jobs_total' in result['jobs'], 'jobs should have jobs_total key'
+        assert isinstance(result['jobs']['by_template'], list), 'by_template should be a list'
+        assert len(result['jobs']['by_template']) == 0, 'by_template should be empty with no data'
+        assert result['jobs']['jobs_total'] == 0, 'jobs_total should be 0 with no data'
 
     # Verify empty values for job_host_summary
     # When empty, can be either an empty list or empty dict depending on code path

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -122,6 +122,11 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
 
     result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
 
+    # print the result with pretty json
+    import json
+
+    print(json.dumps(result, indent=4))
+
     # ========== Validate the results ==========
 
     # Validate structure
@@ -154,15 +159,21 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert isinstance(jhs_list, list)
     assert len(jhs_list) == 2  # T1 and T2
 
-    jhs_by_template = {item['job_template_name']: item for item in jhs_list}
-    assert len(jhs_by_template) == 2
-
     # Verify data was concatenated from both tarballs
-    # T1 should have 2 jobs total (from both tarballs)
-    # T2 should have 2 jobs total (from both tarballs)
-    for template_name, jhs_item in jhs_by_template.items():
-        assert jhs_item['jobs_total'] == 2
-        assert jhs_item['hosts_total'] >= 3  # At least 3 unique hosts
+    # verify number of ok, failures, skipped, ignored, rescued, dark for each template
+    assert jhs_list[0]['ok_total'] == 26
+    assert jhs_list[0]['failures_total'] == 2
+    assert jhs_list[0]['skipped_total'] == 2
+    assert jhs_list[0]['ignored_total'] == 0
+    assert jhs_list[0]['rescued_total'] == 0
+    assert jhs_list[0]['dark_total'] == 0
+
+    assert jhs_list[1]['ok_total'] == 26
+    assert jhs_list[1]['failures_total'] == 4
+    assert jhs_list[1]['skipped_total'] == 0
+    assert jhs_list[1]['ignored_total'] == 0
+    assert jhs_list[1]['rescued_total'] == 0
+    assert jhs_list[1]['dark_total'] == 0
 
     # ========== Validate Events Modules ==========
     events_modules = result['events_modules']

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -262,7 +262,6 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
 
     # Assert required keys are present
     assert 'modules_used_to_automate_total' in events_modules, "Missing 'modules_used_to_automate_total'"
-    assert 'list_of_modules_used_to_automate' in events_modules, "Missing 'list_of_modules_used_to_automate'"
     assert 'module_stats' in events_modules, "Missing 'module_stats'"
     assert 'collection_name_stats' in events_modules, "Missing 'collection_name_stats'"
     assert 'total_hosts_automated' in events_modules, "Missing 'total_hosts_automated'"
@@ -274,13 +273,8 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert events_modules['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
     assert events_modules['avg_number_of_modules_used_in_a_playbooks'] == 3.0, 'Average modules per playbook should be 3.0'
 
-    # Verify list_of_modules_used_to_automate
-    modules_list = events_modules['list_of_modules_used_to_automate']
-    assert isinstance(modules_list, list), 'list_of_modules_used_to_automate should be a list'
-    assert len(modules_list) == 7, 'Should have 7 modules'
-
-    # Check specific known modules are present
-    module_names = [m['module_name'] for m in modules_list if 'module_name' in m]
+    # Check specific known modules are present in module_stats
+    module_names = [m['module_name'] for m in events_modules['module_stats'] if 'module_name' in m]
     assert 'ansible.netcommon.cli_config' in module_names
     assert 'ansible.posix.firewalld' in module_names
     assert 'ansible.windows.win_copy' in module_names

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -189,16 +189,16 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert t1['number_of_jobs_succeeded'] == 2
     assert t1['number_of_jobs_never_started'] == 0
     # Check timing statistics
-    assert t1['job_duration_total_in_seconds'] == 10.0
+    assert t1['job_duration_total_in_seconds'] == pytest.approx(10.0)
     assert t1['job_duration_average_in_seconds'] == pytest.approx(3.333, rel=1e-2)
-    assert t1['job_duration_minimum_in_seconds'] == 2.0
-    assert t1['job_duration_maximum_in_seconds'] == 5.0
-    assert t1['job_duration_median_in_seconds'] == 3.0
-    assert t1['job_waiting_time_total_in_seconds'] == 3.0
-    assert t1['job_waiting_time_average_in_seconds'] == 1.0
-    assert t1['job_waiting_time_minimum_in_seconds'] == 0.0
-    assert t1['job_waiting_time_maximum_in_seconds'] == 2.0
-    assert t1['job_waiting_time_median_in_seconds'] == 1.0
+    assert t1['job_duration_minimum_in_seconds'] == pytest.approx(2.0)
+    assert t1['job_duration_maximum_in_seconds'] == pytest.approx(5.0)
+    assert t1['job_duration_median_in_seconds'] == pytest.approx(3.0)
+    assert t1['job_waiting_time_total_in_seconds'] == pytest.approx(3.0)
+    assert t1['job_waiting_time_average_in_seconds'] == pytest.approx(1.0)
+    assert t1['job_waiting_time_minimum_in_seconds'] == pytest.approx(0.0)
+    assert t1['job_waiting_time_maximum_in_seconds'] == pytest.approx(2.0)
+    assert t1['job_waiting_time_median_in_seconds'] == pytest.approx(1.0)
 
     # T2 should have 1 job executed
     t2_jobs = [j for j in jobs_list if j['number_of_jobs_executed'] == 1 and j['number_of_jobs_never_started'] == 0]
@@ -207,11 +207,11 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert t2['number_of_jobs_executed'] == 1
     assert t2['number_of_jobs_failed'] == 0
     assert t2['number_of_jobs_succeeded'] == 1
-    assert t2['job_duration_total_in_seconds'] == 7.0
-    assert t2['job_duration_average_in_seconds'] == 7.0
-    assert t2['job_duration_median_in_seconds'] == 7.0
-    assert t2['job_waiting_time_total_in_seconds'] == 4.0
-    assert t2['job_waiting_time_average_in_seconds'] == 4.0
+    assert t2['job_duration_total_in_seconds'] == pytest.approx(7.0)
+    assert t2['job_duration_average_in_seconds'] == pytest.approx(7.0)
+    assert t2['job_duration_median_in_seconds'] == pytest.approx(7.0)
+    assert t2['job_waiting_time_total_in_seconds'] == pytest.approx(4.0)
+    assert t2['job_waiting_time_average_in_seconds'] == pytest.approx(4.0)
 
     # T3 should have never started job
     t3_jobs = [j for j in jobs_list if j['number_of_jobs_never_started'] == 1]
@@ -220,10 +220,10 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert t3['number_of_jobs_executed'] == 1
     assert t3['number_of_jobs_failed'] == 1
     assert t3['number_of_jobs_succeeded'] == 0
-    assert t3['job_duration_total_in_seconds'] == 0.0
+    assert t3['job_duration_total_in_seconds'] == pytest.approx(0.0)
     assert t3['job_duration_average_in_seconds'] is None
     assert t3['job_duration_median_in_seconds'] is None
-    assert t3['job_waiting_time_total_in_seconds'] == 0.0
+    assert t3['job_waiting_time_total_in_seconds'] == pytest.approx(0.0)
     assert t3['job_waiting_time_average_in_seconds'] is None
 
     # ========== Validate Execution Environments ==========
@@ -259,7 +259,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     # Verify values from concatenated data across 3 tarballs
     assert result['statistics']['modules_used_to_automate_total'] == 7, 'Should have 7 unique modules from all tarballs'
     assert result['statistics']['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
-    assert result['statistics']['avg_number_of_modules_used_in_a_playbooks'] == 3.0, 'Average modules per playbook should be 3.0'
+    assert result['statistics']['avg_number_of_modules_used_in_a_playbooks'] == pytest.approx(3.0), 'Average modules per playbook should be 3.0'
 
     # Check specific known modules are present in module_stats
     module_names = [m['module_name'] for m in result['module_stats'] if 'module_name' in m]
@@ -286,8 +286,8 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert win_copy['task_clean_success_total'] == 1
     assert win_copy['task_success_with_reruns_total'] == 2
     assert win_copy['task_failed_total'] == 0
-    assert win_copy['job_duration_total_seconds'] == 2100.0
-    assert win_copy['avg_job_duration_seconds'] == 700.0
+    assert win_copy['job_duration_total_seconds'] == pytest.approx(2100.0)
+    assert win_copy['avg_job_duration_seconds'] == pytest.approx(700.0)
 
     # Verify another module (community.general.yum)
     yum_stats = [m for m in module_stats if m.get('module_name') == 'community.general.yum']
@@ -298,7 +298,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert yum['number_of_jobs_never_started'] == 1
     assert yum['task_failed_total'] == 3
     assert yum['jobs_failed_because_of_module_failure_total'] == 3
-    assert yum['avg_job_duration_seconds'] == 500.0
+    assert yum['avg_job_duration_seconds'] == pytest.approx(500.0)
 
     # Verify collection stats
     collection_stats = result['collection_name_stats']
@@ -314,7 +314,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert windows_coll['hosts_total'] == 3
     assert windows_coll['task_clean_success_total'] == 1
     assert windows_coll['task_success_with_reruns_total'] == 2
-    assert windows_coll['avg_job_duration_seconds'] == 700.0
+    assert windows_coll['avg_job_duration_seconds'] == pytest.approx(700.0)
 
     # Verify modules_used_per_playbook is now an array with 5 entries (flattened structure)
     playbook_modules = result['modules_used_per_playbook']

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -1,10 +1,224 @@
-# This test should test data split into multiple tarballs (each tarball contains one csv data file)
-# I need to make sure that the logic for concatenating the dataframes is working correctly
-# This will work very similar to test_from_gather_to_json.py, but without the gathering data from database
-# as input data, use the data from other test files like
-# test_jobs_anonymized_rollups.py, test_events_modules_anonymized_rollups.py, test_execution_environments_anonymized_rollups.py
-# test_job_host_summary_anonymized_rollups.py
+"""
+This test verifies that data split into multiple tarballs is correctly concatenated.
+It tests the logic for loading and merging dataframes from multiple tarball files.
 
-# those tests have their data in list of dict, so you can import them, split to 2-3 parts, store them into tarball packed csv
+The test:
+1. Takes data from other test files (jobs, events, execution_environments, jobhostsummary)
+2. Splits each dataset into 2-3 separate tarballs
+3. Creates tarball files with CSV data inside
+4. Tests that compute_anonymized_rollup_from_raw_data properly loads and concatenates the data
+5. Validates the final output matches expected aggregated results
+"""
+
+import os
+import shutil
+import tarfile
+
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
+from metrics_utility.test.test_anonymized_rollups.test_events_modules_anonymized_rollups import events
+from metrics_utility.test.test_anonymized_rollups.test_execution_environments_anonymized_rollups import execution_environments
+from metrics_utility.test.test_anonymized_rollups.test_jobhostsummary_anonymized_rollups import jobhostsummary
+
+# Import test data from other test files
+from metrics_utility.test.test_anonymized_rollups.test_jobs_anonymized_rollups import jobs
 
 
+@pytest.fixture
+def cleanup_test_data():
+    """Clean up test directories before and after test."""
+    out_dir = './out'
+
+    # Cleanup before test
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+
+    yield  # Run the test
+
+    # Cleanup after test (commented out for debugging)
+    # if os.path.exists(out_dir):
+    #     shutil.rmtree(out_dir)
+
+
+def create_tarball_with_csv(data_list, csv_filename, tarball_path):
+    """
+    Create a tarball containing a single CSV file.
+
+    Args:
+        data_list: List of dictionaries to convert to CSV
+        csv_filename: Name of the CSV file inside the tarball
+        tarball_path: Path where to save the tarball
+    """
+    # Create directory if it doesn't exist
+    os.makedirs(os.path.dirname(tarball_path), exist_ok=True)
+
+    # Skip creating tarballs for empty data
+    if not data_list:
+        return
+
+    # Convert list of dicts to DataFrame then to CSV
+    df = pd.DataFrame(data_list)
+    csv_buffer = BytesIO()
+    df.to_csv(csv_buffer, index=False)
+    csv_buffer.seek(0)
+
+    # Create tarball with the CSV file inside
+    with tarfile.open(tarball_path, 'w:gz') as tar:
+        tarinfo = tarfile.TarInfo(name=csv_filename)
+        tarinfo.size = len(csv_buffer.getvalue())
+        tar.addfile(tarinfo, csv_buffer)
+
+
+def test_multiple_tarballs_concatenation(cleanup_test_data):
+    """
+    Test that multiple tarballs are properly concatenated and aggregated.
+
+    This test splits the test data into multiple tarballs (2-3 parts each)
+    and verifies that the concatenation logic works correctly.
+    """
+    base_path = './out'
+    year, month, day = 2025, 6, 13
+    data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
+
+    # ========== Split and create tarball files for each collector ==========
+
+    # 1. Jobs data - split into 2 tarballs
+    jobs_part1 = jobs[:3]  # First 3 jobs
+    jobs_part2 = jobs[3:]  # Remaining jobs
+
+    create_tarball_with_csv(jobs_part1, 'unified_jobs.csv', f'{data_dir}/tarball1_unified_jobs.tar.gz')
+    create_tarball_with_csv(jobs_part2, 'unified_jobs.csv', f'{data_dir}/tarball2_unified_jobs.tar.gz')
+
+    # 2. Events data - split into 3 tarballs
+    # Note: collector name is 'main_jobevent_service'
+    events_part1 = events[:100]  # First 100 events
+    events_part2 = events[100:200]  # Middle events
+    events_part3 = events[200:]  # Remaining events
+
+    create_tarball_with_csv(events_part1, 'main_jobevent_service.csv', f'{data_dir}/tarball1_main_jobevent_service.tar.gz')
+    create_tarball_with_csv(events_part2, 'main_jobevent_service.csv', f'{data_dir}/tarball2_main_jobevent_service.tar.gz')
+    create_tarball_with_csv(events_part3, 'main_jobevent_service.csv', f'{data_dir}/tarball3_main_jobevent_service.tar.gz')
+
+    # 3. Execution environments - split into 2 tarballs
+    ee_part1 = execution_environments[:2]
+    ee_part2 = execution_environments[2:]
+
+    create_tarball_with_csv(ee_part1, 'execution_environments.csv', f'{data_dir}/tarball1_execution_environments.tar.gz')
+    create_tarball_with_csv(ee_part2, 'execution_environments.csv', f'{data_dir}/tarball2_execution_environments.tar.gz')
+
+    # 4. Job host summary - split into 2 tarballs
+    # Note: collector name is 'job_host_summary_service'
+    jhs_part1 = jobhostsummary[:8]  # First 8 entries
+    jhs_part2 = jobhostsummary[8:]  # Remaining entries
+
+    create_tarball_with_csv(jhs_part1, 'job_host_summary_service.csv', f'{data_dir}/tarball1_job_host_summary_service.tar.gz')
+    create_tarball_with_csv(jhs_part2, 'job_host_summary_service.csv', f'{data_dir}/tarball2_job_host_summary_service.tar.gz')
+
+    # ========== Run the anonymized rollup computation ==========
+
+    result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
+
+    # ========== Validate the results ==========
+
+    # Validate structure
+    assert 'jobs' in result
+    assert 'job_host_summary' in result
+    assert 'execution_environments' in result
+    assert 'events_modules' in result
+
+    # ========== Validate Jobs ==========
+    jobs_list = result['jobs']
+    assert isinstance(jobs_list, list)
+    assert len(jobs_list) == 3  # T1, T2, T3
+
+    # T1 should have data from both tarballs (jobs 1, 2, 4)
+    t1_jobs = [j for j in jobs_list if j['number_of_jobs_executed'] == 3]
+    assert len(t1_jobs) == 1
+    t1 = t1_jobs[0]
+    assert t1['number_of_jobs_executed'] == 3
+    assert t1['number_of_jobs_failed'] == 1
+    assert t1['number_of_jobs_succeeded'] == 2
+
+    # ========== Validate Execution Environments ==========
+    ee_result = result['execution_environments']
+    assert ee_result['total_EE'] == 5
+    assert ee_result['default_EE'] == 2
+    assert ee_result['custom_EE'] == 3
+
+    # ========== Validate Job Host Summary ==========
+    jhs_list = result['job_host_summary']
+    assert isinstance(jhs_list, list)
+    assert len(jhs_list) == 2  # T1 and T2
+
+    jhs_by_template = {item['job_template_name']: item for item in jhs_list}
+    assert len(jhs_by_template) == 2
+
+    # Verify data was concatenated from both tarballs
+    # T1 should have 2 jobs total (from both tarballs)
+    # T2 should have 2 jobs total (from both tarballs)
+    for template_name, jhs_item in jhs_by_template.items():
+        assert jhs_item['jobs_total'] == 2
+        assert jhs_item['hosts_total'] >= 3  # At least 3 unique hosts
+
+    # ========== Validate Events Modules ==========
+    events_modules = result['events_modules']
+    assert isinstance(events_modules, dict), 'events_modules should be a dictionary'
+
+    # Assert required keys are present
+    assert 'modules_used_to_automate_total' in events_modules, "Missing 'modules_used_to_automate_total'"
+    assert 'list_of_modules_used_to_automate' in events_modules, "Missing 'list_of_modules_used_to_automate'"
+    assert 'module_stats' in events_modules, "Missing 'module_stats'"
+    assert 'collection_name_stats' in events_modules, "Missing 'collection_name_stats'"
+    assert 'total_hosts_automated' in events_modules, "Missing 'total_hosts_automated'"
+
+    # Verify values from concatenated data across 3 tarballs
+    assert events_modules['modules_used_to_automate_total'] == 7, 'Should have 7 unique modules from all tarballs'
+    assert events_modules['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
+
+    # Verify module stats have data from all tarballs
+    module_stats = events_modules['module_stats']
+    assert isinstance(module_stats, list), 'module_stats should be a list'
+    assert len(module_stats) == 7, 'Should have stats for all 7 modules'
+
+    # Verify collection stats
+    collection_stats = events_modules['collection_name_stats']
+    assert isinstance(collection_stats, list), 'collection_name_stats should be a list'
+    assert len(collection_stats) == 7, 'Should have stats for all 7 collections'
+
+    # ========== Validate Anonymization ==========
+    # Check that job template names are hashed (128 character hex strings)
+    for job in jobs_list:
+        template_name = job['job_template_name']
+        assert len(template_name) == 128, f'Template name should be hashed: {template_name}'
+        assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
+
+    for jhs_item in jhs_list:
+        template_name = jhs_item['job_template_name']
+        assert len(template_name) == 128, f'Template name should be hashed: {template_name}'
+        assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
+
+
+def test_empty_tarballs_handling(cleanup_test_data):
+    """
+    Test that the system handles case with no tarball files gracefully.
+    """
+    base_path = './out'
+    year, month, day = 2025, 6, 14
+    data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
+
+    # Create the directory but don't create any tarball files
+    # This simulates a scenario where no data was collected
+    os.makedirs(data_dir, exist_ok=True)
+
+    # Should not crash, but return empty/default results
+    result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
+
+    # Validate structure exists even with empty data
+    assert 'jobs' in result
+    assert 'job_host_summary' in result
+    assert 'execution_environments' in result
+    assert 'events_modules' in result

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -343,10 +343,10 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
     # ========== Validate Anonymization ==========
-    # Check that job template names in jobs section are hashed (128 character hex strings)
+    # Check that job template names in jobs section are hashed (64 character hex strings)
     for job in jobs_list:
         template_name = job['job_template_name']
-        assert len(template_name) == 128, f'Template name should be hashed: {template_name}'
+        assert len(template_name) == 64, f'Template name should be hashed: {template_name}'
         assert all(c in '0123456789abcdef' for c in template_name), 'Template name should be hex'
 
     # Note: job_host_summary template names are NOT anonymized (remain as original names like T1, T2)

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -166,21 +166,19 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
 
     # ========== Validate the results ==========
 
-    # Validate structure
-    assert 'jobs' in result
+    # Validate flattened structure
+    assert 'statistics' in result
+    assert 'jobs_by_template' in result
     assert 'job_host_summary' in result
-    assert 'execution_environments' in result
-    assert 'events_modules' in result
+    assert 'module_stats' in result
+    assert 'collection_name_stats' in result
+    assert 'modules_used_per_playbook' in result
 
     # ========== Validate Jobs ==========
-    jobs_result = result['jobs']
-    assert isinstance(jobs_result, dict)
-    assert 'by_template' in jobs_result
-    assert 'jobs_total' in jobs_result
-    jobs_list = jobs_result['by_template']
+    jobs_list = result['jobs_by_template']
     assert isinstance(jobs_list, list)
     assert len(jobs_list) == 3  # T1, T2, T3
-    assert jobs_result['jobs_total'] == 5  # Total jobs across all templates
+    assert result['statistics']['jobs_total'] == 5  # Total jobs across all templates
 
     # T1 should have data from both tarballs (jobs 1, 2, 4)
     t1_jobs = [j for j in jobs_list if j['number_of_jobs_executed'] == 3]
@@ -229,21 +227,15 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert t3['job_waiting_time_average_in_seconds'] is None
 
     # ========== Validate Execution Environments ==========
-    ee_result = result['execution_environments']
-    assert ee_result['total_EE'] == 5
-    assert ee_result['default_EE'] == 2
-    assert ee_result['custom_EE'] == 3
+    assert result['statistics']['total_EE'] == 5
+    assert result['statistics']['default_EE'] == 2
+    assert result['statistics']['custom_EE'] == 3
 
     # ========== Validate Job Host Summary ==========
-    jhs_result = result['job_host_summary']
-    assert isinstance(jhs_result, dict), 'job_host_summary should be a dict'
-    assert 'aggregated' in jhs_result, 'job_host_summary should have aggregated key'
-    assert 'total_unique_hosts' in jhs_result, 'job_host_summary should have total_unique_hosts key'
-
-    jhs_list = jhs_result['aggregated']
-    assert isinstance(jhs_list, list)
+    jhs_list = result['job_host_summary']
+    assert isinstance(jhs_list, list), 'job_host_summary should be a list'
     assert len(jhs_list) == 2  # T1 and T2
-    assert jhs_result['total_unique_hosts'] == 5, 'Should have 5 unique hosts (h1-h5)'
+    assert result['statistics']['total_unique_hosts'] == 5, 'Should have 5 unique hosts (h1-h5)'
 
     # Verify data was concatenated from both tarballs
     # verify number of ok, failures, skipped, ignored, rescued, dark for each template
@@ -262,24 +254,15 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert jhs_list[1]['dark_total'] == 0
 
     # ========== Validate Events Modules ==========
-    events_modules = result['events_modules']
-    assert isinstance(events_modules, dict), 'events_modules should be a dictionary'
-
-    # Assert required keys are present
-    assert 'modules_used_to_automate_total' in events_modules, "Missing 'modules_used_to_automate_total'"
-    assert 'module_stats' in events_modules, "Missing 'module_stats'"
-    assert 'collection_name_stats' in events_modules, "Missing 'collection_name_stats'"
-    assert 'total_hosts_automated' in events_modules, "Missing 'total_hosts_automated'"
-    assert 'avg_number_of_modules_used_in_a_playbooks' in events_modules, "Missing 'avg_number_of_modules_used_in_a_playbooks'"
-    assert 'modules_used_per_playbook_total' in events_modules, "Missing 'modules_used_per_playbook_total'"
+    # In flattened structure, events_modules data is now in statistics and direct arrays
 
     # Verify values from concatenated data across 3 tarballs
-    assert events_modules['modules_used_to_automate_total'] == 7, 'Should have 7 unique modules from all tarballs'
-    assert events_modules['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
-    assert events_modules['avg_number_of_modules_used_in_a_playbooks'] == 3.0, 'Average modules per playbook should be 3.0'
+    assert result['statistics']['modules_used_to_automate_total'] == 7, 'Should have 7 unique modules from all tarballs'
+    assert result['statistics']['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
+    assert result['statistics']['avg_number_of_modules_used_in_a_playbooks'] == 3.0, 'Average modules per playbook should be 3.0'
 
     # Check specific known modules are present in module_stats
-    module_names = [m['module_name'] for m in events_modules['module_stats'] if 'module_name' in m]
+    module_names = [m['module_name'] for m in result['module_stats'] if 'module_name' in m]
     assert 'ansible.netcommon.cli_config' in module_names
     assert 'ansible.posix.firewalld' in module_names
     assert 'ansible.windows.win_copy' in module_names
@@ -288,7 +271,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert 'community.mongodb.insert' in module_names
 
     # Verify module stats have data from all tarballs
-    module_stats = events_modules['module_stats']
+    module_stats = result['module_stats']
     assert isinstance(module_stats, list), 'module_stats should be a list'
     assert len(module_stats) == 7, 'Should have stats for all 7 modules'
 
@@ -318,7 +301,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert yum['avg_job_duration_seconds'] == 500.0
 
     # Verify collection stats
-    collection_stats = events_modules['collection_name_stats']
+    collection_stats = result['collection_name_stats']
     assert isinstance(collection_stats, list), 'collection_name_stats should be a list'
     assert len(collection_stats) == 7, 'Should have stats for all 7 collections'
 
@@ -333,12 +316,12 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert windows_coll['task_success_with_reruns_total'] == 2
     assert windows_coll['avg_job_duration_seconds'] == 700.0
 
-    # Verify modules_used_per_playbook_total is a dict with 5 entries
-    playbook_modules = events_modules['modules_used_per_playbook_total']
-    assert isinstance(playbook_modules, dict), 'modules_used_per_playbook_total should be a dict'
+    # Verify modules_used_per_playbook is now an array with 5 entries (flattened structure)
+    playbook_modules = result['modules_used_per_playbook']
+    assert isinstance(playbook_modules, list), 'modules_used_per_playbook should be a list'
     assert len(playbook_modules) == 5, 'Should have 5 playbooks'
     # Check values sum to expected total
-    total_module_usage = sum(playbook_modules.values())
+    total_module_usage = sum(p['modules_used'] for p in playbook_modules)
     assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
 
@@ -364,41 +347,48 @@ def test_empty_tarballs_handling(cleanup_test_data):
     print('\n=== Empty Tarball Result ===')
     print(json_content)
 
-    # Validate structure exists even with empty data
-    assert 'jobs' in result
+    # Validate flattened structure exists even with empty data
+    assert 'statistics' in result
+    assert 'jobs_by_template' in result
     assert 'job_host_summary' in result
-    assert 'execution_environments' in result
-    assert 'events_modules' in result
+    assert 'module_stats' in result
+    assert 'collection_name_stats' in result
+    assert 'modules_used_per_playbook' in result
 
-    # When there's no data, the system returns empty dicts/lists
-    # Verify empty values for jobs
-    assert isinstance(result['jobs'], dict), 'jobs should be a dict'
-    # Empty jobs can be either completely empty dict or dict with empty by_template list
-    if result['jobs']:  # If not empty dict
-        assert 'by_template' in result['jobs'], 'jobs should have by_template key'
-        assert 'jobs_total' in result['jobs'], 'jobs should have jobs_total key'
-        assert isinstance(result['jobs']['by_template'], list), 'by_template should be a list'
-        assert len(result['jobs']['by_template']) == 0, 'by_template should be empty with no data'
-        assert result['jobs']['jobs_total'] == 0, 'jobs_total should be 0 with no data'
+    # Verify statistics contains all fields (with null values for empty data)
+    statistics = result['statistics']
+    assert isinstance(statistics, dict), 'statistics should be a dict'
+    assert 'modules_used_to_automate_total' in statistics
+    assert 'avg_number_of_modules_used_in_a_playbooks' in statistics
+    assert 'total_hosts_automated' in statistics
+    assert 'total_EE' in statistics
+    assert 'default_EE' in statistics
+    assert 'custom_EE' in statistics
+    assert 'jobs_total' in statistics
+    assert 'total_unique_hosts' in statistics
 
-    # Verify empty values for job_host_summary
-    # When empty, can be either an empty list or empty dict depending on code path
-    assert isinstance(result['job_host_summary'], (dict, list)), 'job_host_summary should be a dict or list'
-    if isinstance(result['job_host_summary'], dict):
-        if result['job_host_summary']:  # If not empty dict
-            assert 'aggregated' in result['job_host_summary'], 'job_host_summary should have aggregated key'
-            assert 'total_unique_hosts' in result['job_host_summary'], 'job_host_summary should have total_unique_hosts key'
-            assert isinstance(result['job_host_summary']['aggregated'], list), 'aggregated should be a list'
-            assert len(result['job_host_summary']['aggregated']) == 0, 'aggregated should be empty with no data'
-            assert result['job_host_summary']['total_unique_hosts'] == 0, 'total_unique_hosts should be 0 with no data'
-    else:  # list
-        assert len(result['job_host_summary']) == 0, 'job_host_summary list should be empty with no data'
+    # All statistics should be None for empty data
+    assert statistics['modules_used_to_automate_total'] is None
+    assert statistics['avg_number_of_modules_used_in_a_playbooks'] is None
+    assert statistics['total_hosts_automated'] is None
+    assert statistics['total_EE'] is None
+    assert statistics['default_EE'] is None
+    assert statistics['custom_EE'] is None
+    assert statistics['jobs_total'] is None
+    assert statistics['total_unique_hosts'] is None
 
-    # Verify execution_environments is empty dict
-    assert isinstance(result['execution_environments'], dict), 'execution_environments should be a dict'
-    assert len(result['execution_environments']) == 0, 'execution_environments should be empty with no data'
+    # Verify all arrays are empty
+    assert isinstance(result['jobs_by_template'], list), 'jobs_by_template should be a list'
+    assert len(result['jobs_by_template']) == 0, 'jobs_by_template should be empty with no data'
 
-    # Verify events_modules is empty dict
-    events_modules = result['events_modules']
-    assert isinstance(events_modules, dict), 'events_modules should be a dict'
-    assert len(events_modules) == 0, 'events_modules should be empty with no data'
+    assert isinstance(result['job_host_summary'], list), 'job_host_summary should be a list'
+    assert len(result['job_host_summary']) == 0, 'job_host_summary should be empty with no data'
+
+    assert isinstance(result['module_stats'], list), 'module_stats should be a list'
+    assert len(result['module_stats']) == 0, 'module_stats should be empty with no data'
+
+    assert isinstance(result['collection_name_stats'], list), 'collection_name_stats should be a list'
+    assert len(result['collection_name_stats']) == 0, 'collection_name_stats should be empty with no data'
+
+    assert isinstance(result['modules_used_per_playbook'], list), 'modules_used_per_playbook should be a list'
+    assert len(result['modules_used_per_playbook']) == 0, 'modules_used_per_playbook should be empty with no data'

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -125,6 +125,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     # print the result with pretty json
     import json
 
+    # Note: result is already sanitized by compute_anonymized_rollup_from_raw_data
     json_content = json.dumps(result, indent=4)
     print(json_content)
 

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -8,6 +8,14 @@ The test:
 3. Creates tarball files with CSV data inside
 4. Tests that compute_anonymized_rollup_from_raw_data properly loads and concatenates the data
 5. Validates the final output matches expected aggregated results
+
+Enhanced Assertions:
+- Deep validation of JSON structure including all nested values
+- Verification of timing statistics (average, min, max, median for job durations and waiting times)
+- Detailed module and collection statistics validation
+- Edge case handling (never-started jobs, null values)
+- Comprehensive empty data handling test
+- Prints full JSON output to terminal for inspection
 """
 
 import os
@@ -79,6 +87,18 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
 
     This test splits the test data into multiple tarballs (2-3 parts each)
     and verifies that the concatenation logic works correctly.
+
+    The test validates:
+    1. **Jobs**: Verifies counts, timing statistics (avg/min/max/median), and edge cases like never-started jobs
+    2. **Execution Environments**: Validates total, default, and custom EE counts
+    3. **Job Host Summary**: Checks task result counts (ok, failures, skipped, etc.)
+    4. **Events Modules**: Comprehensive validation including:
+       - Total module and host counts
+       - Module and collection lists
+       - Detailed module statistics (jobs, hosts, tasks, durations)
+       - Collection statistics
+       - Playbook-level module usage
+    5. **Anonymization**: Verifies all sensitive names are properly hashed
     """
     base_path = './out'
     year, month, day = 2025, 6, 13
@@ -127,7 +147,11 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
 
     # Note: result is already sanitized by compute_anonymized_rollup_from_raw_data
     json_content = json.dumps(result, indent=4)
+    print('\n' + '=' * 80)
+    print('=== ANONYMIZED ROLLUP RESULT (from multiple tarballs) ===')
+    print('=' * 80)
     print(json_content)
+    print('=' * 80)
 
     # save the result as json inside rollups/2025/06/13/anonymized.json - based on the year, month, day
     json_path = f'./out/rollups/{year}/{month:02d}/{day:02d}/anonymized.json'
@@ -160,6 +184,44 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert t1['number_of_jobs_executed'] == 3
     assert t1['number_of_jobs_failed'] == 1
     assert t1['number_of_jobs_succeeded'] == 2
+    assert t1['number_of_jobs_never_started'] == 0
+    # Check timing statistics
+    assert t1['job_duration_total_in_seconds'] == 10.0
+    assert t1['job_duration_average_in_seconds'] == pytest.approx(3.333, rel=1e-2)
+    assert t1['job_duration_minimum_in_seconds'] == 2.0
+    assert t1['job_duration_maximum_in_seconds'] == 5.0
+    assert t1['job_duration_median_in_seconds'] == 3.0
+    assert t1['job_waiting_time_total_in_seconds'] == 3.0
+    assert t1['job_waiting_time_average_in_seconds'] == 1.0
+    assert t1['job_waiting_time_minimum_in_seconds'] == 0.0
+    assert t1['job_waiting_time_maximum_in_seconds'] == 2.0
+    assert t1['job_waiting_time_median_in_seconds'] == 1.0
+
+    # T2 should have 1 job executed
+    t2_jobs = [j for j in jobs_list if j['number_of_jobs_executed'] == 1 and j['number_of_jobs_never_started'] == 0]
+    assert len(t2_jobs) == 1
+    t2 = t2_jobs[0]
+    assert t2['number_of_jobs_executed'] == 1
+    assert t2['number_of_jobs_failed'] == 0
+    assert t2['number_of_jobs_succeeded'] == 1
+    assert t2['job_duration_total_in_seconds'] == 7.0
+    assert t2['job_duration_average_in_seconds'] == 7.0
+    assert t2['job_duration_median_in_seconds'] == 7.0
+    assert t2['job_waiting_time_total_in_seconds'] == 4.0
+    assert t2['job_waiting_time_average_in_seconds'] == 4.0
+
+    # T3 should have never started job
+    t3_jobs = [j for j in jobs_list if j['number_of_jobs_never_started'] == 1]
+    assert len(t3_jobs) == 1
+    t3 = t3_jobs[0]
+    assert t3['number_of_jobs_executed'] == 1
+    assert t3['number_of_jobs_failed'] == 1
+    assert t3['number_of_jobs_succeeded'] == 0
+    assert t3['job_duration_total_in_seconds'] == 0.0
+    assert t3['job_duration_average_in_seconds'] is None
+    assert t3['job_duration_median_in_seconds'] is None
+    assert t3['job_waiting_time_total_in_seconds'] == 0.0
+    assert t3['job_waiting_time_average_in_seconds'] is None
 
     # ========== Validate Execution Environments ==========
     ee_result = result['execution_environments']
@@ -198,20 +260,81 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert 'module_stats' in events_modules, "Missing 'module_stats'"
     assert 'collection_name_stats' in events_modules, "Missing 'collection_name_stats'"
     assert 'total_hosts_automated' in events_modules, "Missing 'total_hosts_automated'"
+    assert 'avg_number_of_modules_used_in_a_playbooks' in events_modules, "Missing 'avg_number_of_modules_used_in_a_playbooks'"
+    assert 'modules_used_per_playbook_total' in events_modules, "Missing 'modules_used_per_playbook_total'"
 
     # Verify values from concatenated data across 3 tarballs
     assert events_modules['modules_used_to_automate_total'] == 7, 'Should have 7 unique modules from all tarballs'
     assert events_modules['total_hosts_automated'] == 9, 'Should have 9 unique hosts from all tarballs'
+    assert events_modules['avg_number_of_modules_used_in_a_playbooks'] == 3.0, 'Average modules per playbook should be 3.0'
+
+    # Verify list_of_modules_used_to_automate
+    modules_list = events_modules['list_of_modules_used_to_automate']
+    assert isinstance(modules_list, list), 'list_of_modules_used_to_automate should be a list'
+    assert len(modules_list) == 7, 'Should have 7 modules'
+
+    # Check specific known modules are present
+    module_names = [m['module_name'] for m in modules_list if 'module_name' in m]
+    assert 'ansible.netcommon.cli_config' in module_names
+    assert 'ansible.posix.firewalld' in module_names
+    assert 'ansible.windows.win_copy' in module_names
+    assert 'community.aws.ec2' in module_names
+    assert 'community.general.yum' in module_names
+    assert 'community.mongodb.insert' in module_names
 
     # Verify module stats have data from all tarballs
     module_stats = events_modules['module_stats']
     assert isinstance(module_stats, list), 'module_stats should be a list'
     assert len(module_stats) == 7, 'Should have stats for all 7 modules'
 
+    # Verify specific module stats (ansible.windows.win_copy as an example)
+    win_copy_stats = [m for m in module_stats if m.get('module_name') == 'ansible.windows.win_copy']
+    assert len(win_copy_stats) == 1, 'Should have exactly one entry for ansible.windows.win_copy'
+    win_copy = win_copy_stats[0]
+    assert win_copy['collection_source'] == 'certified'
+    assert win_copy['collection_name'] == 'ansible.windows'
+    assert win_copy['jobs_total'] == 3
+    assert win_copy['hosts_total'] == 3
+    assert win_copy['task_clean_success_total'] == 1
+    assert win_copy['task_success_with_reruns_total'] == 2
+    assert win_copy['task_failed_total'] == 0
+    assert win_copy['job_duration_total_seconds'] == 2100.0
+    assert win_copy['avg_job_duration_seconds'] == 700.0
+
+    # Verify another module (community.general.yum)
+    yum_stats = [m for m in module_stats if m.get('module_name') == 'community.general.yum']
+    assert len(yum_stats) == 1, 'Should have exactly one entry for community.general.yum'
+    yum = yum_stats[0]
+    assert yum['collection_source'] == 'community'
+    assert yum['jobs_total'] == 3
+    assert yum['number_of_jobs_never_started'] == 1
+    assert yum['task_failed_total'] == 3
+    assert yum['jobs_failed_because_of_module_failure_total'] == 3
+    assert yum['avg_job_duration_seconds'] == 500.0
+
     # Verify collection stats
     collection_stats = events_modules['collection_name_stats']
     assert isinstance(collection_stats, list), 'collection_name_stats should be a list'
     assert len(collection_stats) == 7, 'Should have stats for all 7 collections'
+
+    # Verify specific collection stats (ansible.windows)
+    windows_collection = [c for c in collection_stats if c.get('collection_name') == 'ansible.windows']
+    assert len(windows_collection) == 1, 'Should have exactly one entry for ansible.windows collection'
+    windows_coll = windows_collection[0]
+    assert windows_coll['collection_source'] == 'certified'
+    assert windows_coll['jobs_total'] == 3
+    assert windows_coll['hosts_total'] == 3
+    assert windows_coll['task_clean_success_total'] == 1
+    assert windows_coll['task_success_with_reruns_total'] == 2
+    assert windows_coll['avg_job_duration_seconds'] == 700.0
+
+    # Verify modules_used_per_playbook_total is a dict with 5 entries
+    playbook_modules = events_modules['modules_used_per_playbook_total']
+    assert isinstance(playbook_modules, dict), 'modules_used_per_playbook_total should be a dict'
+    assert len(playbook_modules) == 5, 'Should have 5 playbooks'
+    # Check values sum to expected total
+    total_module_usage = sum(playbook_modules.values())
+    assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
     # ========== Validate Anonymization ==========
     # Check that job template names are hashed (128 character hex strings)
@@ -241,8 +364,33 @@ def test_empty_tarballs_handling(cleanup_test_data):
     # Should not crash, but return empty/default results
     result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
 
+    # Print the result for debugging
+    import json
+
+    json_content = json.dumps(result, indent=4)
+    print('\n=== Empty Tarball Result ===')
+    print(json_content)
+
     # Validate structure exists even with empty data
     assert 'jobs' in result
     assert 'job_host_summary' in result
     assert 'execution_environments' in result
     assert 'events_modules' in result
+
+    # When there's no data, the system returns empty dicts/lists
+    # Verify empty values for jobs
+    assert isinstance(result['jobs'], dict), 'jobs should be a dict (empty when no data)'
+    assert len(result['jobs']) == 0, 'jobs should be empty with no data'
+
+    # Verify empty values for job_host_summary
+    assert isinstance(result['job_host_summary'], list), 'job_host_summary should be a list'
+    assert len(result['job_host_summary']) == 0, 'job_host_summary should be empty with no data'
+
+    # Verify execution_environments is empty dict
+    assert isinstance(result['execution_environments'], dict), 'execution_environments should be a dict'
+    assert len(result['execution_environments']) == 0, 'execution_environments should be empty with no data'
+
+    # Verify events_modules is empty dict
+    events_modules = result['events_modules']
+    assert isinstance(events_modules, dict), 'events_modules should be a dict'
+    assert len(events_modules) == 0, 'events_modules should be empty with no data'

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -28,18 +28,18 @@ from metrics_utility.test.test_anonymized_rollups.test_jobhostsummary_anonymized
 from metrics_utility.test.test_anonymized_rollups.test_jobs_anonymized_rollups import jobs
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def cleanup_test_data():
-    """Clean up test directories before and after test."""
+    """Clean up test directories before and after all tests in this module."""
     out_dir = './out'
 
-    # Cleanup before test
+    # Cleanup before tests
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
 
-    yield  # Run the test
+    yield  # Run all tests
 
-    # Cleanup after test (commented out for debugging)
+    # Cleanup after all tests (commented out for debugging)
     # if os.path.exists(out_dir):
     #     shutil.rmtree(out_dir)
 
@@ -125,7 +125,19 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     # print the result with pretty json
     import json
 
-    print(json.dumps(result, indent=4))
+    json_content = json.dumps(result, indent=4)
+    print(json_content)
+
+    # save the result as json inside rollups/2025/06/13/anonymized.json - based on the year, month, day
+    json_path = f'./out/rollups/{year}/{month:02d}/{day:02d}/anonymized.json'
+
+    # ensure the directory exists
+    os.makedirs(os.path.dirname(json_path), exist_ok=True)
+
+    with open(json_path, 'w') as f:
+        print(f'Saving result to {json_path}')
+        # write result as json to file
+        f.write(json_content)
 
     # ========== Validate the results ==========
 

--- a/metrics_utility/test/test_helpers.py
+++ b/metrics_utility/test/test_helpers.py
@@ -2,6 +2,8 @@
 Unit tests for helper functions.
 """
 
+import pytest
+
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
 
 
@@ -80,7 +82,7 @@ def test_sanitize_json_with_complex_structure():
 
     # Verify NaN and inf are replaced
     assert result['jobs'][0]['avg_duration'] is None
-    assert result['jobs'][1]['avg_duration'] == 120.5
+    assert result['jobs'][1]['avg_duration'] == pytest.approx(120.5)
     assert result['execution_environments']['ratio'] is None
     assert result['events_modules']['module_stats'][0]['count'] is None
     assert result['events_modules']['module_stats'][1]['count'] == 42

--- a/metrics_utility/test/test_helpers.py
+++ b/metrics_utility/test/test_helpers.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for helper functions.
+"""
+
+from metrics_utility.anonymized_rollups.helpers import sanitize_json
+
+
+def test_sanitize_json_with_nan():
+    """Test that NaN values are replaced with None."""
+    obj = {'value': float('nan')}
+    result = sanitize_json(obj)
+    assert result == {'value': None}
+
+
+def test_sanitize_json_with_infinity():
+    """Test that infinity values are replaced with None."""
+    obj = {'pos_inf': float('inf'), 'neg_inf': float('-inf')}
+    result = sanitize_json(obj)
+    assert result == {'pos_inf': None, 'neg_inf': None}
+
+
+def test_sanitize_json_with_list():
+    """Test sanitization of lists with NaN and infinity."""
+    obj = [1, float('nan'), 3, float('inf'), 5]
+    result = sanitize_json(obj)
+    assert result == [1, None, 3, None, 5]
+
+
+def test_sanitize_json_with_nested_dict():
+    """Test sanitization of nested dictionaries."""
+    obj = {'nested': {'value': float('nan'), 'normal': 42}, 'top_level': float('inf')}
+    result = sanitize_json(obj)
+    assert result == {'nested': {'value': None, 'normal': 42}, 'top_level': None}
+
+
+def test_sanitize_json_with_nested_list():
+    """Test sanitization of nested lists."""
+    obj = {'data': [{'value': float('nan')}, {'value': 42}]}
+    result = sanitize_json(obj)
+    assert result == {'data': [{'value': None}, {'value': 42}]}
+
+
+def test_sanitize_json_with_tuple():
+    """Test that tuples are converted to lists and sanitized."""
+    obj = (1, float('nan'), 3)
+    result = sanitize_json(obj)
+    assert result == [1, None, 3]
+
+
+def test_sanitize_json_with_normal_values():
+    """Test that normal values are not modified."""
+    obj = {
+        'string': 'hello',
+        'int': 42,
+        'float': 3.14,
+        'bool': True,
+        'none': None,
+        'list': [1, 2, 3],
+        'dict': {'a': 1, 'b': 2},
+    }
+    result = sanitize_json(obj)
+    assert result == obj
+
+
+def test_sanitize_json_with_complex_structure():
+    """Test sanitization of a complex structure similar to anonymized rollups."""
+    obj = {
+        'jobs': [
+            {'job_template_name': 'T1', 'number_of_jobs_executed': 5, 'avg_duration': float('nan')},
+            {'job_template_name': 'T2', 'number_of_jobs_executed': 3, 'avg_duration': 120.5},
+        ],
+        'execution_environments': {'total_EE': 10, 'ratio': float('inf')},
+        'events_modules': {
+            'modules_used_to_automate_total': 7,
+            'module_stats': [{'module_name': 'debug', 'count': float('nan')}, {'module_name': 'copy', 'count': 42}],
+        },
+    }
+
+    result = sanitize_json(obj)
+
+    # Verify NaN and inf are replaced
+    assert result['jobs'][0]['avg_duration'] is None
+    assert result['jobs'][1]['avg_duration'] == 120.5
+    assert result['execution_environments']['ratio'] is None
+    assert result['events_modules']['module_stats'][0]['count'] is None
+    assert result['events_modules']['module_stats'][1]['count'] == 42
+
+
+def test_sanitize_json_json_serializable():
+    """Test that the result can be serialized to JSON."""
+    import json
+
+    obj = {
+        'value1': float('nan'),
+        'value2': float('inf'),
+        'value3': float('-inf'),
+        'nested': {'value4': float('nan')},
+        'list': [1, float('nan'), 3],
+    }
+
+    result = sanitize_json(obj)
+
+    # This should not raise an exception
+    json_string = json.dumps(result)
+    assert json_string is not None
+
+    # Verify we can parse it back
+    parsed = json.loads(json_string)
+    assert parsed['value1'] is None
+    assert parsed['value2'] is None
+    assert parsed['value3'] is None


### PR DESCRIPTION
[AAP-[57241](https://issues.redhat.com/browse/AAP-57241)]

## Description

This PR changes many things:

1) Jobs that never started are counted and not filtered (for jobs and events rollups)

2) list of modules uset to automate are no longer in statistics (can be computed from overall statistics of modules) - freeing up the space in json

3) hash is shortened in half

4) Events and job host summaries are now done in batches - in prepare function, some pre agggregates are computed. For events, we are looking for occurences of specific events, thus reducing possible reruns into 1 row (except reruns that are scattered through multiple batches, but that is rare).  So the same must be done again on overall data (to group rows that belong to the same task_uuid on specific host and aggregate seen events again.

5) Job host summaries prepare function simply sums up task counts by template in batches - again reduce memory requirements

6) The events data strings are categorized - this does the pandas easily - it can reduce the memory requirements - but this is done after all batches are concatenated (categorization does not work accross different dataframes that are then concatenated). For even more performant categorization (accross batches), we can do some our own implemenation in the future. But since the whole data needs some memory and operations over data too, its good to reduce them as much as possible.

7) Sanitize json - all NaN values are replaced with null (NaN are not valid for json)

8) metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
This is testing reading from multiple dataframes (testing prepare and concatenation), also it produces the final json and asserts.

9) total number of jobs executed is added.

10) Output json is rearranged, so there are not nested objects other than key : object or key : list of objects

Any other required tests that reflect changes are updated.

## Testing

Most important test:
uv run pytest -s metrics_utility/test/test_anonymized_rollups/test_multiple_files.py

This test will create in out/rollups/year/month/day/anonymized.json

The json that can be sent to the ingress.