### PR TITLE
config.json - take version from main_instance only

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Import SQL dump"
         run: |
-          cat tools/docker/{roles,latest,conf_setting,main_hostmetric,main_jobhostsummary}.sql | sudo su - postgres -c psql
+          cat tools/docker/{roles,latest,conf_setting,main_hostmetric,main_instance,main_jobhostsummary}.sql | sudo su - postgres -c psql
 
       - name: "Set up minio"
         env:

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -1,7 +1,7 @@
 import json
 
 from itertools import chain
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import pandas as pd
 
@@ -11,7 +11,7 @@ from django.utils.dateparse import parse_datetime
 from metrics_utility.logger import logger
 
 
-def get_last_entries_from_db() -> Optional[str]:
+def get_last_entries_from_db() -> Dict:
     """
     Get AUTOMATION_ANALYTICS_LAST_ENTRIES directly from database.
 
@@ -45,7 +45,7 @@ def get_config_and_settings_from_db() -> Tuple[Dict[str, Any], Dict[str, Any]]:
                 SELECT key, value
                 FROM conf_setting
                 WHERE key IN ('LICENSE', 'INSTALL_UUID', 'TOWER_URL_BASE',
-                           'SUBSCRIPTION_USAGE_MODEL','VERSION', 'PENDO_TRACKING_STATE','AUTHENTICATION_BACKENDS',
+                           'SUBSCRIPTION_USAGE_MODEL','PENDO_TRACKING_STATE','AUTHENTICATION_BACKENDS',
                            'LOG_AGGREGATOR_LOGGERS',  'SYSTEM_UUID', 'LOG_AGGREGATOR_ENABLED',
                            'LOG_AGGREGATOR_TYPE')
             """)
@@ -64,48 +64,29 @@ def get_config_and_settings_from_db() -> Tuple[Dict[str, Any], Dict[str, Any]]:
     return license_info, settings_info
 
 
-def get_controller_version_from_db() -> str:
-    """
-    Get AWX/Controller version from database.
-    Tries conf_setting table first, then falls back to main_instance table.
+def _fetch_one(db, sql):
+    with db.cursor() as cursor:
+        cursor.execute(sql)
+        result = cursor.fetchone()
+        if result and result[0]:
+            return result[0]
+    return None
 
-    Returns:
-        str: Version string, 'No data found' if not found, or 'Database error' if query fails
-    """
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute("""
-                SELECT value
-                FROM conf_setting
-                WHERE key IN ('AWX_VERSION', 'TOWER_VERSION', 'VERSION')
-                ORDER BY
-                    CASE key
-                        WHEN 'AWX_VERSION' THEN 1
-                        WHEN 'TOWER_VERSION' THEN 2
-                        WHEN 'VERSION' THEN 3
-                    END
-                LIMIT 1
-            """)
-            result = cursor.fetchone()
-            if result and result[0]:
-                return result[0]
-            cursor.execute("""
-                SELECT version
-                FROM main_instance
-                WHERE enabled = true
-                  AND version IS NOT NULL
-                  AND version != ''
-                ORDER BY modified DESC
-                LIMIT 1
-            """)
-            result = cursor.fetchone()
-            if result and result[0]:
-                return result[0]
-    except Exception as e:
-        logger.error(f'Error getting AWX/Controller version from database: {e}')
-        logger.error('Returning "Database error" as fallback for controller version')
-        return 'Database error'
-    return 'No data found'
+
+def get_controller_version_from_db() -> str:
+    """Get AWX/Controller version from the main_instance DB table."""
+    return _fetch_one(
+        connection,
+        """
+        SELECT version
+        FROM main_instance
+        WHERE enabled = true
+            AND version IS NOT NULL
+            AND version != ''
+        ORDER BY last_seen DESC
+        LIMIT 1
+    """,
+    )
 
 
 def datetime_hook(d):

--- a/metrics_utility/test/test_automation_controller_billing_helpers.py
+++ b/metrics_utility/test/test_automation_controller_billing_helpers.py
@@ -22,9 +22,7 @@ class TestGetLicenseInfoFromDb:
         mock_cursor.fetchall.return_value = [
             ('LICENSE', '{"license_type": "enterprise", "product_name": "AWX"}'),
             ('SUBSCRIPTION_NAME', '"Red Hat Ansible Automation Platform"'),
-            ('SKU', '"MCT3718"'),
             ('INSTALL_UUID', '"12345-67890"'),
-            ('VERSION', '"4.7.5"'),  # VERSION is also returned by fetchall
         ]
 
         # Execute
@@ -40,9 +38,7 @@ class TestGetLicenseInfoFromDb:
         # Assert settings info (other fields)
         expected_settings = {
             'subscription_name': 'Red Hat Ansible Automation Platform',
-            'sku': 'MCT3718',
             'install_uuid': '12345-67890',
-            'version': '4.7.5',
         }
         assert settings_info == expected_settings
 
@@ -170,20 +166,19 @@ class TestIntegration:
         mock_cursor.fetchall.return_value = [
             ('LICENSE', '{"license_type": "enterprise"}'),
             ('SUBSCRIPTION_NAME', '"Red Hat AAP"'),
-            ('VERSION', '"4.7.5"'),
+            ('ABC', '"1.2.3"'),
         ]
         mock_cursor.fetchone.return_value = ('{"config": "2024-01-01T00:00:00Z", "jobs": "2024-01-02T00:00:00Z"}',)  # Last entries result
 
         # Execute all functions
         license_info, settings_info = get_config_and_settings_from_db()
-        version = settings_info.get('version')
         entries = get_last_entries_from_db()
 
         # Assert all return expected realistic data
         assert license_info == {
             'license_type': 'enterprise',
         }
-        assert version == '4.7.5'  # Updated to expect product version
+        assert settings_info.get('abc') == '1.2.3'
         # datetime_hook parses datetime strings to datetime objects
         expected_entries = {
             'config': datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -46,7 +46,8 @@ services:
       - ./latest.sql:/docker-entrypoint-initdb.d/init-1-schema.sql
       - ./conf_setting.sql:/docker-entrypoint-initdb.d/init-2-conf_setting.sql
       - ./main_hostmetric.sql:/docker-entrypoint-initdb.d/init-3-main_hostmetric.sql
-      - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-4-main_jobhostsummary.sql
+      - ./main_instance.sql:/docker-entrypoint-initdb.d/init-4-main_instance.sql
+      - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-5-main_jobhostsummary.sql
 
   postgres-wait:
     image: "mirror.gcr.io/postgres"

--- a/tools/docker/main_instance.sql
+++ b/tools/docker/main_instance.sql
@@ -1,0 +1,13 @@
+INSERT INTO main_instance (
+  uuid, hostname,
+  created, modified,
+  version, enabled, node_type, last_seen, node_state,
+  capacity, capacity_adjustment, cpu, memory,
+  cpu_capacity, mem_capacity, managed, managed_by_policy, ip_address, errors
+) VALUES (
+  '00000000-0000-0000-0000-000000000000', 'myaap-controller-task-59777d4bb7-9btjf',
+  '2025-11-04 15:08:04.389978+00', '2025-11-04 15:08:04.390002+00',
+  '4.7.2', 't', 'control', '2025-11-04 15:15:13.602791+00', 'ready',
+  640, 1.0, 8.0, 8::bigint * 1024 * 1024 * 1024,
+  123, 456, 't', 't', '10.244.0.32', ''
+);


### PR DESCRIPTION
Follows #242 

Change `get_controller_version_from_db` to only use the `main_instance` table, or null.

Fixups:

* `get_last_entries_from_db` returns a Dict, adjust type info
* remove mentions of a `VERSION` `conf_setting` entry; and `sku` is part of license info
