### PR TITLE
get_last_entries_from_db: double json decode

### DIFF
--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -29,7 +29,8 @@ def get_last_entries_from_db() -> Dict:
             result = cursor.fetchone()
 
             if result and result[0]:
-                return json.loads(result[0], object_hook=datetime_hook)  # This is the JSON value
+                json_in_json = json.loads(result[0])
+                return json.loads(json_in_json, object_hook=datetime_hook)  # This is the JSON value
     except Exception as e:
         logger.error(f'Error getting AUTOMATION_ANALYTICS_LAST_ENTRIES from database: {e}')
     return {}

--- a/metrics_utility/test/test_automation_controller_billing_helpers.py
+++ b/metrics_utility/test/test_automation_controller_billing_helpers.py
@@ -70,7 +70,7 @@ class TestGetLastEntriesFromDb:
         # Setup
         mock_cursor = MagicMock()
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        test_json = '{"config": "2024-01-01T00:00:00Z", "hosts": "2024-01-03T00:00:00Z", "jobs": "2024-01-02T00:00:00Z"}'
+        test_json = '"{\\"config\\": \\"2024-01-01T00:00:00Z\\", \\"hosts\\": \\"2024-01-03T00:00:00Z\\", \\"jobs\\": \\"2024-01-02T00:00:00Z\\"}"'
         mock_cursor.fetchone.return_value = (test_json,)
         # Execute
         result = get_last_entries_from_db()
@@ -168,7 +168,8 @@ class TestIntegration:
             ('SUBSCRIPTION_NAME', '"Red Hat AAP"'),
             ('ABC', '"1.2.3"'),
         ]
-        mock_cursor.fetchone.return_value = ('{"config": "2024-01-01T00:00:00Z", "jobs": "2024-01-02T00:00:00Z"}',)  # Last entries result
+        test_json = '"{\\"config\\": \\"2024-01-01T00:00:00Z\\", \\"jobs\\": \\"2024-01-02T00:00:00Z\\"}"'  # Last entries result
+        mock_cursor.fetchone.return_value = (test_json,)
 
         # Execute all functions
         license_info, settings_info = get_config_and_settings_from_db()

--- a/tools/docker/conf_setting.sql
+++ b/tools/docker/conf_setting.sql
@@ -6,4 +6,4 @@ INSERT INTO public.conf_setting (created, modified, key, value) VALUES
   (now(), now(), 'INSTALL_UUID', '"00000000-0000-0000-0000-000000000000"'),
   (now(), now(), 'LICENSE', '{"license_type": "UNLICENSED", "product_name": "AWX", "subscription_name": null, "valid_key": false}'),
   (now(), now(), 'TOWER_URL_BASE', '"https://platformhost"'),
-  (now(), now(), 'AUTOMATION_ANALYTICS_LAST_ENTRIES', '{"config": "2024-01-01T10:00:00Z", "jobs": "2024-01-02T15:30:00Z"}');
+  (now(), now(), 'AUTOMATION_ANALYTICS_LAST_ENTRIES', '"{\"config\": \"2024-01-01T10:00:00Z\", \"jobs\": \"2024-01-02T15:30:00Z\"}"');


### PR DESCRIPTION
the settings model json-encodes everything when saving to the db, but we're already passing it a json.dumps output (in `_save_last_gathered_entries`:

> `settings.AUTOMATION_ANALYTICS_LAST_ENTRIES = json.dumps(last_gathered_entries, cls=DjangoJSONEncoder)`

that's how it works for a while now, not changing that, but updating the parser to cope with the double json
and updating mock db accordingly

Fixes:

```
himdel@lorien:~/metrics/metrics-utility$ ./run-ccsp2-gather 
localhost:5432 - accepting connections
Automation Controller modules not found in /awx_devel (AWX_PATH). Using mock and continuing.
Original since-until: None to 2025-11-05 17:12:00.744412+00:00
Final since-until: None to 2025-11-05 17:12:00.744412+00:00
'str' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/himdel/metrics/metrics-utility/metrics_utility/management_utility.py", line 85, in run_subcommand
    self.fetch_command(subcommand).run_from_argv(argv)
  File "/home/himdel/metrics/metrics-utility/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 416, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/himdel/metrics/metrics-utility/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/management/commands/gather_automation_controller_billing_data.py", line 118, in handle
    tgzfiles = collector.gather(since=since, until=until, billing_provider_params=extra_params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/automation_controller_billing/collector.py", line 62, in gather
    self._gather_initialize(dest, subset, since, until)
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collector.py", line 261, in _gather_initialize
    self._create_collections(collectors_subset)
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collector.py", line 480, in _create_collections
    collection = self._create_collection(fnc)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collector.py", line 496, in _create_collection
    collection = CollectionJSON(self, fnc_collecting)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collection_json.py", line 17, in __init__
    super().__init__(collector, func)
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collection.py", line 40, in __init__
    self.last_gathered_entry = self.collector.last_gathered_entry_for(self.key)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/himdel/metrics/metrics-utility/metrics_utility/base/collector.py", line 155, in last_gathered_entry_for
    return self.last_gathered_entries.get(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
Command exited with non-zero status 1
```

Follows: #242 