### PR TITLE
Fix undefined table handling in main_indirectmanagednodeaudit collector

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -8,6 +8,7 @@ from importlib.metadata import version
 from typing import Tuple
 
 import distro
+import psycopg
 
 from django.db import connection
 from django.db.utils import ProgrammingError
@@ -435,7 +436,7 @@ def main_indirectmanagednodeaudit_table(since, full_path, until, **kwargs):
             query=f'COPY ({query}) TO STDOUT WITH CSV HEADER',
             path=full_path,
         )
-    except ProgrammingError as e:
+    except (ProgrammingError, psycopg.errors.UndefinedTable) as e:
         logger.warning(
             'main_indirectmanagednodeaudit table missing in the database schema: %s.'
             ' Falling back to behavior without indirect managed node audit data.',

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -8,7 +8,6 @@ from importlib.metadata import version
 from typing import Tuple
 
 import distro
-import psycopg
 
 from django.db import connection
 from django.db.utils import ProgrammingError
@@ -26,6 +25,14 @@ from metrics_utility.exceptions import MetricsException, MissingRequiredEnvVar
 from metrics_utility.logger import logger, logger_info_level
 
 from .prometheus_client import PrometheusClient
+
+
+try:
+    from psycopg.errors import UndefinedTable
+except ImportError:
+
+    class UndefinedTable(Exception):
+        pass
 
 
 """
@@ -436,7 +443,7 @@ def main_indirectmanagednodeaudit_table(since, full_path, until, **kwargs):
             query=f'COPY ({query}) TO STDOUT WITH CSV HEADER',
             path=full_path,
         )
-    except (ProgrammingError, psycopg.errors.UndefinedTable) as e:
+    except (ProgrammingError, UndefinedTable) as e:
         logger.warning(
             'main_indirectmanagednodeaudit table missing in the database schema: %s.'
             ' Falling back to behavior without indirect managed node audit data.',


### PR DESCRIPTION
depending on the controller/psycopg version, this could be either exception

```
  File "/home/himdel/metrics/metrics-utility/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 266, in copy
    raise ex.with_traceback(None)
psycopg.errors.UndefinedTable: relation "main_indirectmanagednodeaudit" does not exist
LINE 22:                 FROM main_indirectmanagednodeaudit
```

(when running gather with `export METRICS_UTILITY_OPTIONAL_COLLECTORS="main_indirectmanagednodeaudit"` and a DB without it)
