### PR TITLE
METRICS_UTILITY_OPTIONAL_COLLECTORS - remove magic empty string from VALID_COLLECTORS

### DIFF
--- a/metrics_utility/base/utils.py
+++ b/metrics_utility/base/utils.py
@@ -23,4 +23,4 @@ def get_optional_collectors():
     Get the list of optional collectors from environment variable.
     Defaults to 'main_jobevent' if not set.
     """
-    return os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').rstrip(',').split(',')
+    return list(filter(bool, os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').strip(', \t').split(',')))

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -57,7 +57,6 @@ VALID_COLLECTORS = {
     'job_host_summary_service',
     'main_jobevent_service',
     'execution_environments',
-    '',
 }
 
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
@@ -242,13 +241,13 @@ def validate_collectors(errors):
             list of collector names. Defaults to 'main_jobevent' if not set.
 
     Notes:
-        - The set of valid optional collectors is defined by the global variable
-          VALID_COLLECTORS.
-        - Error messages include the invalid collector names and the list of
-          valid values.
+        - The set of valid optional collectors is defined by the global variable VALID_COLLECTORS.
+        - Error messages include the invalid collector names and the list ofvalid values.
     """
 
-    collectors = os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').rstrip(',').split(',')
+    collectors = os.getenv('METRICS_UTILITY_OPTIONAL_COLLECTORS', 'main_jobevent').strip(', \t')
+    if collectors:
+        collectors = collectors.split(',')
     if collectors:
         invalid = set(collectors) - VALID_COLLECTORS
         if invalid:


### PR DESCRIPTION
Mostly just removing a magic `''` from `VALID_COLLECTORS` which was necessary for `METRICS_UTILITY_OPTIONAL_COLLECTORS=""` to work.

(`''.split(',')` becomes `['']` instead of just `[]`, so, applying a bool filter, so that we only get the valid entries)