### PR TITLE
Replace deprecated utcnow

### DIFF
--- a/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
+++ b/metrics_utility/test/renewal_guidance/test_build_spreadsheet_method.py
@@ -65,7 +65,6 @@ def setup_report_renewal_guidance_instance(fixed_now, setup_build_spreadsheet_mo
         patch(patch_target_dataframe_to_rows, new=setup_build_spreadsheet_mocks['mocks_for_instance']['dataframe_to_rows_func']),
     ):
         mock_datetime_module.datetime.now.return_value = fixed_now
-        mock_datetime_module.datetime.utcnow().return_value = fixed_now.replace(tzinfo=None)
         mock_datetime_module.timedelta = dt_actual.timedelta
         mock_datetime_module.timezone = MagicMock(spec=dt_actual.timezone)
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc

--- a/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
+++ b/metrics_utility/test/renewal_guidance/test_renewal_guidance_query_methods.py
@@ -19,7 +19,6 @@ def setup_report_renewal_guidance_instance(fixed_now):
 
     with patch(patch_target) as mock_datetime_module:
         mock_datetime_module.datetime.now.return_value = fixed_now
-        mock_datetime_module.datetime.utcnow.return_value = fixed_now.replace(tzinfo=None)
         mock_datetime_module.timedelta = dt_actual.timedelta
         mock_datetime_module.timezone = MagicMock(spec=dt_actual.timezone)
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc
@@ -93,7 +92,6 @@ def test_renewal_guidance_queries_with_empty_data(fixed_now):
 
     with patch(patch_target) as mock_datetime_module:
         mock_datetime_module.datetime.now.return_value = fixed_now
-        mock_datetime_module.datetime.utcnow.return_value = fixed_now.replace(tzinfo=None)
         mock_datetime_module.timedelta = dt_actual.timedelta
         mock_datetime_module.timezone = MagicMock(spec=dt_actual.timezone)
         mock_datetime_module.timezone.utc = dt_actual.timezone.utc

--- a/testathon/build_and_copy.py
+++ b/testathon/build_and_copy.py
@@ -58,7 +58,7 @@ import os
 import subprocess
 import sys
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from helper_ocp_prepare import create_oc_environs
 
@@ -484,7 +484,7 @@ def main():
                 until_date = until_match.group(1)
             else:
                 # Default until to today's date in UTC when not provided
-                until_date = datetime.utcnow().strftime('%Y-%m-%d')
+                until_date = datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')
 
             # Generate expected report path for since/until
             report_filename = generate_report_filename(effective_env_vars['METRICS_UTILITY_REPORT_TYPE'], since_date, until_date)


### PR DESCRIPTION
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

`utcnow()` is deprecated since 3.12, changing to `now()` with UTC timezone