### PR TITLE
library.instants - add datetime helpers

### DIFF
--- a/metrics_utility/library/README.md
+++ b/metrics_utility/library/README.md
@@ -160,3 +160,28 @@ A rollup is the process of building a dataframe from raw csv files, and saving t
 Reports are predefined classes which take a set of dataframes, along with additional config, and create a XLSX file with a specific report. ReportCCSP, ReportCCSPv2 and ReportRenewalGuidance are implemented.
 
 The xlsx file can again be passed to storage.
+
+
+### Helpers
+
+#### Datetime helpers (`library.instants`)
+
+The `instants` module provides helper functions for working with datetime values. All functions return `datetime.datetime` objects with timezone set to UTC. These helpers are designed to work with the collector convention where `since` is the first moment of the collected interval (inclusive), while `until` is the first moment outside the interval (exclusive).
+
+Available helpers:
+
+* `now()` - current moment in UTC
+* `this_minute()`, `this_hour`, `this_day`, `this_week`, `this_month` - start of the current time period
+* `last_hour(relative_to=this_hour())`, `last_day`, `last_week`, `last_month` - start of the previous time period (relative to the provided datetime or current time)
+* `minutes_ago(n, relative_to=this_minute())`, `hours_ago`, `days_ago`, `weeks_ago`, `months_ago` - start of the time period n periods ago
+* `iso(dt)` - convert datetime to ISO 8601 string format
+
+Example usage:
+
+```python
+from metrics_utility.library.instants import now, days_ago
+
+# Get data for the last 30 days
+since = days_ago(30)
+until = now()
+```

--- a/metrics_utility/library/instants.py
+++ b/metrics_utility/library/instants.py
@@ -1,48 +1,97 @@
 from datetime import datetime, timedelta, timezone
 
-from .debug import log
+
+def now():
+    return datetime.now(tz=timezone.utc)
 
 
-def last_day():
-    log('library.instants last_day')
-    return datetime.now(tz=timezone.utc) - timedelta(days=1)
+def this_minute():
+    """Return the start of the current minute."""
+    return now().replace(second=0, microsecond=0)
+
+
+def this_hour():
+    """Return the start of the current hour."""
+    return now().replace(minute=0, second=0, microsecond=0)
 
 
 def this_day():
-    log('library.instants this_day')
-    return datetime.now(tz=timezone.utc)
-
-
-def last_week():
-    log('library.instants last_week')
-    return datetime.now(tz=timezone.utc) - timedelta(weeks=1)
+    """Return the start of the current day (midnight)."""
+    return now().replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def this_week():
-    log('library.instants this_week')
-    return datetime.now(tz=timezone.utc)
-
-
-def last_month():
-    log('library.instants last_month')
-    return datetime.now(tz=timezone.utc) - timedelta(days=30)
+    """Return the start of the current week (Monday at midnight)."""
+    current = this_day()
+    # weekday() returns 0 for Monday, 6 for Sunday
+    days_since_monday = current.weekday()
+    return current - timedelta(days=days_since_monday)
 
 
 def this_month():
-    log('library.instants this_month')
-    return datetime.now(tz=timezone.utc)
+    """Return the start of the current month (1st day at midnight)."""
+    return now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
 
-def months_ago(months):
-    log('library.instants months_ago')
-    return datetime.now(tz=timezone.utc) - timedelta(days=30 * months)
+def last_hour(relative_to=None):
+    """Return the start of the hour before relative_to (or current hour if not specified)."""
+    return (relative_to or this_hour()) - timedelta(hours=1)
 
 
-def minutes_ago(minutes):
-    log('library.instants minutes_ago')
-    return datetime.now(tz=timezone.utc) - timedelta(minutes=minutes)
+def last_day(relative_to=None):
+    """Return the start of the day before relative_to (or current day if not specified)."""
+    return (relative_to or this_day()) - timedelta(days=1)
 
 
-def now():
-    log('library.instants now')
-    return datetime.now(tz=timezone.utc)
+def last_week(relative_to=None):
+    """Return the start of the week before relative_to (or current week if not specified)."""
+    return (relative_to or this_week()) - timedelta(weeks=1)
+
+
+def last_month(relative_to=None):
+    """Return the start of the month before relative_to (or current month if not specified)."""
+    relative_to = relative_to or this_month()
+    # To get the previous month, we need to handle year boundaries
+    if relative_to.month == 1:
+        return relative_to.replace(year=relative_to.year - 1, month=12)
+    else:
+        return relative_to.replace(month=relative_to.month - 1)
+
+
+def minutes_ago(minutes, relative_to=None):
+    """Return the start of the minute n minutes ago from relative_to (or current minute if not specified)."""
+    return (relative_to or this_minute()) - timedelta(minutes=minutes)
+
+
+def hours_ago(n, relative_to=None):
+    """Return the start of the hour n hours ago from relative_to (or current hour if not specified)."""
+    return (relative_to or this_hour()) - timedelta(hours=n)
+
+
+def days_ago(n, relative_to=None):
+    """Return the start of the day n days ago from relative_to (or current day if not specified)."""
+    return (relative_to or this_day()) - timedelta(days=n)
+
+
+def weeks_ago(n, relative_to=None):
+    """Return the start of the week n weeks ago from relative_to (or current week if not specified)."""
+    return (relative_to or this_week()) - timedelta(weeks=n)
+
+
+def months_ago(months, relative_to=None):
+    """Return the start of the month n months ago from relative_to (or current month if not specified)."""
+    relative_to = relative_to or this_month()
+
+    # Calculate total months from year 0
+    total_months = relative_to.year * 12 + relative_to.month - 1  # -1 because month is 1-indexed
+    total_months -= months
+
+    new_year = total_months // 12
+    new_month = (total_months % 12) + 1  # +1 because month is 1-indexed
+
+    return relative_to.replace(year=new_year, month=new_month)
+
+
+def iso(dt):
+    """Convert a datetime to ISO 8601 string format."""
+    return dt.isoformat()

--- a/metrics_utility/test/library/test_instants.py
+++ b/metrics_utility/test/library/test_instants.py
@@ -1,0 +1,378 @@
+from datetime import datetime, timedelta, timezone
+
+from metrics_utility.library.instants import (
+    days_ago,
+    hours_ago,
+    iso,
+    last_day,
+    last_hour,
+    last_month,
+    last_week,
+    minutes_ago,
+    months_ago,
+    now,
+    this_day,
+    this_hour,
+    this_minute,
+    this_month,
+    this_week,
+    weeks_ago,
+)
+
+
+def test_now_returns_datetime_with_timezone():
+    """Test that now() returns a datetime with timezone set."""
+    result = now()
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+    assert result.tzinfo == timezone.utc
+
+
+def test_this_minute_returns_start_of_minute():
+    """Test that this_minute() returns the start of the current minute."""
+    result = this_minute()
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.second == 0
+    assert result.microsecond == 0
+
+
+def test_this_hour_returns_start_of_hour():
+    """Test that this_hour() returns the start of the current hour."""
+    result = this_hour()
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+
+def test_this_day_returns_start_of_day():
+    """Test that this_day() returns the start of the current day (midnight)."""
+    result = this_day()
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+
+def test_this_week_returns_start_of_week():
+    """Test that this_week() returns the start of the current week (Monday at midnight)."""
+    result = this_week()
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.weekday() == 0  # Monday
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+
+def test_this_month_returns_start_of_month():
+    """Test that this_month() returns the start of the current month (1st at midnight)."""
+    result = this_month()
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.day == 1
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+
+def test_last_hour_without_relative_to():
+    """Test that last_hour() returns the start of the previous hour."""
+    result = last_hour()
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 1 hour before this_hour()
+    expected = this_hour() - timedelta(hours=1)
+    assert result == expected
+
+
+def test_last_hour_with_relative_to():
+    """Test that last_hour() accepts a relative_to parameter."""
+    reference_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    result = last_hour(relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result == datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+
+def test_last_day_without_relative_to():
+    """Test that last_day() returns the start of the previous day."""
+    result = last_day()
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 1 day before this_day()
+    expected = this_day() - timedelta(days=1)
+    assert result == expected
+
+
+def test_last_day_with_relative_to():
+    """Test that last_day() accepts a relative_to parameter."""
+    reference_time = datetime(2025, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+    result = last_day(relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result == datetime(2025, 1, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_last_week_without_relative_to():
+    """Test that last_week() returns the start of the previous week."""
+    result = last_week()
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.weekday() == 0  # Monday
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 1 week before this_week()
+    expected = this_week() - timedelta(weeks=1)
+    assert result == expected
+
+
+def test_last_week_with_relative_to():
+    """Test that last_week() accepts a relative_to parameter."""
+    # Monday, Jan 13, 2025 at midnight
+    reference_time = datetime(2025, 1, 13, 0, 0, 0, tzinfo=timezone.utc)
+    result = last_week(relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be Monday, Jan 6, 2025 at midnight
+    assert result == datetime(2025, 1, 6, 0, 0, 0, tzinfo=timezone.utc)
+    assert result.weekday() == 0  # Monday
+
+
+def test_last_month_without_relative_to():
+    """Test that last_month() returns the start of the previous month."""
+    result = last_month()
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.day == 1
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be the start of the previous month relative to this_month()
+    current_month = this_month()
+    if current_month.month == 1:
+        expected = current_month.replace(year=current_month.year - 1, month=12)
+    else:
+        expected = current_month.replace(month=current_month.month - 1)
+    assert result == expected
+
+
+def test_last_month_with_relative_to():
+    """Test that last_month() accepts a relative_to parameter."""
+    # March 1, 2025 at midnight
+    reference_time = datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+    result = last_month(relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be February 1, 2025 at midnight
+    assert result == datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_last_month_year_boundary():
+    """Test that last_month() correctly handles year boundaries."""
+    # January 1, 2025 at midnight
+    reference_time = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    result = last_month(relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be December 1, 2024 at midnight
+    assert result == datetime(2024, 12, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_hours_ago():
+    """Test that hours_ago(n) returns the start of the hour n hours ago."""
+    result = hours_ago(3)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 3 hours before this_hour()
+    expected = this_hour() - timedelta(hours=3)
+    assert result == expected
+
+
+def test_hours_ago_with_relative_to():
+    """Test that hours_ago(n) accepts a relative_to parameter."""
+    reference_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    result = hours_ago(3, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result == datetime(2025, 1, 15, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def test_days_ago():
+    """Test that days_ago(n) returns the start of the day n days ago."""
+    result = days_ago(5)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 5 days before this_day()
+    expected = this_day() - timedelta(days=5)
+    assert result == expected
+
+
+def test_days_ago_with_relative_to():
+    """Test that days_ago(n) accepts a relative_to parameter."""
+    reference_time = datetime(2025, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+    result = days_ago(5, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result == datetime(2025, 1, 10, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_weeks_ago():
+    """Test that weeks_ago(n) returns the start of the week n weeks ago."""
+    result = weeks_ago(2)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.weekday() == 0  # Monday
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 2 weeks before this_week()
+    expected = this_week() - timedelta(weeks=2)
+    assert result == expected
+
+
+def test_weeks_ago_with_relative_to():
+    """Test that weeks_ago(n) accepts a relative_to parameter."""
+    # Monday, Jan 20, 2025 at midnight
+    reference_time = datetime(2025, 1, 20, 0, 0, 0, tzinfo=timezone.utc)
+    result = weeks_ago(2, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be Monday, Jan 6, 2025 at midnight
+    assert result == datetime(2025, 1, 6, 0, 0, 0, tzinfo=timezone.utc)
+    assert result.weekday() == 0  # Monday
+
+
+def test_months_ago():
+    """Test that months_ago(n) returns the start of the month n months ago."""
+    result = months_ago(2)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.day == 1
+    assert result.hour == 0
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 2 months before this_month()
+    current_month = this_month()
+    # Calculate expected month manually
+    total_months = current_month.year * 12 + current_month.month - 1
+    total_months -= 2
+    expected_year = total_months // 12
+    expected_month = (total_months % 12) + 1
+    expected = current_month.replace(year=expected_year, month=expected_month)
+    assert result == expected
+
+
+def test_months_ago_with_relative_to():
+    """Test that months_ago(n) accepts a relative_to parameter."""
+    # May 1, 2025 at midnight
+    reference_time = datetime(2025, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
+    result = months_ago(2, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be exactly March 1, 2025
+    assert result == datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_months_ago_year_boundary():
+    """Test that months_ago correctly handles year boundaries."""
+    # February 1, 2025 at midnight
+    reference_time = datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+    result = months_ago(3, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    # Should be November 1, 2024
+    assert result == datetime(2024, 11, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_minutes_ago():
+    """Test that minutes_ago(n) returns the start of the minute n minutes ago."""
+    result = minutes_ago(10)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result.second == 0
+    assert result.microsecond == 0
+
+    # Should be exactly 10 minutes before this_minute()
+    expected = this_minute() - timedelta(minutes=10)
+    assert result == expected
+
+
+def test_minutes_ago_with_relative_to():
+    """Test that minutes_ago(n) accepts a relative_to parameter."""
+    reference_time = datetime(2025, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
+    result = minutes_ago(10, relative_to=reference_time)
+
+    assert isinstance(result, datetime)
+    assert result.tzinfo == timezone.utc
+    assert result == datetime(2025, 1, 15, 12, 20, 0, tzinfo=timezone.utc)
+
+
+def test_iso_converts_datetime_to_string():
+    """Test that iso() converts a datetime to ISO 8601 string."""
+    dt = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+    result = iso(dt)
+
+    assert isinstance(result, str)
+    assert result == '2025-01-15T12:30:45+00:00'
+
+
+def test_iso_preserves_timezone():
+    """Test that iso() preserves timezone information in the output."""
+    dt = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+    result = iso(dt)
+
+    # The ISO string should contain timezone information
+    assert '+00:00' in result or 'Z' in result or result.endswith('+00:00')


### PR DESCRIPTION
Issue: AAP-55190

Adds a couple of datetime helpers:

* `now()` - current moment in UTC
* `this_minute()`, `this_hour`, `this_day`, `this_week`, `this_month` - start of the current time period
* `last_hour(relative_to=this_hour())`, `last_day`, `last_week`, `last_month` - start of the previous time period (relative to the provided datetime or current time)
* `minutes_ago(n, relative_to=this_minute())`, `hours_ago`, `days_ago`, `weeks_ago`, `months_ago` - start of the time period n periods ago
* `iso(dt)` - convert datetime to ISO 8601 string format

Example usage:

```python
from metrics_utility.library.instants import now, days_ago

# Get data for the last 30 days
since = days_ago(30)
until = now()
```