### PR TITLE
AAP-58418: Add connection param to anonymized

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -176,26 +176,26 @@ def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs
     return data
 
 
-def compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, base_path, save_rollups: bool = True):
+def compute_anonymized_rollup_from_raw_data(input_data, salt, since, until, base_path, save_rollups: bool = True):
     jobs = load_anonymized_rollup_data(JobsAnonymizedRollup(), input_data['unified_jobs'])
     jobs_result = JobsAnonymizedRollup().base(jobs)
     if save_rollups:
-        JobsAnonymizedRollup().save_rollup(jobs_result['rollup'], base_path, year, month, day)
+        JobsAnonymizedRollup().save_rollup(jobs_result['rollup'], base_path, since, until)
 
     job_host_summary = load_anonymized_rollup_data(JobHostSummaryAnonymizedRollup(), input_data['job_host_summary'])
     job_host_summary_result = JobHostSummaryAnonymizedRollup().base(job_host_summary)
     if save_rollups:
-        JobHostSummaryAnonymizedRollup().save_rollup(job_host_summary_result['rollup'], base_path, year, month, day)
+        JobHostSummaryAnonymizedRollup().save_rollup(job_host_summary_result['rollup'], base_path, since, until)
 
     events_modules = load_anonymized_rollup_data(EventModulesAnonymizedRollup(), input_data['main_jobevent'])
     events_modules_result = EventModulesAnonymizedRollup().base(events_modules)
     if save_rollups:
-        EventModulesAnonymizedRollup().save_rollup(events_modules_result['rollup'], base_path, year, month, day)
+        EventModulesAnonymizedRollup().save_rollup(events_modules_result['rollup'], base_path, since, until)
 
     execution_environments = load_anonymized_rollup_data(ExecutionEnvironmentsAnonymizedRollup(), input_data['execution_environments'])
     execution_environments_result = ExecutionEnvironmentsAnonymizedRollup().base(execution_environments)
     if save_rollups:
-        ExecutionEnvironmentsAnonymizedRollup().save_rollup(execution_environments_result['rollup'], base_path, year, month, day)
+        ExecutionEnvironmentsAnonymizedRollup().save_rollup(execution_environments_result['rollup'], base_path, since, until)
 
     anonymized_rollup = anonymize_rollups(
         events_modules_result['json'], execution_environments_result['json'], jobs_result['json'], job_host_summary_result['json'], salt

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -1,6 +1,4 @@
-import glob
 import hashlib
-import tarfile
 
 from typing import Any, Dict, List
 
@@ -211,7 +209,7 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, 
 # inside tarball is file named {collector_name}.csv
 # this goes to dataframe, then filter_function is applied to the dataframe
 # all result dataframes are concatenated into one dataframe
-def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, file_list : []) -> DataFrame:
+def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, file_list: []) -> DataFrame:
     # file_list - list of csv files that needs to be read
 
     concat_dataframe = pd.DataFrame()

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -178,29 +178,29 @@ def anonymize_rollups(events_modules_rollup, execution_environments_rollup, jobs
     return data
 
 
-def compute_anonymized_rollup_from_raw_data(salt, year, month, day, base_path, save_rollups: bool = True):
-    jobs = load_anonymized_rollup_data(JobsAnonymizedRollup(), base_path, year, month, day)
+def compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, base_path, save_rollups: bool = True):
+    jobs = load_anonymized_rollup_data(JobsAnonymizedRollup(), input_data['unified_jobs'])
     jobs_result = JobsAnonymizedRollup().base(jobs)
     if save_rollups:
         JobsAnonymizedRollup().save_rollup(jobs_result['rollup'], base_path, year, month, day)
 
-    job_host_summary = load_anonymized_rollup_data(JobHostSummaryAnonymizedRollup(), base_path, year, month, day)
+    job_host_summary = load_anonymized_rollup_data(JobHostSummaryAnonymizedRollup(), input_data['job_host_summary'])
     job_host_summary_result = JobHostSummaryAnonymizedRollup().base(job_host_summary)
     if save_rollups:
         JobHostSummaryAnonymizedRollup().save_rollup(job_host_summary_result['rollup'], base_path, year, month, day)
 
-    events_modules = load_anonymized_rollup_data(EventModulesAnonymizedRollup(), base_path, year, month, day)
+    events_modules = load_anonymized_rollup_data(EventModulesAnonymizedRollup(), input_data['main_jobevent'])
     events_modules_result = EventModulesAnonymizedRollup().base(events_modules)
     if save_rollups:
         EventModulesAnonymizedRollup().save_rollup(events_modules_result['rollup'], base_path, year, month, day)
 
-    execution_environments = load_anonymized_rollup_data(ExecutionEnvironmentsAnonymizedRollup(), base_path, year, month, day)
+    execution_environments = load_anonymized_rollup_data(ExecutionEnvironmentsAnonymizedRollup(), input_data['execution_environments'])
     execution_environments_result = ExecutionEnvironmentsAnonymizedRollup().base(execution_environments)
     if save_rollups:
         ExecutionEnvironmentsAnonymizedRollup().save_rollup(execution_environments_result['rollup'], base_path, year, month, day)
 
     anonymized_rollup = anonymize_rollups(
-        events_modules_result['json'], execution_environments_result['json'], jobs_result['json'], job_host_summary_result['json'], 'salt'
+        events_modules_result['json'], execution_environments_result['json'], jobs_result['json'], job_host_summary_result['json'], salt
     )
     # Sanitize the result to replace NaN and infinity values with None (valid JSON)
     anonymized_rollup = sanitize_json(anonymized_rollup)
@@ -211,26 +211,14 @@ def compute_anonymized_rollup_from_raw_data(salt, year, month, day, base_path, s
 # inside tarball is file named {collector_name}.csv
 # this goes to dataframe, then filter_function is applied to the dataframe
 # all result dataframes are concatenated into one dataframe
-def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, base_path: str, year: int, month: int, day: int) -> DataFrame:
-    # list all tarballs in base_path/data/year/month/day/*{collector_name}*.tar.gz
+def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, file_list : []) -> DataFrame:
+    # file_list - list of csv files that needs to be read
 
-    collection_names = rollup_object.collector_names
-
-    tarballs = []
-    for collection_name in collection_names:
-        tarballs2 = glob.glob(f'{base_path}/data/{year}/{month:02d}/{day:02d}/*{collection_name}*.tar.gz')
-        tarballs.extend(tarballs2)
-
-    # load each tarball into a dataframe
     concat_dataframe = pd.DataFrame()
 
-    for tarball in tarballs:
-        with tarfile.open(tarball, 'r') as tar:
-            for member in tar.getmembers():
-                if member.name.endswith(f'{collection_name}.csv'):
-                    df = pd.read_csv(tar.extractfile(member))
-
-                    df = rollup_object.prepare(df)
-                    concat_dataframe = rollup_object.merge(concat_dataframe, df)
+    for file in file_list:
+        df = pd.read_csv(file)
+        df = rollup_object.prepare(df)
+        concat_dataframe = rollup_object.merge(concat_dataframe, df)
 
     return concat_dataframe

--- a/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
@@ -3,6 +3,8 @@ import json
 import os
 import tarfile
 
+from datetime import datetime
+
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
@@ -26,7 +28,7 @@ class BaseAnonymizedRollup:
     def base(self, dataframe):
         return pd.DataFrame()
 
-    def save_rollup(self, rollup_data: dict, base_path: str, year: int, month: int, day: int) -> None:
+    def save_rollup(self, rollup_data: dict, base_path: str, since: datetime, until: datetime) -> None:
         # rollup data is dictionary
         # the dictionary can have those values:
         # scalar, list, pandas.Series, pandas.DataFrame
@@ -36,6 +38,11 @@ class BaseAnonymizedRollup:
         # file will be stored inside base_path/rollups/rollup_name/year/month/day
 
         # make sure year is 4 digits, month is 2 digits, day is 2 digits
+
+        year = since.year
+        month = since.month
+        day = since.day
+
         year = str(year).zfill(4)
         month = str(month).zfill(2)
         day = str(day).zfill(2)
@@ -47,7 +54,8 @@ class BaseAnonymizedRollup:
         tar_files = {}
 
         for key, value in rollup_data.items():
-            filename = key + '_' + str(year) + '_' + str(month) + '_' + str(day)
+            # filename is key + since + until, month and day are 2 digits
+            filename = key + '_' + since.strftime('%Y-%m-%d') + '_' + until.strftime('%Y-%m-%d')
 
             if isinstance(value, pd.DataFrame):
                 # Save CSV to tarball instead of filesystem

--- a/metrics_utility/anonymized_rollups/compute_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/compute_anonymized_rollup.py
@@ -4,7 +4,7 @@ from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonym
 from metrics_utility.library.collectors.controller import execution_environments, job_host_summary_service, main_jobevent_service, unified_jobs
 
 
-def task_anonymized_rollups(db, salt, since, until, ship_path, save_rollups: bool = True):
+def compute_anonymized_rollup(db, salt, since, until, ship_path, save_rollups: bool = True):
     # This will contain list of files that belongs to particular collector
     execution_environments_data = execution_environments(db=db).gather()
     unified_jobs_data = unified_jobs(db=db, since=since, until=until).gather()

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
 
@@ -6,15 +5,12 @@ from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonym
 from metrics_utility.library.collectors.controller import execution_environments, job_host_summary_service, main_jobevent_service, unified_jobs
 
 
-def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups: bool = True):
-    datetime_since = datetime(year, month, day)
-    datetime_until = datetime_since + timedelta(days=1)
-
+def task_anonymized_rollups(db, salt, since, until, ship_path, save_rollups: bool = True):
     # This will contain list of files that belongs to particular collector
     execution_environments_data = execution_environments(db=db).gather()
-    unified_jobs_data = unified_jobs(db=db, since=datetime_since, until=datetime_until).gather()
-    job_host_summary_data = job_host_summary_service(db=db, since=datetime_since, until=datetime_until).gather()
-    main_jobevent_data = main_jobevent_service(db=db, since=datetime_since, until=datetime_until).gather()
+    unified_jobs_data = unified_jobs(db=db, since=since, until=until).gather()
+    job_host_summary_data = job_host_summary_service(db=db, since=since, until=until).gather()
+    main_jobevent_data = main_jobevent_service(db=db, since=since, until=until).gather()
 
     input_data = {
         'execution_environments': execution_environments_data,
@@ -24,6 +20,6 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     }
 
     # load data for each collector
-    json_data = compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, ship_path, save_rollups)
+    json_data = compute_anonymized_rollup_from_raw_data(input_data, salt, since, until, ship_path, save_rollups)
 
     return json_data

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -18,10 +18,10 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     datetime_since = datetime(year, month, day)
     datetime_until = datetime_since + timedelta(days=1)
 
-    execution_environments_data = execution_environments(db, since=datetime_since, until=datetime_until)
-    unified_jobs_data = unified_jobs(db, since=datetime_since, until=datetime_until)
-    job_host_summary_data = job_host_summary_service(db, since=datetime_since, until=datetime_until)
-    main_jobevent_data = main_jobevent_service(db, since=datetime_since, until=datetime_until)
+    execution_environments_data = execution_environments(db=db).gather()
+    unified_jobs_data = unified_jobs(db=db, since=datetime_since, until=datetime_until).gather()
+    job_host_summary_data = job_host_summary_service(db=db, since=datetime_since, until=datetime_until).gather()
+    main_jobevent_data = main_jobevent_service(db=db, since=datetime_since, until=datetime_until).gather()
 
     print(execution_environments_data)
     print(unified_jobs_data)

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
 #from metrics_utility.test.util import run_gather_int
 
-from metrics_utility.library.collectors import execution_environments, unified_jobs, job_host_summary_service, main_jobevent_service
+from metrics_utility.library.collectors.controller import execution_environments, unified_jobs, job_host_summary_service, main_jobevent_service
 
 def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups: bool = True):
     '''

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -25,11 +25,6 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     job_host_summary_data = job_host_summary_service(db=db, since=datetime_since, until=datetime_until).gather()
     main_jobevent_data = main_jobevent_service(db=db, since=datetime_since, until=datetime_until).gather()
 
-    print(execution_environments_data)
-    print(unified_jobs_data)
-    print(job_host_summary_data)
-    print(main_jobevent_data)
-
     input_data = {
         'execution_environments': execution_environments_data,
         'unified_jobs': unified_jobs_data,

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -1,4 +1,3 @@
-
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
 
 # from metrics_utility.test.util import run_gather_int

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -1,26 +1,42 @@
 from datetime import datetime, timedelta
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
-from metrics_utility.test.util import run_gather_int
+#from metrics_utility.test.util import run_gather_int
 
+from metrics_utility.library.collectors import execution_environments, unified_jobs, job_host_summary_service, main_jobevent_service
 
-def task_anonymized_rollups(salt, year, month, day, ship_path, save_rollups: bool = True):
+def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups: bool = True):
+    '''
     env_vars = {
         'METRICS_UTILITY_SHIP_PATH': ship_path,
         'METRICS_UTILITY_SHIP_TARGET': 'directory',
         'METRICS_UTILITY_OPTIONAL_COLLECTORS': 'main_jobevent_service,execution_environments,unified_jobs,job_host_summary_service',
         'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': 'true',
     }
+    '''
 
     datetime_since = datetime(year, month, day)
     datetime_until = datetime_since + timedelta(days=1)
 
-    since_param = datetime_since.strftime('%Y-%m-%d')
-    until_param = datetime_until.strftime('%Y-%m-%d')
+    execution_environments_data = execution_environments(db, since=datetime_since, until=datetime_until)
+    unified_jobs_data = unified_jobs(db, since=datetime_since, until=datetime_until)
+    job_host_summary_data = job_host_summary_service(db, since=datetime_since, until=datetime_until)
+    main_jobevent_data = main_jobevent_service(db, since=datetime_since, until=datetime_until)
 
-    run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
+    print(execution_environments_data)
+    print(unified_jobs_data)
+    print(job_host_summary_data)
+    print(main_jobevent_data)
+
+    #since_param = datetime_since.strftime('%Y-%m-%d')
+    #until_param = datetime_until.strftime('%Y-%m-%d')
+
+    #run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
+
+    # run gather from collectors in library
 
     # load data for each collector
-    json_data = compute_anonymized_rollup_from_raw_data(salt, year, month, day, ship_path, save_rollups)
+    #json_data = compute_anonymized_rollup_from_raw_data(salt, year, month, day, ship_path, save_rollups)
 
-    return json_data
+    #return json_data
+    return {}

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -7,15 +7,6 @@ from metrics_utility.library.collectors.controller import execution_environments
 
 
 def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups: bool = True):
-    """
-    env_vars = {
-        'METRICS_UTILITY_SHIP_PATH': ship_path,
-        'METRICS_UTILITY_SHIP_TARGET': 'directory',
-        'METRICS_UTILITY_OPTIONAL_COLLECTORS': 'main_jobevent_service,execution_environments,unified_jobs,job_host_summary_service',
-        'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': 'true',
-    }
-    """
-
     datetime_since = datetime(year, month, day)
     datetime_until = datetime_since + timedelta(days=1)
 
@@ -31,13 +22,6 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
         'job_host_summary': job_host_summary_data,
         'main_jobevent': main_jobevent_data,
     }
-
-    # since_param = datetime_since.strftime('%Y-%m-%d')
-    # until_param = datetime_until.strftime('%Y-%m-%d')
-
-    # run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
-
-    # run gather from collectors in library
 
     # load data for each collector
     json_data = compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, ship_path, save_rollups)

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -1,19 +1,20 @@
 from datetime import datetime, timedelta
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
-#from metrics_utility.test.util import run_gather_int
 
-from metrics_utility.library.collectors.controller import execution_environments, unified_jobs, job_host_summary_service, main_jobevent_service
+# from metrics_utility.test.util import run_gather_int
+from metrics_utility.library.collectors.controller import execution_environments, job_host_summary_service, main_jobevent_service, unified_jobs
+
 
 def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups: bool = True):
-    '''
+    """
     env_vars = {
         'METRICS_UTILITY_SHIP_PATH': ship_path,
         'METRICS_UTILITY_SHIP_TARGET': 'directory',
         'METRICS_UTILITY_OPTIONAL_COLLECTORS': 'main_jobevent_service,execution_environments,unified_jobs,job_host_summary_service',
         'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': 'true',
     }
-    '''
+    """
 
     datetime_since = datetime(year, month, day)
     datetime_until = datetime_since + timedelta(days=1)
@@ -36,10 +37,10 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
         'main_jobevent': main_jobevent_data,
     }
 
-    #since_param = datetime_since.strftime('%Y-%m-%d')
-    #until_param = datetime_until.strftime('%Y-%m-%d')
+    # since_param = datetime_since.strftime('%Y-%m-%d')
+    # until_param = datetime_until.strftime('%Y-%m-%d')
 
-    #run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
+    # run_gather_int(env_vars, {'ship': True, 'force': True, 'since': since_param, 'until': until_param})
 
     # run gather from collectors in library
 

--- a/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/task_anonymized_rollups.py
@@ -18,6 +18,7 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     datetime_since = datetime(year, month, day)
     datetime_until = datetime_since + timedelta(days=1)
 
+    # This will contain list of files that belongs to particular collector
     execution_environments_data = execution_environments(db=db).gather()
     unified_jobs_data = unified_jobs(db=db, since=datetime_since, until=datetime_until).gather()
     job_host_summary_data = job_host_summary_service(db=db, since=datetime_since, until=datetime_until).gather()
@@ -28,6 +29,13 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     print(job_host_summary_data)
     print(main_jobevent_data)
 
+    input_data = {
+        'execution_environments': execution_environments_data,
+        'unified_jobs': unified_jobs_data,
+        'job_host_summary': job_host_summary_data,
+        'main_jobevent': main_jobevent_data,
+    }
+
     #since_param = datetime_since.strftime('%Y-%m-%d')
     #until_param = datetime_until.strftime('%Y-%m-%d')
 
@@ -36,7 +44,6 @@ def task_anonymized_rollups(db, salt, year, month, day, ship_path, save_rollups:
     # run gather from collectors in library
 
     # load data for each collector
-    #json_data = compute_anonymized_rollup_from_raw_data(salt, year, month, day, ship_path, save_rollups)
+    json_data = compute_anonymized_rollup_from_raw_data(input_data, salt, year, month, day, ship_path, save_rollups)
 
-    #return json_data
-    return {}
+    return json_data

--- a/metrics_utility/library/anonymize/anonymized_rollups_processor.py
+++ b/metrics_utility/library/anonymize/anonymized_rollups_processor.py
@@ -1,0 +1,7 @@
+# call compute_anonymized_rollup
+
+from metrics_utility.anonymized_rollups.compute_anonymized_rollup import compute_anonymized_rollup
+
+
+def anonymized_rollups_processor(db, salt, since, until, ship_path, save_rollups: bool = True):
+    return compute_anonymized_rollup(db, salt, since, until, ship_path, save_rollups)

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -47,7 +47,7 @@ def test_from_gather_to_json(cleanup_glob):
     since = datetime(2025, 6, 13, 0, 0, 0)
     until = datetime(2025, 6, 14, 0, 0, 0)
 
-    # run gather
+    # runher
     # here what the connection should be? The postgres is in docker compose
     db = connection
     json_data = task_anonymized_rollups(db, 'salt', since, until, './out', save_rollups=False)
@@ -225,3 +225,32 @@ def test_from_gather_to_json(cleanup_glob):
         )
 
     print('✅ All data value assertions passed!')
+
+
+def test_half_day_rollup(cleanup_glob):
+    """Test with half-day time range: from midnight to noon"""
+    # since = beginning of the day
+    # until = half of the day (noon)
+    since = datetime(2025, 6, 13, 0, 0, 0)
+    until = datetime(2025, 6, 13, 12, 0, 0)
+
+    # Get the data from the database
+    db = connection
+    json_data = task_anonymized_rollups(db, 'salt', since, until, './out', save_rollups=False)
+
+    print('\n========== Half-Day Rollup JSON Data ==========')
+    print(json.dumps(json_data, indent=4))
+    print('================================================\n')
+
+    # Save as json for inspection
+    json_path = (
+        f'./out/rollups/{since.year}/{since.month}/{since.day}/anonymized_{since.strftime("%Y-%m-%d")}_{until.strftime("%Y-%m-%d-%H-%M")}.json'
+    )
+
+    # Create the directory
+    os.makedirs(os.path.dirname(json_path), exist_ok=True)
+
+    with open(json_path, 'w') as f:
+        json.dump(json_data, f, indent=4)
+
+    print(f'JSON saved to: {json_path}')

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -32,7 +32,8 @@ def test_empty_data(cleanup_glob):
 
 def test_from_gather_to_json(cleanup_glob):
     # run gather
-    json_data = task_anonymized_rollups('salt', 2025, 6, 13, './out', save_rollups=False)
+    db = 
+    json_data = task_anonymized_rollups(db, 'salt', 2025, 6, 13, './out', save_rollups=False)
 
     print(json_data)
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 import pytest
+from django.db import connection
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
 from metrics_utility.anonymized_rollups.task_anonymized_rollups import task_anonymized_rollups
@@ -32,7 +33,8 @@ def test_empty_data(cleanup_glob):
 
 def test_from_gather_to_json(cleanup_glob):
     # run gather
-    db = 
+    # here what the connection should be? The postgres is in docker compose
+    db = connection
     json_data = task_anonymized_rollups(db, 'salt', 2025, 6, 13, './out', save_rollups=False)
 
     print(json_data)

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -28,7 +28,7 @@ def cleanup_glob():
 
 
 def test_empty_data(cleanup_glob):
-    compute_anonymized_rollup_from_raw_data('salt', 2025, 6, 13, './out')
+    compute_anonymized_rollup_from_raw_data({'unified_jobs': [], 'job_host_summary': [], 'main_jobevent': [], 'execution_environments': []}, 'salt', 2025, 6, 13, './out')
 
 
 def test_from_gather_to_json(cleanup_glob):

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -254,3 +254,21 @@ def test_half_day_rollup(cleanup_glob):
         json.dump(json_data, f, indent=4)
 
     print(f'JSON saved to: {json_path}')
+
+    # Basic assertions - just validate structure
+    assert 'statistics' in json_data, "Missing 'statistics' in json_data"
+    assert 'module_stats' in json_data, "Missing 'module_stats' in json_data"
+    assert 'collection_name_stats' in json_data, "Missing 'collection_name_stats' in json_data"
+    assert 'modules_used_per_playbook' in json_data, "Missing 'modules_used_per_playbook' in json_data"
+    assert 'jobs_by_template' in json_data, "Missing 'jobs_by_template' in json_data"
+    assert 'job_host_summary' in json_data, "Missing 'job_host_summary' in json_data"
+
+    # Validate basic types
+    assert isinstance(json_data['statistics'], dict), 'statistics should be a dictionary'
+    assert isinstance(json_data['module_stats'], list), 'module_stats should be a list'
+    assert isinstance(json_data['collection_name_stats'], list), 'collection_name_stats should be a list'
+    assert isinstance(json_data['modules_used_per_playbook'], list), 'modules_used_per_playbook should be a list'
+    assert isinstance(json_data['jobs_by_template'], list), 'jobs_by_template should be a list'
+    assert isinstance(json_data['job_host_summary'], list), 'job_host_summary should be a list'
+
+    print('✅ Basic structure assertions passed!')

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 import pytest
+
 from django.db import connection
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
@@ -28,7 +29,9 @@ def cleanup_glob():
 
 
 def test_empty_data(cleanup_glob):
-    compute_anonymized_rollup_from_raw_data({'unified_jobs': [], 'job_host_summary': [], 'main_jobevent': [], 'execution_environments': []}, 'salt', 2025, 6, 13, './out')
+    compute_anonymized_rollup_from_raw_data(
+        {'unified_jobs': [], 'job_host_summary': [], 'main_jobevent': [], 'execution_environments': []}, 'salt', 2025, 6, 13, './out'
+    )
 
 
 def test_from_gather_to_json(cleanup_glob):

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -9,7 +9,7 @@ import pytest
 from django.db import connection
 
 from metrics_utility.anonymized_rollups.anonymized_rollups import compute_anonymized_rollup_from_raw_data
-from metrics_utility.anonymized_rollups.task_anonymized_rollups import task_anonymized_rollups
+from metrics_utility.anonymized_rollups.compute_anonymized_rollup import compute_anonymized_rollup
 
 
 # where to find the tar.gz (match jobhostsummary test layout)
@@ -50,7 +50,7 @@ def test_from_gather_to_json(cleanup_glob):
     # runher
     # here what the connection should be? The postgres is in docker compose
     db = connection
-    json_data = task_anonymized_rollups(db, 'salt', since, until, './out', save_rollups=False)
+    json_data = compute_anonymized_rollup(db, 'salt', since, until, './out', save_rollups=False)
 
     print(json_data)
 
@@ -236,7 +236,7 @@ def test_half_day_rollup(cleanup_glob):
 
     # Get the data from the database
     db = connection
-    json_data = task_anonymized_rollups(db, 'salt', since, until, './out', save_rollups=False)
+    json_data = compute_anonymized_rollup(db, 'salt', since, until, './out', save_rollups=False)
 
     print('\n========== Half-Day Rollup JSON Data ==========')
     print(json.dumps(json_data, indent=4))

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -2,6 +2,8 @@ import json
 import os
 import shutil
 
+from datetime import datetime
+
 import pytest
 
 from django.db import connection
@@ -29,21 +31,31 @@ def cleanup_glob():
 
 
 def test_empty_data(cleanup_glob):
+    # since = begining of the day
+    # until = begining of the next day
+    since = datetime(2025, 6, 13, 0, 0, 0)
+    until = datetime(2025, 6, 14, 0, 0, 0)
+
     compute_anonymized_rollup_from_raw_data(
-        {'unified_jobs': [], 'job_host_summary': [], 'main_jobevent': [], 'execution_environments': []}, 'salt', 2025, 6, 13, './out'
+        {'unified_jobs': [], 'job_host_summary': [], 'main_jobevent': [], 'execution_environments': []}, 'salt', since, until, './out'
     )
 
 
 def test_from_gather_to_json(cleanup_glob):
+    # since = begining of the day
+    # until = begining of the next day
+    since = datetime(2025, 6, 13, 0, 0, 0)
+    until = datetime(2025, 6, 14, 0, 0, 0)
+
     # run gather
     # here what the connection should be? The postgres is in docker compose
     db = connection
-    json_data = task_anonymized_rollups(db, 'salt', 2025, 6, 13, './out', save_rollups=False)
+    json_data = task_anonymized_rollups(db, 'salt', since, until, './out', save_rollups=False)
 
     print(json_data)
 
     # save as json inside rollups/2025/06/13/anonymized.json
-    json_path = f'./out/rollups/{2025}/06/13/anonymized.json'
+    json_path = f'./out/rollups/{since.year}/{since.month}/{since.day}/anonymized_{since.strftime("%Y-%m-%d")}_{until.strftime("%Y-%m-%d")}.json'
 
     # create the dir
     os.makedirs(os.path.dirname(json_path), exist_ok=True)

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -56,7 +56,7 @@ def create_csv_file(data_list, csv_path):
     Args:
         data_list: List of dictionaries to convert to CSV
         csv_path: Path where to save the CSV file
-    
+
     Returns:
         The path to the created CSV file, or None if data_list is empty
     """
@@ -70,7 +70,7 @@ def create_csv_file(data_list, csv_path):
     # Convert list of dicts to DataFrame then to CSV
     df = pd.DataFrame(data_list)
     df.to_csv(csv_path, index=False)
-    
+
     return csv_path
 
 
@@ -162,13 +162,7 @@ def test_multiple_csv_files_concatenation(cleanup_test_data):
     }
 
     result = compute_anonymized_rollup_from_raw_data(
-        input_data=input_data,
-        salt='test_salt',
-        year=year,
-        month=month,
-        day=day,
-        base_path=base_path,
-        save_rollups=False
+        input_data=input_data, salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False
     )
 
     # print the result with pretty json
@@ -376,13 +370,7 @@ def test_empty_csv_files_handling(cleanup_test_data):
 
     # Should not crash, but return empty/default results
     result = compute_anonymized_rollup_from_raw_data(
-        input_data=input_data,
-        salt='test_salt',
-        year=year,
-        month=month,
-        day=day,
-        base_path=base_path,
-        save_rollups=False
+        input_data=input_data, salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False
     )
 
     # Print the result for debugging

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -360,8 +360,11 @@ def test_empty_csv_files_handling(cleanup_test_data):
     """
     Test that the system handles case with no CSV files gracefully.
     """
+
     base_path = './out'
-    year, month, day = 2025, 6, 14
+    since = datetime(2025, 6, 13, 0, 0, 0)
+    until = datetime(2025, 6, 14, 0, 0, 0)
+    year, month, day = since.year, since.month, since.day
     data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
 
     # Create the directory but don't create any CSV files
@@ -378,7 +381,7 @@ def test_empty_csv_files_handling(cleanup_test_data):
 
     # Should not crash, but return empty/default results
     result = compute_anonymized_rollup_from_raw_data(
-        input_data=input_data, salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False
+        input_data=input_data, salt='test_salt', since=since, until=until, base_path=base_path, save_rollups=False
     )
 
     # Print the result for debugging

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -1,11 +1,11 @@
 """
-This test verifies that data split into multiple tarballs is correctly concatenated.
-It tests the logic for loading and merging dataframes from multiple tarball files.
+This test verifies that data split into multiple CSV files is correctly concatenated.
+It tests the logic for loading and merging dataframes from multiple CSV files.
 
 The test:
 1. Takes data from other test files (jobs, events, execution_environments, jobhostsummary)
-2. Splits each dataset into 2-3 separate tarballs
-3. Creates tarball files with CSV data inside
+2. Splits each dataset into 2-3 separate CSV files
+3. Creates CSV files with the split data
 4. Tests that compute_anonymized_rollup_from_raw_data properly loads and concatenates the data
 5. Validates the final output matches expected aggregated results
 
@@ -20,9 +20,6 @@ Enhanced Assertions:
 
 import os
 import shutil
-import tarfile
-
-from io import BytesIO
 
 import pandas as pd
 import pytest
@@ -52,40 +49,36 @@ def cleanup_test_data():
     #     shutil.rmtree(out_dir)
 
 
-def create_tarball_with_csv(data_list, csv_filename, tarball_path):
+def create_csv_file(data_list, csv_path):
     """
-    Create a tarball containing a single CSV file.
+    Create a CSV file from a list of dictionaries.
 
     Args:
         data_list: List of dictionaries to convert to CSV
-        csv_filename: Name of the CSV file inside the tarball
-        tarball_path: Path where to save the tarball
+        csv_path: Path where to save the CSV file
+    
+    Returns:
+        The path to the created CSV file, or None if data_list is empty
     """
     # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(tarball_path), exist_ok=True)
+    os.makedirs(os.path.dirname(csv_path), exist_ok=True)
 
-    # Skip creating tarballs for empty data
+    # Skip creating CSV for empty data
     if not data_list:
-        return
+        return None
 
     # Convert list of dicts to DataFrame then to CSV
     df = pd.DataFrame(data_list)
-    csv_buffer = BytesIO()
-    df.to_csv(csv_buffer, index=False)
-    csv_buffer.seek(0)
-
-    # Create tarball with the CSV file inside
-    with tarfile.open(tarball_path, 'w:gz') as tar:
-        tarinfo = tarfile.TarInfo(name=csv_filename)
-        tarinfo.size = len(csv_buffer.getvalue())
-        tar.addfile(tarinfo, csv_buffer)
+    df.to_csv(csv_path, index=False)
+    
+    return csv_path
 
 
-def test_multiple_tarballs_concatenation(cleanup_test_data):
+def test_multiple_csv_files_concatenation(cleanup_test_data):
     """
-    Test that multiple tarballs are properly concatenated and aggregated.
+    Test that multiple CSV files are properly concatenated and aggregated.
 
-    This test splits the test data into multiple tarballs (2-3 parts each)
+    This test splits the test data into multiple CSV files (2-3 parts each)
     and verifies that the concatenation logic works correctly.
 
     The test validates:
@@ -104,43 +97,79 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     year, month, day = 2025, 6, 13
     data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
 
-    # ========== Split and create tarball files for each collector ==========
+    # ========== Split and create CSV files for each collector ==========
 
-    # 1. Jobs data - split into 2 tarballs
+    # 1. Jobs data - split into 2 CSV files
     jobs_part1 = jobs[:3]  # First 3 jobs
     jobs_part2 = jobs[3:]  # Remaining jobs
 
-    create_tarball_with_csv(jobs_part1, 'unified_jobs.csv', f'{data_dir}/tarball1_unified_jobs.tar.gz')
-    create_tarball_with_csv(jobs_part2, 'unified_jobs.csv', f'{data_dir}/tarball2_unified_jobs.tar.gz')
+    jobs_csv_files = []
+    csv1 = create_csv_file(jobs_part1, f'{data_dir}/part1_unified_jobs.csv')
+    if csv1:
+        jobs_csv_files.append(csv1)
+    csv2 = create_csv_file(jobs_part2, f'{data_dir}/part2_unified_jobs.csv')
+    if csv2:
+        jobs_csv_files.append(csv2)
 
-    # 2. Events data - split into 3 tarballs
-    # Note: collector name is 'main_jobevent_service'
+    # 2. Events data - split into 3 CSV files
     events_part1 = events[:100]  # First 100 events
     events_part2 = events[100:200]  # Middle events
     events_part3 = events[200:]  # Remaining events
 
-    create_tarball_with_csv(events_part1, 'main_jobevent_service.csv', f'{data_dir}/tarball1_main_jobevent_service.tar.gz')
-    create_tarball_with_csv(events_part2, 'main_jobevent_service.csv', f'{data_dir}/tarball2_main_jobevent_service.tar.gz')
-    create_tarball_with_csv(events_part3, 'main_jobevent_service.csv', f'{data_dir}/tarball3_main_jobevent_service.tar.gz')
+    events_csv_files = []
+    csv1 = create_csv_file(events_part1, f'{data_dir}/part1_main_jobevent.csv')
+    if csv1:
+        events_csv_files.append(csv1)
+    csv2 = create_csv_file(events_part2, f'{data_dir}/part2_main_jobevent.csv')
+    if csv2:
+        events_csv_files.append(csv2)
+    csv3 = create_csv_file(events_part3, f'{data_dir}/part3_main_jobevent.csv')
+    if csv3:
+        events_csv_files.append(csv3)
 
-    # 3. Execution environments - split into 2 tarballs
+    # 3. Execution environments - split into 2 CSV files
     ee_part1 = execution_environments[:2]
     ee_part2 = execution_environments[2:]
 
-    create_tarball_with_csv(ee_part1, 'execution_environments.csv', f'{data_dir}/tarball1_execution_environments.tar.gz')
-    create_tarball_with_csv(ee_part2, 'execution_environments.csv', f'{data_dir}/tarball2_execution_environments.tar.gz')
+    ee_csv_files = []
+    csv1 = create_csv_file(ee_part1, f'{data_dir}/part1_execution_environments.csv')
+    if csv1:
+        ee_csv_files.append(csv1)
+    csv2 = create_csv_file(ee_part2, f'{data_dir}/part2_execution_environments.csv')
+    if csv2:
+        ee_csv_files.append(csv2)
 
-    # 4. Job host summary - split into 2 tarballs
-    # Note: collector name is 'job_host_summary_service'
+    # 4. Job host summary - split into 2 CSV files
     jhs_part1 = jobhostsummary[:8]  # First 8 entries
     jhs_part2 = jobhostsummary[8:]  # Remaining entries
 
-    create_tarball_with_csv(jhs_part1, 'job_host_summary_service.csv', f'{data_dir}/tarball1_job_host_summary_service.tar.gz')
-    create_tarball_with_csv(jhs_part2, 'job_host_summary_service.csv', f'{data_dir}/tarball2_job_host_summary_service.tar.gz')
+    jhs_csv_files = []
+    csv1 = create_csv_file(jhs_part1, f'{data_dir}/part1_job_host_summary.csv')
+    if csv1:
+        jhs_csv_files.append(csv1)
+    csv2 = create_csv_file(jhs_part2, f'{data_dir}/part2_job_host_summary.csv')
+    if csv2:
+        jhs_csv_files.append(csv2)
 
     # ========== Run the anonymized rollup computation ==========
 
-    result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
+    # Create input_data dict with lists of CSV file paths
+    input_data = {
+        'unified_jobs': jobs_csv_files,
+        'job_host_summary': jhs_csv_files,
+        'main_jobevent': events_csv_files,
+        'execution_environments': ee_csv_files,
+    }
+
+    result = compute_anonymized_rollup_from_raw_data(
+        input_data=input_data,
+        salt='test_salt',
+        year=year,
+        month=month,
+        day=day,
+        base_path=base_path,
+        save_rollups=False
+    )
 
     # print the result with pretty json
     import json
@@ -148,7 +177,7 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     # Note: result is already sanitized by compute_anonymized_rollup_from_raw_data
     json_content = json.dumps(result, indent=4)
     print('\n' + '=' * 80)
-    print('=== ANONYMIZED ROLLUP RESULT (from multiple tarballs) ===')
+    print('=== ANONYMIZED ROLLUP RESULT (from multiple CSV files) ===')
     print('=' * 80)
     print(json_content)
     print('=' * 80)
@@ -325,26 +354,42 @@ def test_multiple_tarballs_concatenation(cleanup_test_data):
     assert total_module_usage == 15, 'Total module usage across playbooks should be 15'
 
 
-def test_empty_tarballs_handling(cleanup_test_data):
+def test_empty_csv_files_handling(cleanup_test_data):
     """
-    Test that the system handles case with no tarball files gracefully.
+    Test that the system handles case with no CSV files gracefully.
     """
     base_path = './out'
     year, month, day = 2025, 6, 14
     data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
 
-    # Create the directory but don't create any tarball files
+    # Create the directory but don't create any CSV files
     # This simulates a scenario where no data was collected
     os.makedirs(data_dir, exist_ok=True)
 
+    # Create input_data dict with empty lists
+    input_data = {
+        'unified_jobs': [],
+        'job_host_summary': [],
+        'main_jobevent': [],
+        'execution_environments': [],
+    }
+
     # Should not crash, but return empty/default results
-    result = compute_anonymized_rollup_from_raw_data(salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False)
+    result = compute_anonymized_rollup_from_raw_data(
+        input_data=input_data,
+        salt='test_salt',
+        year=year,
+        month=month,
+        day=day,
+        base_path=base_path,
+        save_rollups=False
+    )
 
     # Print the result for debugging
     import json
 
     json_content = json.dumps(result, indent=4)
-    print('\n=== Empty Tarball Result ===')
+    print('\n=== Empty CSV Files Result ===')
     print(json_content)
 
     # Validate flattened structure exists even with empty data

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -21,6 +21,8 @@ Enhanced Assertions:
 import os
 import shutil
 
+from datetime import datetime
+
 import pandas as pd
 import pytest
 
@@ -93,8 +95,14 @@ def test_multiple_csv_files_concatenation(cleanup_test_data):
        - Playbook-level module usage
     5. **Anonymization**: Verifies all sensitive names are properly hashed
     """
+
+    # since = begining of the day
+    # until = begining of the next day
+    since = datetime(2025, 6, 13, 0, 0, 0)
+    until = datetime(2025, 6, 14, 0, 0, 0)
+
     base_path = './out'
-    year, month, day = 2025, 6, 13
+    year, month, day = since.year, since.month, since.day
     data_dir = f'{base_path}/data/{year}/{month:02d}/{day:02d}'
 
     # ========== Split and create CSV files for each collector ==========
@@ -162,7 +170,7 @@ def test_multiple_csv_files_concatenation(cleanup_test_data):
     }
 
     result = compute_anonymized_rollup_from_raw_data(
-        input_data=input_data, salt='test_salt', year=year, month=month, day=day, base_path=base_path, save_rollups=False
+        input_data=input_data, salt='test_salt', since=since, until=until, base_path=base_path, save_rollups=False
     )
 
     # print the result with pretty json
@@ -177,7 +185,7 @@ def test_multiple_csv_files_concatenation(cleanup_test_data):
     print('=' * 80)
 
     # save the result as json inside rollups/2025/06/13/anonymized.json - based on the year, month, day
-    json_path = f'./out/rollups/{year}/{month:02d}/{day:02d}/anonymized.json'
+    json_path = f'./out/rollups/{year}/{month:02d}/{day:02d}/anonymized_{since.strftime("%Y-%m-%d")}_{until.strftime("%Y-%m-%d")}.json'
 
     # ensure the directory exists
     os.makedirs(os.path.dirname(json_path), exist_ok=True)


### PR DESCRIPTION
[AAP-58418]
Small change - what is being changed is basicaly described in issue.

1) Two files had to be changed that now accepts DB connection, it is calling library for data gathering with DB connection, instead of calling metrics-utility CLI for gathering.

2) Two tests had to be updated.

Additionaly, I added some extra things, since it was requested by Ciaran and Apurva may use it while testing:

1) Renamed metrics_utility/anonymized_rollups/task_anonymized_rollups.py into
metrics_utility/anonymized_rollups/compute_anonymized_rollup.py

2) Add entrypoint file: metrics_utility/library/anonymize/anonymized_rollups_processor.py
So library has all important entrypoints for metrics-service

3) Add ability to call it with since-until rather than year-month-day, so we can compute anonymized metrics for example every hour, every 4 hours, every day...

