### PR TITLE
Change exposed port for metrics-utility

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -92,6 +92,7 @@ jobs:
           METRICS_UTILITY_BUCKET_REGION: "us-east-1"
           METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
           METRICS_UTILITY_DB_HOST: "localhost"
+          METRICS_UTILITY_DB_PORT: "5432"
         run: |
           uv run pytest -s -v --cov=. --cov-report=xml
 

--- a/manage.py
+++ b/manage.py
@@ -5,3 +5,4 @@ if __name__ == '__main__':
     from metrics_utility import manage
 
     manage()
+# test

--- a/mock_awx/settings/__init__.py
+++ b/mock_awx/settings/__init__.py
@@ -8,7 +8,7 @@ DATABASES = {
         'USER': 'myuser',
         'PASSWORD': 'mypassword',
         'HOST': os.getenv('METRICS_UTILITY_DB_HOST', 'localhost'),
-        'PORT': '5432',
+        'PORT': '5433',
     }
 }
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/mock_awx/settings/__init__.py
+++ b/mock_awx/settings/__init__.py
@@ -8,7 +8,7 @@ DATABASES = {
         'USER': 'myuser',
         'PASSWORD': 'mypassword',
         'HOST': os.getenv('METRICS_UTILITY_DB_HOST', 'localhost'),
-        'PORT': '5433',
+        'PORT': os.getenv('METRICS_UTILITY_DB_PORT', '5433'),
     }
 }
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       POSTGRES_USER: "myuser"
       POSTGRES_PASSWORD: "mypassword"
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - ./roles.sql:/docker-entrypoint-initdb.d/init-0-roles.sql
       - ./latest.sql:/docker-entrypoint-initdb.d/init-1-schema.sql


### PR DESCRIPTION
[AAP-XXXXX]
Dont forget to link back issue to PR.

## Description

Exposed port should be changed so it does not collide with the same exposed port for metrics service DB, so we can run both on local machine and dont have to manualy start/stop based on what we are working at.

CI test fails because pytest.yml needs to set the default postgres port, but its pull request target, so the changes are valid after PR is merged. If there will be any problems after merge, we will revert this PR.

## Testing

export METRICS_UTILITY_SHIP_PATH="./out"
export METRICS_UTILITY_SHIP_TARGET="directory"

export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"

uv run ./manage.py gather_automation_controller_billing_data --ship --since=2025-06-13 --until=2025-06-14

Failure on collecting indirect data is expected, since we have older version of awx from winter before indirect node counting (and we are missing automatic tests here probably).
