### PR TITLE
Revert "Change exposed port for metrics-utility"

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -92,7 +92,6 @@ jobs:
           METRICS_UTILITY_BUCKET_REGION: "us-east-1"
           METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
           METRICS_UTILITY_DB_HOST: "localhost"
-          METRICS_UTILITY_DB_PORT: "5432"
         run: |
           uv run pytest -s -v --cov=. --cov-report=xml
 

--- a/manage.py
+++ b/manage.py
@@ -5,4 +5,3 @@ if __name__ == '__main__':
     from metrics_utility import manage
 
     manage()
-# test

--- a/mock_awx/settings/__init__.py
+++ b/mock_awx/settings/__init__.py
@@ -8,7 +8,7 @@ DATABASES = {
         'USER': 'myuser',
         'PASSWORD': 'mypassword',
         'HOST': os.getenv('METRICS_UTILITY_DB_HOST', 'localhost'),
-        'PORT': os.getenv('METRICS_UTILITY_DB_PORT', '5433'),
+        'PORT': '5432',
     }
 }
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       POSTGRES_USER: "myuser"
       POSTGRES_PASSWORD: "mypassword"
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
       - ./roles.sql:/docker-entrypoint-initdb.d/init-0-roles.sql
       - ./latest.sql:/docker-entrypoint-initdb.d/init-1-schema.sql


### PR DESCRIPTION
Reverts ansible/metrics-utility#274

CI didn't start working in https://github.com/ansible/metrics-utility/pull/275
Reverting, we won't be doing that.

Closes https://github.com/ansible/metrics-utility/pull/275


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts PostgreSQL port changes, restoring 5432 in settings and Docker, removes DB port env from CI, and cleans up manage.py.
> 
> - **Config/DB**:
>   - Set `mock_awx/settings/__init__.py` DB `PORT` to `'5432'` (was env-driven defaulting to `5433`).
>   - Update `tools/docker/docker-compose.yaml` Postgres mapping to `"5432:5432"`.
> - **CI**:
>   - Remove `METRICS_UTILITY_DB_PORT` from `.github/workflows/pytest.yml`.
> - **Misc**:
>   - Remove stray comment in `manage.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d31f8145aabd32f09e05a2ba9605e8b0636cece0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->