### PR TITLE
[stable-0.6] Add extra info in the logs for vcpu metrics

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -547,8 +547,10 @@ def total_workers_vcpu(since, full_path, until, **kwargs):
         return None
 
     cluster_name = os.getenv('METRICS_UTILITY_CLUSTER_NAME')
+    red_hat_org_id = os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID')
+    log_prefix = f'[METRICS_UTILITY_VCPU]: cluster_name: {cluster_name}, red_hat_org_id: {red_hat_org_id},'
     if not cluster_name:
-        logger.error('environment variable METRICS_UTILITY_CLUSTER_NAME is not set')
+        logger.error('%s, environment variable METRICS_UTILITY_CLUSTER_NAME is not set', log_prefix)
         raise MissingRequiredEnvVar('environment variable METRICS_UTILITY_CLUSTER_NAME is not set')
 
     now = datetime.now(timezone.utc)
@@ -570,15 +572,19 @@ def total_workers_vcpu(since, full_path, until, **kwargs):
     if not usage_based_billing_enabled:
         info['total_workers_vcpu'] = 1
         # This message must always appear in the log regardless of the log level.
-        logger_info_level.info(json.dumps(info, indent=2))
-        return {'timestamp': info['end_timestamp'], 'cluster_name': info['cluster_name'], 'total_workers_vcpu': info['total_workers_vcpu']}
+        logger_info_level.info('%s info: %s', log_prefix, json.dumps(info))
+        data = {'timestamp': info['end_timestamp'], 'cluster_name': info['cluster_name'], 'total_workers_vcpu': info['total_workers_vcpu']}
+        logger_info_level.info('%s data: %s', log_prefix, json.dumps(data))
+        return data
 
     url = os.getenv('METRICS_UTILITY_PROMETHEUS_URL')
     if not url:
         prometheus_default_url = 'https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091'
         logger.info(
-            f'environment variable METRICS_UTILITY_PROMETHEUS_URL is not set, \
-                    default {prometheus_default_url} will be assigned'
+            '%s environment variable METRICS_UTILITY_PROMETHEUS_URL is not set, \
+                    default %s will be assigned',
+            log_prefix,
+            prometheus_default_url,
         )
         url = prometheus_default_url
 
@@ -596,20 +602,22 @@ def total_workers_vcpu(since, full_path, until, **kwargs):
     info['promql_query'] = promql_query
     info['timeline'] = timeline
 
-    logger.debug(f'total_workers_vcpu: {total_workers_vcpu}')
+    logger.debug('%s total_workers_vcpu: %s', log_prefix, total_workers_vcpu)
 
     # This can happen when the prev_hour_start doesn't have data, it could be when the cluster just started or
     # if for some reasons prometheus loss some data.
     if total_workers_vcpu is None:
-        logger.warning('No data availble yet, the cluster is probably running for less than an hour')
+        logger.warning('%s No data availble yet, the cluster is probably running for less than an hour', log_prefix)
         raise MetricsException('No data availble yet, the cluster is probably running for less than an hour')
 
     info['total_workers_vcpu'] = int(total_workers_vcpu)
 
     # This message must always appear in the log regardless of the log level.
-    logger_info_level.info(json.dumps(info, indent=2))
+    logger_info_level.info('%s info: %s', log_prefix, json.dumps(info))
 
-    return {'timestamp': info['end_timestamp'], 'cluster_name': info['cluster_name'], 'total_workers_vcpu': info['total_workers_vcpu']}
+    data = {'timestamp': info['end_timestamp'], 'cluster_name': info['cluster_name'], 'total_workers_vcpu': info['total_workers_vcpu']}
+    logger_info_level.info('%s data: %s', log_prefix, json.dumps(data))
+    return data
 
 
 def get_hour_boundaries(current_timestamp: float) -> Tuple[float, float, float]:

--- a/metrics_utility/test/gather/test_total_workers_vcpu.py
+++ b/metrics_utility/test/gather/test_total_workers_vcpu.py
@@ -32,7 +32,11 @@ class TestTotalWorkersVcpu:
                     total_workers_vcpu(None, None, None)
 
                 assert 'environment variable METRICS_UTILITY_CLUSTER_NAME is not set' in str(exc_info.value)
-                mock_logger.error.assert_called_once_with('environment variable METRICS_UTILITY_CLUSTER_NAME is not set')
+                # Check that error was called with the log prefix format
+                mock_logger.error.assert_called_once()
+                call_args = mock_logger.error.call_args[0]
+                assert '%s, environment variable METRICS_UTILITY_CLUSTER_NAME is not set' == call_args[0]
+                assert '[METRICS_UTILITY_VCPU]:' in call_args[1]
 
     def test_returns_hardcoded_value_when_usage_based_billing_disabled(self):
         """Test that the function returns hardcoded value when METRICS_UTILITY_USAGE_BASED_METERING_ENABLED is not set or false (default behavior)."""
@@ -50,7 +54,12 @@ class TestTotalWorkersVcpu:
                 assert 'timestamp' in result
 
                 # Verify the logged JSON contains usage_based_billing_enabled = False and all required fields
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                # The logger now logs twice: once for info, once for data
+                assert mock_logger_info.info.call_count == 2
+                # First call is info with log prefix
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                assert first_call_args[0] == '%s info: %s'
+                logged_json = json.loads(first_call_args[2])
                 assert not logged_json['usage_based_billing_enabled']
                 assert logged_json['total_workers_vcpu'] == 1
                 assert 'cluster_name' in logged_json
@@ -65,7 +74,8 @@ class TestTotalWorkersVcpu:
                 assert result['total_workers_vcpu'] == 1
 
                 # Verify the logged JSON contains usage_based_billing_enabled = False
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                logged_json = json.loads(first_call_args[2])
                 assert not logged_json['usage_based_billing_enabled']
 
     def test_usage_based_billing_enabled_case_insensitive(self):
@@ -127,14 +137,17 @@ class TestTotalWorkersVcpu:
 
                 # Verify it uses the default URL
                 mock_prom_client_class.assert_called_once_with(url='https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091')
-                expected_message = (
-                    'environment variable METRICS_UTILITY_PROMETHEUS_URL is not set,'
-                    '                     default https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091 will be assigned'
+
+                # Check that the info message was logged with format string
+                info_calls = [call[0] for call in mock_logger.info.call_args_list]
+                assert any('%s environment variable METRICS_UTILITY_PROMETHEUS_URL is not set' in str(call) for call in info_calls), (
+                    'Expected info log with format string for PROMETHEUS_URL not found'
                 )
-                # Check that the expected message was called (not necessarily the last call)
-                mock_logger.info.assert_any_call(expected_message)
-                # Also verify the total_workers_vcpu value was logged
-                mock_logger.debug.assert_called_with('total_workers_vcpu: 16.0')
+
+                # Verify the debug message was logged with format string
+                debug_call_args = mock_logger.debug.call_args[0]
+                assert debug_call_args[0] == '%s total_workers_vcpu: %s'
+                assert debug_call_args[2] == 16.0
 
                 # Verify helper functions were called
                 mock_get_cpu.assert_called_once()
@@ -145,7 +158,11 @@ class TestTotalWorkersVcpu:
                 assert result['total_workers_vcpu'] == 16
 
                 # Verify that the logged info contains all expected fields
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                # The logger now logs twice: once for info, once for data
+                assert mock_logger_info.info.call_count == 2
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                assert first_call_args[0] == '%s info: %s'
+                logged_json = json.loads(first_call_args[2])
                 assert 'cluster_name' in logged_json
                 assert 'collection_timestamp' in logged_json
                 assert 'start_timestamp' in logged_json
@@ -230,9 +247,14 @@ class TestTotalWorkersVcpu:
                 # Verify the exception message
                 assert 'No data availble yet, the cluster is probably running for less than an hour' in str(exc_info.value)
 
-                # Verify the warning message was logged
-                mock_logger.debug.assert_called_with('total_workers_vcpu: None')
-                mock_logger.warning.assert_called_with('No data availble yet, the cluster is probably running for less than an hour')
+                # Verify the debug and warning messages were logged with format string
+                debug_call_args = mock_logger.debug.call_args[0]
+                assert debug_call_args[0] == '%s total_workers_vcpu: %s'
+                assert debug_call_args[2] is None
+
+                warning_call_args = mock_logger.warning.call_args[0]
+                assert warning_call_args[0] == '%s No data availble yet, the cluster is probably running for less than an hour'
+                assert '[METRICS_UTILITY_VCPU]:' in warning_call_args[1]
 
     def test_successful_prometheus_query_with_vcpu_calculation(self):
         """Test successful Prometheus query with vCPU calculation."""
@@ -270,9 +292,11 @@ class TestTotalWorkersVcpu:
                 assert 'max_over_time(sum(machine_cpu_cores)[59m59s:5m]' in query_call
                 assert '@' in query_call  # Should contain timestamp
 
-                # Verify logging
-                mock_logger_info.info.assert_called_once()
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                # Verify logging - logger now logs twice: once for info, once for data
+                assert mock_logger_info.info.call_count == 2
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                assert first_call_args[0] == '%s info: %s'
+                logged_json = json.loads(first_call_args[2])
                 assert logged_json['cluster_name'] == 'my-cluster'
                 assert logged_json['total_workers_vcpu'] == 24
                 assert logged_json['usage_based_billing_enabled']
@@ -405,9 +429,11 @@ class TestTotalWorkersVcpu:
                 assert 'timestamp' in result
                 assert result['timestamp'] == expected_timestamp
 
-                # Check logged JSON
-                mock_logger_info.info.assert_called_once()
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                # Check logged JSON - logger now logs twice: once for info, once for data
+                assert mock_logger_info.info.call_count == 2
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                assert first_call_args[0] == '%s info: %s'
+                logged_json = json.loads(first_call_args[2])
                 assert logged_json['end_timestamp'] == expected_timestamp
                 assert logged_json['cluster_name'] == 'test-cluster'
                 assert logged_json['total_workers_vcpu'] == 8
@@ -427,7 +453,11 @@ class TestTotalWorkersVcpu:
                 assert result['total_workers_vcpu'] == 1
 
                 # Verify the logged JSON contains usage_based_billing_enabled = False
-                logged_json = json.loads(mock_logger_info.info.call_args[0][0])
+                # The logger now logs twice: once for info, once for data
+                assert mock_logger_info.info.call_count == 2
+                first_call_args = mock_logger_info.info.call_args_list[0][0]
+                assert first_call_args[0] == '%s info: %s'
+                logged_json = json.loads(first_call_args[2])
                 assert not logged_json['usage_based_billing_enabled']
 
 


### PR DESCRIPTION
## Summary
This is a backport of PR #273 to the stable-0.6 branch.

## Changes
- Adds `[METRICS_UTILITY_VCPU]` log prefix to all vCPU metrics logging
- Includes cluster_name and red_hat_org_id in log prefix for easier searching in Splunk
- Logs both detailed info (with PromQL query and timeline) and summary data
- Uses Python format strings for better logging performance

## Testing
All unit tests pass (same tests as PR #273).

## Related Issues
- Original PR: https://github.com/ansible/metrics-utility/pull/273
- JIRA: https://issues.redhat.com/browse/AAP-58445
- JIRA: https://issues.redhat.com/browse/AAP-58446

## Notes
This backport was created using `git cherry-pick` from commit b13b9c5 in the devel branch.