### PR TITLE
Add __init__.py to anonymized_rollups for package imports

### DIFF
--- a/metrics_utility/anonymized_rollups/__init__.py
+++ b/metrics_utility/anonymized_rollups/__init__.py
@@ -8,7 +8,6 @@ from .anonymized_rollups import (
     load_anonymized_rollup_data,
 )
 from .base_anonymized_rollup import BaseAnonymizedRollup
-from .compute_anonymized_rollup import compute_anonymized_rollup
 from .events_modules_anonymized_rollup import EventModulesAnonymizedRollup
 from .execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
 from .helpers import sanitize_json
@@ -24,7 +23,6 @@ __all__ = [
     'JobsAnonymizedRollup',
     'anonymize_data',
     'anonymize_rollups',
-    'compute_anonymized_rollup',
     'compute_anonymized_rollup_from_raw_data',
     'create_anonymized_object',
     'flatten_json_report',

--- a/metrics_utility/anonymized_rollups/__init__.py
+++ b/metrics_utility/anonymized_rollups/__init__.py
@@ -32,4 +32,3 @@ __all__ = [
     'load_anonymized_rollup_data',
     'sanitize_json',
 ]
-

--- a/metrics_utility/anonymized_rollups/__init__.py
+++ b/metrics_utility/anonymized_rollups/__init__.py
@@ -1,0 +1,35 @@
+from .anonymized_rollups import (
+    anonymize_data,
+    anonymize_rollups,
+    compute_anonymized_rollup_from_raw_data,
+    create_anonymized_object,
+    flatten_json_report,
+    hash,
+    load_anonymized_rollup_data,
+)
+from .base_anonymized_rollup import BaseAnonymizedRollup
+from .compute_anonymized_rollup import compute_anonymized_rollup
+from .events_modules_anonymized_rollup import EventModulesAnonymizedRollup
+from .execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
+from .helpers import sanitize_json
+from .jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
+from .jobs_anonymized_rollup import JobsAnonymizedRollup
+
+
+__all__ = [
+    'BaseAnonymizedRollup',
+    'EventModulesAnonymizedRollup',
+    'ExecutionEnvironmentsAnonymizedRollup',
+    'JobHostSummaryAnonymizedRollup',
+    'JobsAnonymizedRollup',
+    'anonymize_data',
+    'anonymize_rollups',
+    'compute_anonymized_rollup',
+    'compute_anonymized_rollup_from_raw_data',
+    'create_anonymized_object',
+    'flatten_json_report',
+    'hash',
+    'load_anonymized_rollup_data',
+    'sanitize_json',
+]
+

--- a/metrics_utility/library/__init__.py
+++ b/metrics_utility/library/__init__.py
@@ -1,4 +1,4 @@
-from . import collectors, dataframes, extractors, instants, package, reports, storage
+from . import anonymize, collectors, dataframes, extractors, instants, package, reports, storage
 from .csv_file_splitter import CsvFileSplitter
 from .lock import lock
 from .utils import last_gather, save_last_gather, tempdir
@@ -6,6 +6,7 @@ from .utils import last_gather, save_last_gather, tempdir
 
 __all__ = [
     'CsvFileSplitter',
+    'anonymize',
     'collectors',
     'dataframes',
     'extractors',

--- a/metrics_utility/library/anonymize/__init__.py
+++ b/metrics_utility/library/anonymize/__init__.py
@@ -1,0 +1,6 @@
+from .anonymized_rollups_processor import anonymized_rollups_processor
+
+
+__all__ = [
+    'anonymized_rollups_processor',
+]


### PR DESCRIPTION
Added __init__.py to anonymized_rollups for package imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds package __init__ files to expose anonymized rollup APIs and anonymize processor, and updates library exports accordingly.
> 
> - **Packaging / Exports**:
>   - Add `metrics_utility/anonymized_rollups/__init__.py` exporting rollup helpers and classes (`anonymize_data`, `anonymize_rollups`, `BaseAnonymizedRollup`, etc.).
>   - Update `metrics_utility/library/__init__.py` to include `anonymize` in imports and `__all__`.
>   - Add `metrics_utility/library/anonymize/__init__.py` exporting `anonymized_rollups_processor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeecf2e0b7e60d274a58ed436be42d317da26011. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->