### PR TITLE
roles.sql: also create metrics_service user & db

### DIFF
--- a/tools/docker/roles.sql
+++ b/tools/docker/roles.sql
@@ -1,1 +1,4 @@
 CREATE ROLE awx SUPERUSER LOGIN PASSWORD 'awx';
+
+CREATE ROLE metrics_service SUPERUSER LOGIN PASSWORD 'metrics_service';
+CREATE DATABASE metrics_service OWNER 'metrics_service';


### PR DESCRIPTION
in case people want to run it that way

related to ansible/metrics-service#40

---

To start the DB:

```
cd metrics-utility
make compose
```

To start the service:

(make sure `.env` exists, and points to `127.0.0.1 5432 metrics_service metrics_service metrics_service` - really just `cp .env.example .env`)

```
cd metrics-service
uv run ./manage.py migrate
uv run ./manage.py metrics_service init-service-id
uv run ./manage.py metrics_service init-system-tasks
uv run ./manage.py createsuperuser
uv run ./manage.py metrics_service run
```