### PR TITLE
Optimize service event query

### DIFF
--- a/metrics_utility/library/__init__.py
+++ b/metrics_utility/library/__init__.py
@@ -1,4 +1,4 @@
-from . import anonymize, collectors, dataframes, extractors, instants, package, reports, storage
+from . import collectors, dataframes, extractors, instants, package, reports, storage
 from .csv_file_splitter import CsvFileSplitter
 from .lock import lock
 from .utils import last_gather, save_last_gather, tempdir
@@ -6,7 +6,6 @@ from .utils import last_gather, save_last_gather, tempdir
 
 __all__ = [
     'CsvFileSplitter',
-    'anonymize',
     'collectors',
     'dataframes',
     'extractors',

--- a/metrics_utility/library/collectors/controller/main_jobevent.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent.py
@@ -3,9 +3,6 @@ from ..util import collector, copy_table
 
 @collector
 def main_jobevent(*, db=None, since=None, until=None, output_dir=None):
-    # FIXME: suspicious replace, why not main_jobevent.event_data::jsonb->>'foo' (also, perf candidate)
-    event_data = r"replace(main_jobevent.event_data, '\u', '\u005cu')::jsonb"
-
     where = ' AND '.join(
         [
             f"main_jobhostsummary.modified >= '{since.isoformat()}'",
@@ -34,10 +31,10 @@ def main_jobevent(*, db=None, since=None, until=None, output_dir=None):
             main_jobevent.modified,
             main_jobevent.job_created as job_created,
             main_jobevent.event,
-            ({event_data}->>'task_action')::TEXT AS task_action,
-            ({event_data}->>'resolved_action')::TEXT AS resolved_action,
-            ({event_data}->>'resolved_role')::TEXT AS resolved_role,
-            ({event_data}->>'duration')::TEXT AS duration,
+            (ed.event_data->>'task_action')::TEXT AS task_action,
+            (ed.event_data->>'resolved_action')::TEXT AS resolved_action,
+            (ed.event_data->>'resolved_role')::TEXT AS resolved_role,
+            (ed.event_data->>'duration')::TEXT AS duration,
             main_jobevent.failed,
             main_jobevent.changed,
             main_jobevent.playbook,
@@ -48,6 +45,9 @@ def main_jobevent(*, db=None, since=None, until=None, output_dir=None):
             main_jobevent.host_id as host_remote_id,
             main_jobevent.host_name
         FROM main_jobevent
+        CROSS JOIN LATERAL (
+            SELECT replace(main_jobevent.event_data, '\\u', '\\u005cu')::jsonb AS event_data
+        ) AS ed
         JOIN job_scope ON
             job_scope.job_created = main_jobevent.job_created
             AND job_scope.job_id = main_jobevent.job_id

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -4,8 +4,6 @@ from ..util import collector, copy_table
 @collector
 def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     # Use the table alias 'e' here (you alias main_jobevent as e in the FROM)
-    # FIXME: suspicious replace, why not e.event_data::jsonb->>'foo'
-    event_data = r"replace(e.event_data, '\u', '\u005cu')::jsonb"
 
     jobs_query = """
         SELECT
@@ -44,14 +42,14 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
             e.event,
 
             -- JSON extracted fields
-            ({event_data}->>'task_action')       AS task_action,
-            ({event_data}->>'resolved_action')   AS resolved_action,
-            ({event_data}->>'resolved_role')     AS resolved_role,
-            ({event_data}->>'duration')          AS duration,
-            ({event_data}->>'start')::timestamptz AS start,
-            ({event_data}->>'end')::timestamptz   AS end,
-            ({event_data}->>'task_uuid')        AS task_uuid,
-            COALESCE( ({event_data}->>'ignore_errors')::boolean, false ) AS ignore_errors,
+            (ed.event_data->>'task_action')       AS task_action,
+            (ed.event_data->>'resolved_action')   AS resolved_action,
+            (ed.event_data->>'resolved_role')     AS resolved_role,
+            (ed.event_data->>'duration')          AS duration,
+            (ed.event_data->>'start')::timestamptz AS start,
+            (ed.event_data->>'end')::timestamptz   AS end,
+            (ed.event_data->>'task_uuid')        AS task_uuid,
+            COALESCE( (ed.event_data->>'ignore_errors')::boolean, false ) AS ignore_errors,
             e.failed,
             e.changed,
             e.playbook,
@@ -65,18 +63,21 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
             e.host_name,
 
             -- Warnings and deprecations (json arrays)
-            {event_data}->'res'->'warnings'     AS warnings,
-            {event_data}->'res'->'deprecations' AS deprecations,
+            ed.event_data->'res'->'warnings'     AS warnings,
+            ed.event_data->'res'->'deprecations' AS deprecations,
 
             CASE
                 WHEN e.event = 'playbook_on_stats'
-                THEN {event_data} - 'artifact_data'
+                THEN ed.event_data - 'artifact_data'
             END AS playbook_on_stats,
 
             uj.failed as job_failed,
             uj.started as job_started
 
         FROM main_jobevent e
+        CROSS JOIN LATERAL (
+            SELECT replace(e.event_data, '\\u', '\\u005cu')::jsonb AS event_data
+        ) AS ed
         LEFT JOIN main_unifiedjob uj ON uj.id = e.job_id
         WHERE {where_clause}
     """

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -72,12 +72,32 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
         hour_start = job_created.replace(minute=0, second=0, microsecond=0)
         hour_boundaries.add(hour_start)
 
-    # Build WHERE clause with literal hour ranges for partition pruning
+    # Sort hours for range grouping
+    sorted_hours = sorted(hour_boundaries)
+
+    # Group consecutive hours into ranges to reduce OR clauses
+    # e.g., hours [0,1,2,5,6,10] → ranges [(0,3), (5,7), (10,11)]
+    ranges = []
+    if sorted_hours:
+        range_start = sorted_hours[0]
+        range_end = sorted_hours[0] + timedelta(hours=1)
+
+        for hour in sorted_hours[1:]:
+            if hour == range_end:  # Consecutive hour - extend current range
+                range_end = hour + timedelta(hours=1)
+            else:  # Gap found - save current range and start new one
+                ranges.append((range_start, range_end))
+                range_start = hour
+                range_end = hour + timedelta(hours=1)
+
+        # Don't forget the last range
+        ranges.append((range_start, range_end))
+
+    # Build WHERE clause with consolidated ranges for partition pruning
     # PostgreSQL can see these literal timestamps and prune partitions accordingly
     or_clauses = []
-    for hour_start in sorted(hour_boundaries):
-        hour_end = hour_start + timedelta(hours=1)
-        or_clauses.append(f"(e.job_created >= '{hour_start.isoformat()}'::timestamptz AND e.job_created < '{hour_end.isoformat()}'::timestamptz)")
+    for range_start, range_end in ranges:
+        or_clauses.append(f"(e.job_created >= '{range_start.isoformat()}'::timestamptz AND e.job_created < '{range_end.isoformat()}'::timestamptz)")
 
     where_clause = ' OR '.join(or_clauses)
 

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -10,7 +10,7 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
 
     Uses two optimizations for partition pruning:
     1. Hourly timestamp ranges in WHERE clause (literal values for partition pruning)
-    2. Temporary table for job_ids to avoid huge IN clauses
+    2. Direct job_id filtering in WHERE clause
     """
 
     jobs_query = """
@@ -31,40 +31,11 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     if not jobs:
         return None
 
-    # Create temporary table for job_ids
-    # - DROP IF EXISTS ensures no bloat from previous runs in same session
-    # - TEMPORARY TABLE is session-scoped, auto-drops when connection closes
-    # - This avoids huge IN clauses with 100K+ job_ids
-
+    # Extract unique job_ids
     # We are loading the finished jobs then we are filtering
     # for the job_created, this cannot be done by simple joins because
-    # job_created is partitioned and partitions prunning dont work with joins
-    with db.cursor() as cursor:
-        cursor.execute('DROP TABLE IF EXISTS temp_jobevent_service_jobs')
-
-        cursor.execute("""
-            CREATE TEMPORARY TABLE temp_jobevent_service_jobs (
-                job_id INTEGER PRIMARY KEY
-            )
-        """)
-
-        # Insert unique job_ids
-        job_ids_set = set(job_id for job_id, _ in jobs)
-
-        # Use execute_values for efficient bulk insert
-        # Check for psycopg2 vs psycopg3 using the same method as copy_table
-        if hasattr(cursor, 'copy_expert') and callable(cursor.copy_expert):
-            # psycopg2 (Automation Controller 4.4 and below)
-            from psycopg2.extras import execute_values
-
-            execute_values(cursor, 'INSERT INTO temp_jobevent_service_jobs (job_id) VALUES %s', [(jid,) for jid in job_ids_set], page_size=1000)
-        else:
-            # psycopg3 (Automation Controller 4.5 and above)
-            for job_id in job_ids_set:
-                cursor.execute('INSERT INTO temp_jobevent_service_jobs (job_id) VALUES (%s)', (job_id,))
-
-        # Analyze temp table for query optimizer
-        cursor.execute('ANALYZE temp_jobevent_service_jobs')
+    # job_created is partitioned and partitions pruning dont work with joins
+    job_ids_set = set(job_id for job_id, _ in jobs)
 
     # Extract unique hour boundaries from job_created timestamps
     # This reduces potentially 100K timestamps down to ~100-1000 hourly ranges
@@ -106,11 +77,17 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
 
     # Handle edge case: if no ranges, use FALSE to return empty result set
     # This maintains valid SQL structure while returning 0 rows
-    where_clause = ' OR '.join(or_clauses) if or_clauses else 'FALSE'
+    timestamp_where_clause = ' OR '.join(or_clauses) if or_clauses else 'FALSE'
+
+    # Build job_id IN clause
+    job_ids_str = ','.join(str(job_id) for job_id in job_ids_set)
+    job_id_where_clause = f'e.job_id IN ({job_ids_str})'
+
+    # Combine both WHERE conditions
+    where_clause = f'({timestamp_where_clause}) AND ({job_id_where_clause})'
 
     # Final event query
-    # - INNER JOIN with temp table filters events immediately (efficient!)
-    # - WHERE clause enables partition pruning via literal hour boundaries
+    # - WHERE clause filters by job_id and enables partition pruning via literal hour boundaries
     query = f"""
         SELECT
             e.id,
@@ -156,12 +133,11 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
             uj.started as job_started
 
         FROM main_jobevent e
-        INNER JOIN temp_jobevent_service_jobs t ON t.job_id = e.job_id
         CROSS JOIN LATERAL (
             SELECT replace(e.event_data, '\\u', '\\u005cu')::jsonb AS event_data
         ) AS ed
         LEFT JOIN main_unifiedjob uj ON uj.id = e.job_id
-        WHERE ({where_clause})
+        WHERE {where_clause}
     """
 
     return copy_table(db=db, table='main_jobevent', query=query, output_dir=output_dir)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -1,9 +1,17 @@
+from datetime import timedelta
+
 from ..util import collector, copy_table
 
 
 @collector
 def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
-    # Use the table alias 'e' here (you alias main_jobevent as e in the FROM)
+    """
+    Collects job events for jobs that finished in the given time window.
+
+    Uses two optimizations for partition pruning:
+    1. Hourly timestamp ranges in WHERE clause (literal values for partition pruning)
+    2. Temporary table for job_ids to avoid huge IN clauses
+    """
 
     jobs_query = """
         SELECT
@@ -13,9 +21,8 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
         WHERE uj.finished >= %(since)s
           AND uj.finished < %(until)s
     """
-    jobs = []
 
-    # do raw sql for django.db connection
+    # Fetch all jobs in the time window
     with db.cursor() as cursor:
         cursor.execute(jobs_query, {'since': since, 'until': until})
         jobs = cursor.fetchall()
@@ -24,12 +31,55 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     if not jobs:
         return None
 
-    # Build a literal WHERE clause that preserves (job_id, job_created) pairing
-    # (e.job_id, e.job_created) IN (VALUES (id1, 'ts1'::timestamptz), ...)
-    pairs_sql = ',\n'.join(f"({jid}, '{jcreated.isoformat()}'::timestamptz)" for jid, jcreated in jobs)
-    where_clause = f'(e.job_id, e.job_created) IN (VALUES {pairs_sql})'
+    # Create temporary table for job_ids
+    # - DROP IF EXISTS ensures no bloat from previous runs in same session
+    # - TEMPORARY TABLE is session-scoped, auto-drops when connection closes
+    # - This avoids huge IN clauses with 100K+ job_ids
+    with db.cursor() as cursor:
+        cursor.execute('DROP TABLE IF EXISTS temp_jobevent_service_jobs')
+
+        cursor.execute("""
+            CREATE TEMPORARY TABLE temp_jobevent_service_jobs (
+                job_id INTEGER PRIMARY KEY
+            )
+        """)
+
+        # Insert unique job_ids
+        job_ids_set = set(job_id for job_id, _ in jobs)
+
+        # Use execute_values for efficient bulk insert
+        try:
+            from psycopg2.extras import execute_values
+
+            execute_values(cursor, 'INSERT INTO temp_jobevent_service_jobs (job_id) VALUES %s', [(jid,) for jid in job_ids_set], page_size=1000)
+        except ImportError:
+            # Fallback for psycopg3
+            for job_id in job_ids_set:
+                cursor.execute('INSERT INTO temp_jobevent_service_jobs (job_id) VALUES (%s)', (job_id,))
+
+        # Analyze temp table for query optimizer
+        cursor.execute('ANALYZE temp_jobevent_service_jobs')
+
+    # Extract unique hour boundaries from job_created timestamps
+    # This reduces potentially 100K timestamps down to ~100-1000 hourly ranges
+    hour_boundaries = set()
+    for job_id, job_created in jobs:
+        # Truncate to hour boundary (matching partition boundaries)
+        hour_start = job_created.replace(minute=0, second=0, microsecond=0)
+        hour_boundaries.add(hour_start)
+
+    # Build WHERE clause with literal hour ranges for partition pruning
+    # PostgreSQL can see these literal timestamps and prune partitions accordingly
+    or_clauses = []
+    for hour_start in sorted(hour_boundaries):
+        hour_end = hour_start + timedelta(hours=1)
+        or_clauses.append(f"(e.job_created >= '{hour_start.isoformat()}'::timestamptz AND e.job_created < '{hour_end.isoformat()}'::timestamptz)")
+
+    where_clause = ' OR '.join(or_clauses)
 
     # Final event query
+    # - INNER JOIN with temp table filters events immediately (efficient!)
+    # - WHERE clause enables partition pruning via literal hour boundaries
     query = f"""
         SELECT
             e.id,
@@ -75,11 +125,12 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
             uj.started as job_started
 
         FROM main_jobevent e
+        INNER JOIN temp_jobevent_service_jobs t ON t.job_id = e.job_id
         CROSS JOIN LATERAL (
             SELECT replace(e.event_data, '\\u', '\\u005cu')::jsonb AS event_data
         ) AS ed
         LEFT JOIN main_unifiedjob uj ON uj.id = e.job_id
-        WHERE {where_clause}
+        WHERE ({where_clause})
     """
 
     return copy_table(db=db, table='main_jobevent', query=query, output_dir=output_dir)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -68,6 +68,9 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     # This reduces potentially 100K timestamps down to ~100-1000 hourly ranges
     hour_boundaries = set()
     for job_id, job_created in jobs:
+        # Skip jobs with NULL created timestamp (defensive programming)
+        if job_created is None:
+            continue
         # Truncate to hour boundary (matching partition boundaries)
         hour_start = job_created.replace(minute=0, second=0, microsecond=0)
         hour_boundaries.add(hour_start)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -99,7 +99,9 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     for range_start, range_end in ranges:
         or_clauses.append(f"(e.job_created >= '{range_start.isoformat()}'::timestamptz AND e.job_created < '{range_end.isoformat()}'::timestamptz)")
 
-    where_clause = ' OR '.join(or_clauses)
+    # Handle edge case: if no ranges, use FALSE to return empty result set
+    # This maintains valid SQL structure while returning 0 rows
+    where_clause = ' OR '.join(or_clauses) if or_clauses else 'FALSE'
 
     # Final event query
     # - INNER JOIN with temp table filters events immediately (efficient!)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -27,10 +27,6 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
         cursor.execute(jobs_query, {'since': since, 'until': until})
         jobs = cursor.fetchall()
 
-    # No jobs in the window
-    if not jobs:
-        return None
-
     # Extract unique job_ids
     # We are loading the finished jobs then we are filtering
     # for the job_created, this cannot be done by simple joins because
@@ -80,8 +76,12 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     timestamp_where_clause = ' OR '.join(or_clauses) if or_clauses else 'FALSE'
 
     # Build job_id IN clause
-    job_ids_str = ','.join(str(job_id) for job_id in job_ids_set)
-    job_id_where_clause = f'e.job_id IN ({job_ids_str})'
+    # Handle edge case: if no jobs, use FALSE to return empty result set with proper schema
+    if job_ids_set:
+        job_ids_str = ','.join(str(job_id) for job_id in job_ids_set)
+        job_id_where_clause = f'e.job_id IN ({job_ids_str})'
+    else:
+        job_id_where_clause = 'FALSE'
 
     # Combine both WHERE conditions
     where_clause = f'({timestamp_where_clause}) AND ({job_id_where_clause})'

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -52,12 +52,14 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
         job_ids_set = set(job_id for job_id, _ in jobs)
 
         # Use execute_values for efficient bulk insert
-        try:
+        # Check for psycopg2 vs psycopg3 using the same method as copy_table
+        if hasattr(cursor, 'copy_expert') and callable(cursor.copy_expert):
+            # psycopg2 (Automation Controller 4.4 and below)
             from psycopg2.extras import execute_values
 
             execute_values(cursor, 'INSERT INTO temp_jobevent_service_jobs (job_id) VALUES %s', [(jid,) for jid in job_ids_set], page_size=1000)
-        except ImportError:
-            # Fallback for psycopg3
+        else:
+            # psycopg3 (Automation Controller 4.5 and above)
             for job_id in job_ids_set:
                 cursor.execute('INSERT INTO temp_jobevent_service_jobs (job_id) VALUES (%s)', (job_id,))
 

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -35,6 +35,10 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
     # - DROP IF EXISTS ensures no bloat from previous runs in same session
     # - TEMPORARY TABLE is session-scoped, auto-drops when connection closes
     # - This avoids huge IN clauses with 100K+ job_ids
+
+    # We are loading the finished jobs then we are filtering
+    # for the job_created, this cannot be done by simple joins because
+    # job_created is partitioned and partitions prunning dont work with joins
     with db.cursor() as cursor:
         cursor.execute('DROP TABLE IF EXISTS temp_jobevent_service_jobs')
 

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -61,6 +61,8 @@ def test_main_jobevent_service_with_jobs_calls_copy_table(mock_copy_table):
     """Test that collector calls copy_table when jobs are found."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
+    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
+    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -92,6 +94,8 @@ def test_main_jobevent_service_query_structure(mock_copy_table):
     """Test that the SQL query has expected structure."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
+    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
+    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -126,6 +130,8 @@ def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_tab
     """Test that query uses temp table and builds hourly timestamp ranges."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
+    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
+    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -201,6 +207,8 @@ def test_main_jobevent_service_playbook_stats_handling(mock_copy_table):
     """Test that query handles playbook_on_stats event specially."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
+    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
+    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -34,7 +34,7 @@ def test_main_jobevent_service_with_output_dir():
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
 def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
-    """Test that collector returns None when no jobs are found."""
+    """Test that collector returns empty CSV with headers when no jobs are found."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -42,6 +42,7 @@ def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
 
     # No jobs found
     mock_cursor.fetchall.return_value = []
+    mock_copy_table.return_value = ['/tmp/main_jobevent_table.csv']
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -49,11 +50,16 @@ def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
     instance = main_jobevent_service(db=mock_db, since=since, until=until)
     result = instance.gather()
 
-    # Should return None when no jobs
-    assert result is None
+    # Should still call copy_table to generate CSV with headers (even if 0 rows)
+    mock_copy_table.assert_called_once()
 
-    # Should not call copy_table
-    mock_copy_table.assert_not_called()
+    # Verify the query has FALSE conditions (returns 0 rows but maintains schema)
+    call_args = mock_copy_table.call_args
+    query = call_args[1]['query']
+    assert 'FALSE' in query  # Should have FALSE for empty job set
+
+    # Should return CSV file path
+    assert result == ['/tmp/main_jobevent_table.csv']
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -122,8 +122,8 @@ def test_main_jobevent_service_query_structure(mock_copy_table):
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
-def test_main_jobevent_service_builds_values_clause(mock_copy_table):
-    """Test that query builds VALUES clause from job list."""
+def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_table):
+    """Test that query uses temp table and builds hourly timestamp ranges."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -143,12 +143,31 @@ def test_main_jobevent_service_builds_values_clause(mock_copy_table):
     call_args = mock_copy_table.call_args
     query = call_args[1]['query']
 
-    # Should have VALUES clause with job pairs
-    assert 'VALUES' in query
-    assert '(100,' in query
-    assert '(200,' in query
-    assert '2024-01-15T10:30:45+00:00' in query
-    assert '2024-01-16T14:45:30+00:00' in query
+    # Should use temp table join instead of VALUES clause
+    assert 'temp_jobevent_service_jobs' in query
+    assert 'INNER JOIN temp_jobevent_service_jobs t ON t.job_id = e.job_id' in query
+
+    # Should have hourly timestamp ranges (truncated to hour boundaries)
+    # Job 1 at 10:30:45 -> hour range 10:00:00 to 11:00:00
+    assert '2024-01-15T10:00:00+00:00' in query
+    assert '2024-01-15T11:00:00+00:00' in query
+
+    # Job 2 at 14:45:30 -> hour range 14:00:00 to 15:00:00
+    assert '2024-01-16T14:00:00+00:00' in query
+    assert '2024-01-16T15:00:00+00:00' in query
+
+    # Should have OR clause for multiple hour ranges
+    assert ' OR ' in query
+
+    # Verify temp table was created
+    # cursor.execute should be called multiple times: DROP, CREATE, INSERTs, ANALYZE
+    assert mock_cursor.execute.call_count >= 3
+
+    # Check that temp table operations were called
+    execute_calls = [str(call[0][0]) for call in mock_cursor.execute.call_args_list]
+    assert any('DROP TABLE IF EXISTS temp_jobevent_service_jobs' in call for call in execute_calls)
+    assert any('CREATE TEMPORARY TABLE temp_jobevent_service_jobs' in call for call in execute_calls)
+    assert any('ANALYZE temp_jobevent_service_jobs' in call for call in execute_calls)
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -127,11 +127,9 @@ def test_main_jobevent_service_query_structure(mock_copy_table):
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
 def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_table):
-    """Test that query uses temp table and builds hourly timestamp ranges."""
+    """Test that query uses job_id IN clause and builds hourly timestamp ranges."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
-    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
-    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -149,9 +147,9 @@ def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_tab
     call_args = mock_copy_table.call_args
     query = call_args[1]['query']
 
-    # Should use temp table join instead of VALUES clause
-    assert 'temp_jobevent_service_jobs' in query
-    assert 'INNER JOIN temp_jobevent_service_jobs t ON t.job_id = e.job_id' in query
+    # Should use direct job_id IN clause (no temp table for read-only replica compatibility)
+    assert 'e.job_id IN (' in query
+    assert '100' in query or '200' in query  # Should contain job IDs
 
     # Should have hourly timestamp ranges (truncated to hour boundaries)
     # Job 1 at 10:30:45 -> hour range 10:00:00 to 11:00:00
@@ -165,15 +163,12 @@ def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_tab
     # Should have OR clause for multiple hour ranges
     assert ' OR ' in query
 
-    # Verify temp table was created
-    # cursor.execute should be called multiple times: DROP, CREATE, INSERTs, ANALYZE
-    assert mock_cursor.execute.call_count >= 3
+    # Verify only the initial jobs query was executed (no temp table operations)
+    assert mock_cursor.execute.call_count == 1
 
-    # Check that temp table operations were called
+    # Check that no temp table operations were called
     execute_calls = [str(call[0][0]) for call in mock_cursor.execute.call_args_list]
-    assert any('DROP TABLE IF EXISTS temp_jobevent_service_jobs' in call for call in execute_calls)
-    assert any('CREATE TEMPORARY TABLE temp_jobevent_service_jobs' in call for call in execute_calls)
-    assert any('ANALYZE temp_jobevent_service_jobs' in call for call in execute_calls)
+    assert not any('temp_jobevent_service_jobs' in call for call in execute_calls)
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')


### PR DESCRIPTION
[AAP-59250]

Speedup for main_jobevent_service and main_jobevent in library using LATERAL.

main_jobevent service now reduces number of pairs in jobs:

    where_clause = f'(e.job_id, e.job_created) IN (VALUES {pairs_sql})'
    
This will contain all jobs finished in since-until, which can be tens of thousands of jobs!
 
 This can easily bloat. We introduce new approach. Since we can not join on jobs according to job_created, because in order to work with partitions prunning on job_created (job_created is houlrly partition in event table), we need to do very clear literal explicit filter on event table (thus WHERE with contstant job_created).
 
 Improvements: 
 job_created is simplified - awx uses hourly partitions, so we split into hourly job_created and put it into set, this keeps max hundreds of hours
 
 Then we also makes groups of nearby hours to reduce it even more, for example 2025-06-01 10:00:00 and 2025-06-01 11:00:00 will be concatenated and the resulted range filter will be job_created => min AND job_created < max.
   
Also removed cyclic import.
