### PR TITLE
Updated collections.json path in EventmodulesAnonymizedRollup

### DIFF
--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 import pandas as pd
@@ -77,8 +78,9 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         self.collector_names = ['main_jobevent_service']
 
-        # Open the JSON file
-        with open('metrics_utility/anonymized_rollups/collections.json', 'r') as f:
+        # Open the JSON file using path relative to this module
+        collections_path = os.path.join(os.path.dirname(__file__), 'collections.json')
+        with open(collections_path, 'r') as f:
             self.collections = json.load(f)
 
     # Prepare is run for each batch of data


### PR DESCRIPTION
Currently when the library is imported, it looks for the collections.json file at `<current working directory>/metrics_utility/anonymized_rollups/collections.json` rather than where the package is installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Load `collections.json` via a module-relative path in `EventModulesAnonymizedRollup` to remove CWD dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f32ef4e1201ab4c3e57014222f0b31622145dea9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->