### PR TITLE
Revert "Bump psycopg from 3.2.10 to 3.3.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "kubernetes>=33.1.0",
     "openpyxl==3.1.2",
     "pandas>=2.2.3",
-    "psycopg==3.3.0",
+    "psycopg==3.2.10",
     "requests==2.32.5",
     "segment-analytics-python>=2.3.4",
     "setuptools==80.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "openpyxl", specifier = "==3.1.2" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "psycopg", specifier = "==3.3.0" },
+    { name = "psycopg", specifier = "==3.2.10" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "segment-analytics-python", specifier = ">=2.3.4" },
     { name = "setuptools", specifier = "==80.9.0" },
@@ -638,15 +638,15 @@ wheels = [
 
 [[package]]
 name = "psycopg"
-version = "3.3.0"
+version = "3.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/bd/06dc36aeda16ffff129d03d90e75fd5e24222a719adcef37cd07f1926b06/psycopg-3.3.0.tar.gz", hash = "sha256:68950107fb8979d34bfc16b61560a26afe5d8dab96617881c87dfff58221df09", size = 165593, upload-time = "2025-12-01T11:35:07.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f1/0258a123c045afaf3c3b60c22ccff077bceeb24b8dc2c593270899353bd0/psycopg-3.2.10.tar.gz", hash = "sha256:0bce99269d16ed18401683a8569b2c5abd94f72f8364856d56c0389bcd50972a", size = 160380, upload-time = "2025-09-08T09:13:37.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/5d/3569bab5a92f33e4a1b3c3c16816718ef5cc306f55f3965a8cb630c496ac/psycopg-3.3.0-py3-none-any.whl", hash = "sha256:c9f070afeda682f6364f86cd77145f43feaf60648b2ce1f6e883e594d04cbea8", size = 212759, upload-time = "2025-12-01T11:21:15.91Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/422ffbbeeb9418c795dae2a768db860401446af0c6768bc061ce22325f58/psycopg-3.2.10-py3-none-any.whl", hash = "sha256:ab5caf09a9ec42e314a21f5216dbcceac528e0e05142e42eea83a3b28b320ac3", size = 206586, upload-time = "2025-09-08T09:07:50.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts ansible/metrics-utility#291

This is causing a error when running metrics utility in metrics service 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts psycopg dependency from 3.3.0 to 3.2.10 in `pyproject.toml` and updates `uv.lock` accordingly.
> 
> - **Dependencies**:
>   - Downgrade `psycopg` from `3.3.0` to `3.2.10`.
>   - Update `uv.lock` entries (version, specifier, sdist/wheel URLs and hashes) to match `3.2.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673ee598171778cdd61c525f8d1fe6414f96fdcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->