### PR TITLE
Update deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.0"]
+requires = ["setuptools>=45", "setuptools_scm[toml]~=6.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,17 +7,17 @@ name = "metrics-utility"
 dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
-    "boto3==1.35.96",
-    "botocore==1.35.96",
-    "distro==1.9.0",
-    "django==5.2.7",
-    "kubernetes>=33.1.0",
-    "openpyxl==3.1.2",
-    "pandas>=2.2.3",
-    "psycopg==3.3.0",
-    "requests==2.32.5",
-    "segment-analytics-python>=2.3.4",
-    "setuptools==80.9.0",
+    "boto3~=1.35",
+    "botocore~=1.35",
+    "distro~=1.9",
+    "django~=5.2",
+    "kubernetes>=33.1",
+    "openpyxl~=3.1",
+    "pandas~=2.2",
+    "psycopg~=3.3",
+    "requests~=2.32",
+    "segment-analytics-python~=2.3",
+    "setuptools>=80.9",
 ]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -51,11 +51,11 @@ Changelog = "https://github.com/ansible/metrics-utility/blob/devel/CHANGELOG.md"
 [dependency-groups]
 dev = [
     "django-ansible-base>=2025.1.3",
-    "pre-commit>=4.0.1",
-    "pytest-cov>=6.0.0",
-    "pytest-mock>=3.14.0",
-    "pytest>=8.3.4",
-    "ruff>=0.9.2",
+    "pre-commit~=4.0",
+    "pytest-cov~=6.0",
+    "pytest-mock~=3.14",
+    "pytest~=8.3",
+    "ruff>=0.9.2, <1",
 ]
 
 # Do not uncomment the line below. We need to be able to override the version via a file, and this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]~=6.0"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,7 @@ dependencies = [
     "django~=5.2",
     "kubernetes>=33.1",
     "openpyxl~=3.1",
-    "pandas~=2.2",
+    "pandas>=2.2.3,<3",
     "psycopg~=3.3",
     "requests~=2.32",
     "segment-analytics-python~=2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,7 @@ requires-dist = [
     { name = "django", specifier = "~=5.2" },
     { name = "kubernetes", specifier = ">=33.1" },
     { name = "openpyxl", specifier = "~=3.1" },
-    { name = "pandas", specifier = "~=2.2" },
+    { name = "pandas", specifier = ">=2.2.3,<3" },
     { name = "psycopg", specifier = "~=3.3" },
     { name = "requests", specifier = "~=2.32" },
     { name = "segment-analytics-python", specifier = "~=2.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -477,27 +477,27 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "==1.35.96" },
-    { name = "botocore", specifier = "==1.35.96" },
-    { name = "distro", specifier = "==1.9.0" },
-    { name = "django", specifier = "==5.2.7" },
-    { name = "kubernetes", specifier = ">=33.1.0" },
-    { name = "openpyxl", specifier = "==3.1.2" },
-    { name = "pandas", specifier = ">=2.2.3" },
-    { name = "psycopg", specifier = "==3.3.0" },
-    { name = "requests", specifier = "==2.32.5" },
-    { name = "segment-analytics-python", specifier = ">=2.3.4" },
-    { name = "setuptools", specifier = "==80.9.0" },
+    { name = "boto3", specifier = "~=1.35" },
+    { name = "botocore", specifier = "~=1.35" },
+    { name = "distro", specifier = "~=1.9" },
+    { name = "django", specifier = "~=5.2" },
+    { name = "kubernetes", specifier = ">=33.1" },
+    { name = "openpyxl", specifier = "~=3.1" },
+    { name = "pandas", specifier = "~=2.2" },
+    { name = "psycopg", specifier = "~=3.3" },
+    { name = "requests", specifier = "~=2.32" },
+    { name = "segment-analytics-python", specifier = "~=2.3" },
+    { name = "setuptools", specifier = ">=80.9" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "django-ansible-base", specifier = ">=2025.1.3" },
-    { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-mock", specifier = ">=3.14.0" },
-    { name = "ruff", specifier = ">=0.9.2" },
+    { name = "pre-commit", specifier = "~=4.0" },
+    { name = "pytest", specifier = "~=8.3" },
+    { name = "pytest-cov", specifier = "~=6.0" },
+    { name = "pytest-mock", specifier = "~=3.14" },
+    { name = "ruff", specifier = ">=0.9.2,<1" },
 ]
 
 [[package]]
@@ -715,16 +715,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The dependencies in `pyproject.toml` get applied to the library now, so we shouldn't `==` any version unless really needed to work.

So, updating the deps based on which kind of versioning the package seems to be using:

* majorver (versions like 33.1.0, where we don't expect 34 to be incompatible)
  * change to `>=33.1`

* semver (versions like 1.33.1, where 2.0 might be incompatible)
  * change to `~=1.33` (equivalent to `>= 1.33, < 2`)

* pre-1.0 (versions like 0.9.1, where 1.0 might be incompatible)
  * change to `>=0.9.1, <1` (same as ^, except `*=`  *might* act differently for <1)

* calver (versions like 2025.1.3, which don't imply the existence of 2025.1.0)
  * stay with `>=2025.1.3`

* python (just actual python)
  * stay with `>=3.12`, as `~=3.12` raises a warning

Exceptions:

pandas - keeping 2.2.3+ for new python
setuptools - leaving >=6.0 because cursor