### PR TITLE
Milan optimize events batches

### DIFF
--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -190,30 +190,34 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         # This groups by (job, host, task, module, collection) and summarizes all events
         # This can reduce the number of rows, depends of number of retries
-        task_summary = dataframe.groupby(
-            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
-        ).agg(
-            seen_success=('task_success_event', 'max'),
-            seen_failed=('task_failed_event', 'max'),
-            seen_unreachable=('task_unreachable_event', 'max'),
-            seen_skipped=('task_skipped_event', 'max'),
-            seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
-            job_started=('job_started', 'first'),
-            job_failed=('job_failed', 'first'),
-            job_duration_seconds=('job_duration_seconds', 'first'),
-            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            playbook=('playbook', 'first'),
-        ).assign(
-            # mutually exclusive categories - only one can be true
-            task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
-            task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
-            task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
-            task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
-            task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
-            task_skipped=lambda x: (
-                x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
-            ),
-            job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
+        task_summary = (
+            dataframe.groupby(
+                ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+            )
+            .agg(
+                seen_success=('task_success_event', 'max'),
+                seen_failed=('task_failed_event', 'max'),
+                seen_unreachable=('task_unreachable_event', 'max'),
+                seen_skipped=('task_skipped_event', 'max'),
+                seen_failed_and_ignored=('task_failed_and_ignored_event', 'max'),
+                job_started=('job_started', 'first'),
+                job_failed=('job_failed', 'first'),
+                job_duration_seconds=('job_duration_seconds', 'first'),
+                job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+                playbook=('playbook', 'first'),
+            )
+            .assign(
+                # mutually exclusive categories - only one can be true
+                task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
+                task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
+                task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
+                task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
+                task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
+                task_skipped=lambda x: (
+                    x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
+                ),
+                job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
+            )
         )
 
         # aggregate task_summary by job_id, task_uuid, module_name, collection_source, collection_name
@@ -221,7 +225,9 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         # note that prepare is called in batches and one job and task can be split between batches
         # This will cause acceptable precision loss, because we will end up with two entries for the same job and task
         # duplicated entries will be summed in base function
-        task_summary = task_summary.groupby(['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
+        task_summary = task_summary.groupby(
+            ['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+        ).agg(
             task_clean_success=('task_clean_success', 'sum'),
             task_success_with_reruns=('task_success_with_reruns', 'sum'),
             task_failed=('task_failed', 'sum'),
@@ -281,7 +287,9 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             }
 
         # Final aggregation: handle any cross-batch duplicates, sum them, loss of precision is acceptable
-        dataframe = dataframe.groupby(['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
+        dataframe = dataframe.groupby(
+            ['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
+        ).agg(
             task_clean_success=('task_clean_success', 'sum'),
             task_success_with_reruns=('task_success_with_reruns', 'sum'),
             task_failed=('task_failed', 'sum'),

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -289,6 +289,13 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             task_unreachable=('task_unreachable', 'sum'),
             task_skipped=('task_skipped', 'sum'),
             job_id_that_contained_failed_task=('job_id_that_contained_failed_task', 'first'),
+            # Preserve columns needed for later aggregations
+            playbook=('playbook', 'first'),
+            job_started=('job_started', 'first'),
+            job_failed=('job_failed', 'first'),
+            job_duration_seconds=('job_duration_seconds', 'first'),
+            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+            host_ids=('host_ids', lambda x: set().union(*[s for s in x.dropna() if isinstance(s, set)]) if any(isinstance(s, set) for s in x.dropna()) else set()),
         )
 
         # Modules used to automate

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -96,6 +96,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         return {
             'event_total': data_all['event_total'] + data_new['event_total'],
             'task_summary': pd.concat([data_all['task_summary'], data_new['task_summary']], ignore_index=True),
+            'hosts': data_all['hosts'] | data_new['hosts'],
         }
 
     # Prepare is run for each batch of data
@@ -104,6 +105,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
     def prepare(self, dataframe):
         # Count all events before pruning
         event_total = len(dataframe)
+        hosts = set(dataframe['host_id'].unique())
 
         # Failure/Success rate of modules
         success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
@@ -188,9 +190,8 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         dataframe = dataframe[columns_to_keep]
 
-        # Aggregate events per task to reduce rows before merging batches
         # This groups by (job, host, task, module, collection) and summarizes all events
-        # This can greatly reduce the number of rows, depends of number of retries
+        # This can reduce the number of rows, depends of number of retries
         task_summary = dataframe.groupby(
             ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
         ).agg(
@@ -204,11 +205,38 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
             playbook=('playbook', 'first'),
+        ).assign(
+            # mutually exclusive categories - only one can be true
+            task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
+            task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
+            task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
+            task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
+            task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
+            task_skipped=lambda x: (
+                x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
+            ),
+            job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
+        )
+
+        # aggregate task_summary by job_id, task_uuid, module_name, collection_source, collection_name
+        # aggregate data for hosts together
+        # note that prepare is called in batches and one job and task can be split between batches
+        # This will cause acceptable precision loss, because we will end up with two entries for the same job and task
+        # duplicated entries will be summed in base function
+        task_summary = task_summary.groupby(['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
+            task_clean_success=('task_clean_success', 'sum'),
+            task_success_with_reruns=('task_success_with_reruns', 'sum'),
+            task_failed=('task_failed', 'sum'),
+            task_failed_and_ignored=('task_failed_and_ignored', 'sum'),
+            task_unreachable=('task_unreachable', 'sum'),
+            task_skipped=('task_skipped', 'sum'),
+            job_id_that_contained_failed_task=('job_id_that_contained_failed_task', 'first'),
         )
 
         return {
             'event_total': event_total,
             'task_summary': task_summary,
+            'hosts': hosts,
         }
 
     def base(self, data):
@@ -248,23 +276,15 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 'rollup': {'aggregated': dataframe, 'event_total': event_total},
             }
 
-        # Final aggregation: handle any cross-batch duplicates
-        # because the task running on host can be split between batches
-        # we need to aggregate the data second time to get the correct results
-        # since this will be rare, reduction of rows will be still significant
-        dataframe = dataframe.groupby(
-            ['job_id', 'host_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True
-        ).agg(
-            seen_success=('seen_success', 'max'),
-            seen_failed=('seen_failed', 'max'),
-            seen_unreachable=('seen_unreachable', 'max'),
-            seen_skipped=('seen_skipped', 'max'),
-            seen_failed_and_ignored=('seen_failed_and_ignored', 'max'),
-            job_started=('job_started', 'first'),
-            job_failed=('job_failed', 'first'),
-            job_duration_seconds=('job_duration_seconds', 'first'),
-            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            playbook=('playbook', 'first'),
+        # Final aggregation: handle any cross-batch duplicates, sum them, loss of precision is acceptable
+        dataframe = dataframe.groupby(['job_id', 'task_uuid', 'module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
+            task_clean_success=('task_clean_success', 'sum'),
+            task_success_with_reruns=('task_success_with_reruns', 'sum'),
+            task_failed=('task_failed', 'sum'),
+            task_failed_and_ignored=('task_failed_and_ignored', 'sum'),
+            task_unreachable=('task_unreachable', 'sum'),
+            task_skipped=('task_skipped', 'sum'),
+            job_id_that_contained_failed_task=('job_id_that_contained_failed_task', 'first'),
         )
 
         # Modules used to automate
@@ -281,8 +301,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         # Avg number of modules used in a playbook
         avg_number_of_modules_used_in_a_playbooks = dataframe.groupby('playbook', observed=True)['module_name'].nunique().mean()
         modules_used_per_playbook_total = dataframe.groupby('playbook', observed=True)['module_name'].nunique()
-
-        hosts_automated_total = dataframe['host_id'].nunique()
 
         # Data is already aggregated from prepare() and merge()
         # We just need to compute the mutually exclusive task status categories

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -295,7 +295,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             job_failed=('job_failed', 'first'),
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            host_ids=('host_ids', lambda x: set().union(*[s for s in x.dropna() if isinstance(s, set)]) if any(isinstance(s, set) for s in x.dropna()) else set()),
+            host_ids=('host_ids', lambda x: set().union(*[s for s in x.dropna() if isinstance(s, set)])),
         )
 
         # Modules used to automate
@@ -322,7 +322,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         module_stats = task_summary.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
+            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)]))),
             task_clean_success_total=('task_clean_success', 'sum'),
             task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
             task_failed_total=('task_failed', 'sum'),
@@ -335,7 +335,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         collection_name_stats = task_summary.groupby(['collection_name', 'collection_source'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
+            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)]))),
             jobs_failed_because_of_collection_name_failure_total=('job_id_that_contained_failed_task', 'nunique'),
             task_clean_success_total=('task_clean_success', 'sum'),
             task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
@@ -349,7 +349,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         per_job_module = dataframe.groupby(['job_id', 'module_name', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
+            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)]))),
             job_containing_module_failed=('job_failed', 'max'),
         )
 
@@ -371,7 +371,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         per_job_collection_name = dataframe.groupby(['job_id', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
+            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)]))),
             job_containing_collection_name_failed=('job_failed', 'max'),
         )
 

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -248,21 +248,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 'rollup': {'aggregated': dataframe, 'event_total': event_total},
             }
 
-        # Categorize columns to reduce memory footprint
-        # This is done after batches are concatenated to ensure consistent categories
-        # Only categorize string columns with low-to-medium cardinality (high repetition)
-        categorical_columns = [
-            'collection_source',  # ~20 unique values (Red Hat, Community, Partner, etc.)
-            'collection_name',  # ~500-1000 unique collections
-            'module_name',  # ~2000-5000 unique modules
-            'playbook',  # ~1000-5000 unique playbooks
-            'task_uuid',  # ~1000-5000 unique task uuids
-        ]
-
-        for col in categorical_columns:
-            if col in dataframe.columns:
-                dataframe[col] = dataframe[col].astype('category')
-
         # Final aggregation: handle any cross-batch duplicates
         # because the task running on host can be split between batches
         # we need to aggregate the data second time to get the correct results

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -96,7 +96,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         return {
             'event_total': data_all['event_total'] + data_new['event_total'],
             'task_summary': pd.concat([data_all['task_summary'], data_new['task_summary']], ignore_index=True),
-            'hosts': data_all['hosts'] | data_new['hosts'],
         }
 
     # Prepare is run for each batch of data
@@ -105,7 +104,6 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
     def prepare(self, dataframe):
         # Count all events before pruning
         event_total = len(dataframe)
-        hosts = set(dataframe['host_id'].unique())
 
         # Failure/Success rate of modules
         success_events_list = ['runner_on_ok', 'runner_on_async_ok', 'runner_item_on_ok']
@@ -231,12 +229,18 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             task_unreachable=('task_unreachable', 'sum'),
             task_skipped=('task_skipped', 'sum'),
             job_id_that_contained_failed_task=('job_id_that_contained_failed_task', 'first'),
+            # Preserve columns needed in base() function
+            job_started=('job_started', 'first'),
+            job_failed=('job_failed', 'first'),
+            job_duration_seconds=('job_duration_seconds', 'first'),
+            job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
+            playbook=('playbook', 'first'),
+            host_ids=('host_id', lambda x: set(x)),
         )
 
         return {
             'event_total': event_total,
             'task_summary': task_summary,
-            'hosts': hosts,
         }
 
     def base(self, data):
@@ -303,26 +307,15 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         modules_used_per_playbook_total = dataframe.groupby('playbook', observed=True)['module_name'].nunique()
 
         # Data is already aggregated from prepare() and merge()
-        # We just need to compute the mutually exclusive task status categories
-        task_summary = dataframe.assign(
-            # mutually exclusive categories - only one can be true
-            task_clean_success=lambda x: x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_skipped'],
-            task_success_with_reruns=lambda x: x['seen_success'] & (x['seen_failed'] | x['seen_unreachable']),
-            task_failed=lambda x: x['seen_failed'] & ~x['seen_success'],
-            task_failed_and_ignored=lambda x: x['seen_failed_and_ignored'] & ~x['seen_success'],
-            task_unreachable=lambda x: x['seen_unreachable'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_failed_and_ignored'],
-            task_skipped=lambda x: (
-                x['seen_skipped'] & ~x['seen_success'] & ~x['seen_failed'] & ~x['seen_unreachable'] & ~x['seen_failed_and_ignored']
-            ),
-            job_id_that_contained_failed_task=lambda df: df['job_id'].where(df['task_failed']),
-        )
+        # Task status categories are already computed in prepare(), so we can use dataframe directly
+        task_summary = dataframe
 
         # Per-module counts
         # receiver of this data can easily calculate success rates
         module_stats = task_summary.groupby(['module_name', 'collection_source', 'collection_name'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-            hosts_total=('host_id', 'nunique'),
+            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
             task_clean_success_total=('task_clean_success', 'sum'),
             task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
             task_failed_total=('task_failed', 'sum'),
@@ -335,7 +328,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         collection_name_stats = task_summary.groupby(['collection_name', 'collection_source'], as_index=False, observed=True).agg(
             jobs_total=('job_id', 'nunique'),
             number_of_jobs_never_started=('job_started', lambda x: x.isna().sum()),
-            hosts_total=('host_id', 'nunique'),
+            hosts_total=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
             jobs_failed_because_of_collection_name_failure_total=('job_id_that_contained_failed_task', 'nunique'),
             task_clean_success_total=('task_clean_success', 'sum'),
             task_success_with_reruns_total=('task_success_with_reruns', 'sum'),
@@ -349,7 +342,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         per_job_module = dataframe.groupby(['job_id', 'module_name', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            host_count=('host_id', 'nunique'),
+            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
             job_containing_module_failed=('job_failed', 'max'),
         )
 
@@ -371,7 +364,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         per_job_collection_name = dataframe.groupby(['job_id', 'collection_name', 'collection_source'], as_index=False, observed=True).agg(
             job_duration_seconds=('job_duration_seconds', 'first'),
             job_waiting_time_seconds=('job_waiting_time_seconds', 'first'),
-            host_count=('host_id', 'nunique'),
+            host_count=('host_ids', lambda x: len(set().union(*[s for s in x.dropna() if isinstance(s, set)])) if any(isinstance(s, set) for s in x.dropna()) else 0),
             job_containing_collection_name_failed=('job_failed', 'max'),
         )
 
@@ -399,6 +392,14 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         collection_name_stats_dict = collection_name_stats.to_dict(orient='records')
         job_time_stats_collection_name_dict = job_time_stats_collection_name.to_dict(orient='records')
         merged_list_collection_name = merge_by_name(collection_name_stats_dict, job_time_stats_collection_name_dict, 'collection_name')
+
+        # Get hosts_automated_total from the dataframe by unioning all host_ids sets
+        if not dataframe.empty and 'host_ids' in dataframe.columns:
+            host_sets = [s for s in dataframe['host_ids'].dropna() if isinstance(s, set)]
+            all_hosts = set().union(*host_sets) if host_sets else set()
+            hosts_automated_total = len(all_hosts)
+        else:
+            hosts_automated_total = 0
 
         # Prepare rollup data (dataframes before conversion)
         rollup_data = {


### PR DESCRIPTION
[AAP-61941]

Optimize event rollups by processing it in batches while accepting loosing of small precision.

## Before:
Each batch was preprocessed only a little in prepare function - some columns were dropped, events were filtered (and now they are filtered in collector, but I kept filtering also here just in case, so we dont rely too much on having something in collectors only).

Then they were aggregated by job, task and host - searching for events for particular task - there can be reruns, so they may be task failures on one host, then success. Those reruns were aggregated into one row. Tasks with no reruns were kept as original - one row.

Then in base function - the aggregation was done again, because some task can be scattered between two nearby batches (nearby = two subsequent batches in time). The second aggregation aggregated again and if for example in first batch the task on host was filed and the same task in second batch succeeded, the result is success with reruns.

## After
Whole aggregation above is done in prepare function, greatly aggregating within one batches - for example, for 1000 hosts (average accross jobs), there will be 1000 times less rows in dataframe.

It aggregates first as above in prepare function, but then it aggregates all hosts for particular tasks into one record, counting number of success, failures and such. It also pushes lost host information into set of host_id, holding set of aggregated hosts ids into array - this adds some extra memory, but way lower than holding whole row for each host.

This aggregation is then passed in base function and this remains unchanged (beside deleting aggregations that are now in prepare] and categorization is now not necessary - much lower number of rows.

Downside is the less precision -borderline tasks scattered between batches are now counted twice. This is hopefully not big problem since with hourly collection, it is probable, that everything will fit into one batch anyway and for more batches, only very small percentage of tasks will be counted twice.