### PR TITLE
vcpu - update library, add run-vcpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 - TODO
 
 
+## 0.6.3
+
+- vcpu collector - add timezone info to timestamps where missing
+
+
+## 0.6.2
+
+- vcpu collector - add extra log info
+
+
 ## 0.6.1
 
 - vcpu collector - use prometheus

--- a/metrics_utility/library/collectors/others/total_workers_vcpu.py
+++ b/metrics_utility/library/collectors/others/total_workers_vcpu.py
@@ -17,9 +17,9 @@ def total_workers_vcpu(*, cluster_name=None, metering_enabled=False, prometheus_
 
     info = {
         'cluster_name': cluster_name,
-        'collection_timestamp': datetime.fromtimestamp(current_ts).isoformat(),
-        'start_timestamp': datetime.fromtimestamp(prev_hour_start).isoformat(),
-        'end_timestamp': datetime.fromtimestamp(prev_hour_end).isoformat(),
+        'collection_timestamp': datetime.fromtimestamp(current_ts, timezone.utc).isoformat(),
+        'start_timestamp': datetime.fromtimestamp(prev_hour_start, timezone.utc).isoformat(),
+        'end_timestamp': datetime.fromtimestamp(prev_hour_end, timezone.utc).isoformat(),
         'usage_based_billing_enabled': metering_enabled,
         # total_workers_vcpu
         # promql_query

--- a/run-ccsp2-build
+++ b/run-ccsp2-build
@@ -21,8 +21,7 @@ export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Pl
 
 export METRICS_UTILITY_OPTIONAL_CCSP_REPORT_SHEETS="ccsp_summary,data_collection_status,indirectly_managed_nodes,infrastructure_summary,inventory_scope,jobs,managed_nodes,managed_nodes_by_organizations,usage_by_collections,usage_by_modules,usage_by_organizations,usage_by_roles"
 
-TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
-$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+env time -format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --month=2024-04 --force "$@"
 
 set -x

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -5,16 +5,15 @@ cd "`dirname "$0"`"
 export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="directory"
 
-# FIXME: total_workers_vcpu needs more setup
+# total_workers_vcpu excluded - see ./run-vcpu
 export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"
 
 if ! pg_isready -h localhost; then
-  echo "run-s3-gather-build: DB not ready, run make compose first"
+  echo "run-ccsp2-gather: DB not ready, run make compose first"
   exit 1
 fi
 
-TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
-$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+env time -format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"
 
 set -x

--- a/run-renewal
+++ b/run-renewal
@@ -7,12 +7,11 @@ export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="controller_db"
 
 if ! pg_isready -h localhost; then
-  echo "run-s3-gather-build: DB not ready, run make compose first"
+  echo "run-renewal: DB not ready, run make compose first"
   exit 1
 fi
 
-TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
-$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+env time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
 uv run ./manage.py build_report --since=12months --ephemeral=1month --force "$@"
 
 set -x

--- a/run-vcpu
+++ b/run-vcpu
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+cd "`dirname "$0"`"
+
+export METRICS_UTILITY_CLUSTER_NAME="aap-dev"
+export METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR="true"
+export METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES="true"
+export METRICS_UTILITY_OPTIONAL_COLLECTORS="total_workers_vcpu"
+export METRICS_UTILITY_PROMETHEUS_URL="http://localhost:12345" # FIXME
+export METRICS_UTILITY_SHIP_PATH="./out/vcpu"
+export METRICS_UTILITY_SHIP_TARGET="directory"
+export METRICS_UTILITY_USAGE_BASED_METERING_ENABLED="true"
+
+if ! pg_isready -h localhost; then
+  echo "run-vcpu: DB not ready, run make compose first"
+  exit 1
+fi
+
+env time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+uv run ./manage.py gather_automation_controller_billing_data --ship --verbose
+
+set -x
+ls -lR out/vcpu/data/`date +%Y`/

--- a/tools/perf/run-perf-build
+++ b/tools/perf/run-perf-build
@@ -2,9 +2,8 @@
 set -e
 cd "`dirname "$0"`"
 
-TIME=`command -v gtime >/dev/null && echo 'gtime' || echo '/usr/bin/time'`
 measure() {
-  "$TIME" --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' -o /dev/stdout "$@"
+  env time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' -o /dev/stdout "$@"
 }
 
 log() {

--- a/tools/perf/run-perf-gen
+++ b/tools/perf/run-perf-gen
@@ -2,9 +2,8 @@
 set -e
 cd "`dirname "$0"`"
 
-TIME=`command -v gtime >/dev/null && echo 'gtime' || echo '/usr/bin/time'`
 measure() {
-  "$TIME" --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' -o /dev/stdout "$@"
+  env time --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' -o /dev/stdout "$@"
 }
 
 log() {


### PR DESCRIPTION
draft, mostly so I don't forget

port changes from #314 to library/ (TODO, all, not just the first bit)

adds a run-vcpu script to test things locally (TODO prometheus)
but might depend on the library changes so that I can provide different sources for the /var/kubernetes path and cert path.

update changelog