### PR TITLE
ruff updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.14.10
     hooks:
-      - id: ruff
+      - id: ruff-check
+      - id: ruff-format

--- a/metrics_utility/test/conftest.py
+++ b/metrics_utility/test/conftest.py
@@ -38,7 +38,7 @@ def setup_processed_dataframe(fixed_now):
         mock_df_for_batch_processed[col] = pd.to_datetime(mock_df_for_batch_processed[col], utc=True).dt.tz_localize(None)
 
     mock_df_for_batch_processed['last_deleted'] = mock_df_for_batch_processed['last_deleted'].apply(
-        lambda x: (x.isoformat(timespec='seconds') if pd.notna(x) and isinstance(x, dt_actual.datetime) else None)
+        lambda x: x.isoformat(timespec='seconds') if pd.notna(x) and isinstance(x, dt_actual.datetime) else None
     )
 
     mock_batches = [{'host_metric': mock_df_for_batch_processed}]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,7 @@ sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
 
 # Only scan with python3
-sonar.python.version=3.11,3.12
+sonar.python.version=3.12
 
 # Ignore code dupe for the migrations, tests and xlsx report definitions
 sonar.issue.ignore.multicriteria.e2.ruleKey=python:S1192


### PR DESCRIPTION
looks like new version of ruff is out and the formatting rules changed slightly - updating
bump the version of ruff used by pre-commit to match uv.lock.
and drop python 3.11 from sonar config, leave only 3.12