### PR TITLE
add --date flag to generator

### DIFF
--- a/metrics_utility/test/conftest.py
+++ b/metrics_utility/test/conftest.py
@@ -38,7 +38,7 @@ def setup_processed_dataframe(fixed_now):
         mock_df_for_batch_processed[col] = pd.to_datetime(mock_df_for_batch_processed[col], utc=True).dt.tz_localize(None)
 
     mock_df_for_batch_processed['last_deleted'] = mock_df_for_batch_processed['last_deleted'].apply(
-        lambda x: (x.isoformat(timespec='seconds') if pd.notna(x) and isinstance(x, dt_actual.datetime) else None)
+        lambda x: x.isoformat(timespec='seconds') if pd.notna(x) and isinstance(x, dt_actual.datetime) else None
     )
 
     mock_batches = [{'host_metric': mock_df_for_batch_processed}]

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -4,7 +4,9 @@
 import argparse
 import random
 import uuid
+from datetime import datetime, timedelta
 
+import helpers
 from helpers import (
     create_hosts,
     create_inventory,
@@ -179,8 +181,15 @@ if __name__ == '__main__':
     parser.add_argument('--job-count', type=int, default=20, help='Number of jobs to create (default: 5)')
     parser.add_argument('--task-count', type=int, default=50, help='Number of tasks per job (default: 50)')
     parser.add_argument('--template-count', type=int, default=10, help='Number of job templates to create (default: 10)')
+    parser.add_argument('--date', type=str, default=None, help='Constrain jobs to a single day (e.g. 2024-01-25). Default spreads across all of January 2024')
 
     args = parser.parse_args()
+
+    # Override date range if --date is provided
+    if args.date:
+        date = datetime.fromisoformat(args.date)
+        helpers.JOB_DATE_START = date.replace(hour=0, minute=0, second=0, microsecond=0)
+        helpers.JOB_DATE_END = (date + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
     fill_perf_db_data(
         host_count=args.host_count,

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -7,8 +7,6 @@ import uuid
 
 from datetime import datetime, timedelta
 
-import helpers
-
 from helpers import (
     create_hosts,
     create_inventory,
@@ -91,7 +89,7 @@ def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffi
     }
 
 
-def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=10):
+def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=10, start_date=None, end_date=None):
     """Fill the database with performance test data.
 
     Note: This function does NOT clean existing data. Use clean_all_data.py to clean before filling.
@@ -101,21 +99,22 @@ def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=
         job_count: Number of jobs to create
         task_count: Number of tasks per job
         template_count: Number of job templates to create
+        start_date: Start of the date range for job timestamps
+        end_date: End of the date range for job timestamps
     """
     print(f'=== Configuration: {host_count} hosts, {job_count} jobs, {task_count} tasks/job, {template_count} templates ===')
 
-    # Create partitions for January 2024 (required for partitioned main_jobevent)
-    create_jobevent_partitions()
+    create_jobevent_partitions(start_date, end_date)
 
     init_data = fill_init_data(host_count=host_count, task_count=task_count, template_count=template_count)
 
     for i in range(job_count):
-        fill_job(init_data, i)
+        fill_job(init_data, i, start_date, end_date)
 
     print_counts()
 
 
-def fill_job_data(init_data, job_index):
+def fill_job_data(init_data, job_index, start_date, end_date):
     """Create a job using the init_data IDs. Returns (job_id, job_created, job_finished)."""
     # Randomly select a job template
     templates = init_data['templates']
@@ -129,6 +128,8 @@ def fill_job_data(init_data, job_index):
         org_id=init_data['org_id'],
         job_index=job_index,
         job_template_id=template_id,
+        start_date=start_date,
+        end_date=end_date,
     )
     return job_id, job_created, job_finished
 
@@ -141,8 +142,8 @@ def fill_jobevent(init_data, job_id, job_index, job_created):
     create_job_events(job_id, init_data['host_ids'], init_data['task_count'], job_index, job_created, unique_suffix=init_data.get('unique_suffix'))
 
 
-def fill_job(init_data, job_index):
-    job_id, job_created, job_finished = fill_job_data(init_data, job_index)
+def fill_job(init_data, job_index, start_date, end_date):
+    job_id, job_created, job_finished = fill_job_data(init_data, job_index, start_date, end_date)
     fill_jobhostsummary(init_data, job_id, job_created, job_finished)
     fill_jobevent(init_data, job_id, job_index, job_created)
     return
@@ -192,12 +193,17 @@ if __name__ == '__main__':
     # Override date range if --date is provided
     if args.date:
         date = datetime.fromisoformat(args.date)
-        helpers.JOB_DATE_START = date.replace(hour=0, minute=0, second=0, microsecond=0)
-        helpers.JOB_DATE_END = (date + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = (date + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    else:
+        start_date = datetime(2024, 1, 1, 0, 0, 0)
+        end_date = datetime(2024, 1, 31, 23, 59, 59)
 
     fill_perf_db_data(
         host_count=args.host_count,
         job_count=args.job_count,
         task_count=args.task_count,
         template_count=args.template_count,
+        start_date=start_date,
+        end_date=end_date,
     )

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -4,9 +4,11 @@
 import argparse
 import random
 import uuid
+
 from datetime import datetime, timedelta
 
 import helpers
+
 from helpers import (
     create_hosts,
     create_inventory,
@@ -181,7 +183,9 @@ if __name__ == '__main__':
     parser.add_argument('--job-count', type=int, default=20, help='Number of jobs to create (default: 5)')
     parser.add_argument('--task-count', type=int, default=50, help='Number of tasks per job (default: 50)')
     parser.add_argument('--template-count', type=int, default=10, help='Number of job templates to create (default: 10)')
-    parser.add_argument('--date', type=str, default=None, help='Constrain jobs to a single day (e.g. 2024-01-25). Default spreads across all of January 2024')
+    parser.add_argument(
+        '--date', type=str, default=None, help='Constrain jobs to a single day (e.g. 2024-01-25). Default spreads across all of January 2024'
+    )
 
     args = parser.parse_args()
 

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -2,7 +2,7 @@ import json
 import random
 import uuid
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from modules import MODULES
 
@@ -403,10 +403,12 @@ def create_hosts(inventory_id=None, host_count=1000, unique_suffix=None):
     return host_ids
 
 
-def create_job(name='Perf Test Job', inventory_id=None, project_id=None, org_id=None, job_index=0, job_template_id=None):
+def create_job(
+    name='Perf Test Job', inventory_id=None, project_id=None, org_id=None, job_index=0, job_template_id=None, start_date=None, end_date=None
+):
     """Create a job (via unified_job) and return its auto-generated ID and timestamps."""
     # Get deterministic timestamps for this job
-    created, started, finished = get_job_timestamps(job_index)
+    created, started, finished = get_job_timestamps(job_index, start_date, end_date)
     elapsed = (finished - started).total_seconds()
 
     created_str = created.strftime('%Y-%m-%d %H:%M:%S+00')
@@ -518,23 +520,15 @@ def create_job_host_summaries(job_id, host_count, job_created, job_finished, uni
 # Random seed for deterministic generation
 RANDOM_SEED = 42
 
-# Job date range: January 2024
-JOB_DATE_START = datetime(2024, 1, 1, 0, 0, 0)
-JOB_DATE_END = datetime(2024, 1, 31, 23, 59, 59)
 
-
-def create_jobevent_partitions():
-    """Create hourly partitions for main_jobevent for January 2024 (batch SQL)."""
-    print('Creating jobevent partitions for January 2024...')
-
-    # Create partitions for each hour in January 2024
-    start = datetime(2024, 1, 1, 0, 0, 0)
-    end = datetime(2024, 2, 1, 0, 0, 0)
+def create_jobevent_partitions(start_date, end_date):
+    """Create hourly partitions for main_jobevent (batch SQL)."""
+    print(f'Creating jobevent partitions from {start_date} to {end_date}...')
 
     # Build all CREATE TABLE statements in one batch
     statements = []
-    current = start
-    while current < end:
+    current = start_date
+    while current < end_date:
         next_hour = current + timedelta(hours=1)
         partition_name = f'main_jobevent_{current.strftime("%Y%m%d_%H")}'
 
@@ -550,20 +544,20 @@ def create_jobevent_partitions():
     sql = ';\n'.join(statements) + ';'
     run(sql)
 
-    print(f'Created {len(statements)} hourly partitions for January 2024')
+    print(f'Created {len(statements)} hourly partitions')
 
 
-def get_job_timestamps(job_index):
-    """Generate deterministic job timestamps within January 2024.
+def get_job_timestamps(job_index, start_date, end_date):
+    """Generate deterministic job timestamps within the given date range.
 
     Returns (created, started, finished) timestamps.
     """
     rng = random.Random(RANDOM_SEED + job_index)
 
-    # Job created: random time within January 2024
-    total_seconds = int((JOB_DATE_END - JOB_DATE_START).total_seconds())
+    # Job created: random time within the date range
+    total_seconds = int((end_date - start_date).total_seconds())
     created_offset = rng.randint(0, total_seconds - 7200)  # Leave room for job duration
-    created = JOB_DATE_START + timedelta(seconds=created_offset)
+    created = start_date + timedelta(seconds=created_offset)
 
     # Job started: 1-60 minutes after created (queue wait time)
     wait_seconds = rng.randint(60, 3600)


### PR DESCRIPTION
[AAP-64856]


## Description

The generator script fill_perf_db_data.py is hard-coded to generate data across the month of January 2024. For performance testing, we need the option to target one day with this script to ensure data covers most hours in the 24 hour period we are testing. Enter the `--date` param.

Usage example: 
```
.venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
      --date=2024-01-25 \
      --job-count=20 \
      --host-count=1000 \
      --task-count=50
```



### Steps to Test

1.
2.
3.

### Expected Results

<!-- Describe what should happen after following the steps -->

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
