### PR TITLE
AAP-62673: library: collect to dataframe

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -479,18 +479,23 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt):
     return anonymized_rollup
 
 
-# loads data from tarballs located in base_path/data/year/month/day/*{collector_name}*.tar.gz
-# inside tarball is file named {collector_name}.csv
-# this goes to dataframe, then filter_function is applied to the dataframe
+# loads data from a list of dataframes
+# then filter_function is applied to the dataframe
 # all result dataframes are concatenated into one dataframe
-def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, file_list: []):
-    # file_list - list of csv files that needs to be read
+def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, dataframe_list):
+    # compat for one dataframe
+    if isinstance(dataframe_list, pd.DataFrame):
+        prepared_data = rollup_object.prepare(dataframe_list)
+        return rollup_object.merge(None, prepared_data)
 
     concat_data = None
 
-    for file in file_list:
-        df = pd.read_csv(file, encoding='utf-8')
-        prepared_data = rollup_object.prepare(df)
+    for dataframe in dataframe_list:
+        # compat for CSVs
+        if isinstance(dataframe, str):
+            dataframe = pd.read_csv(dataframe, encoding='utf-8')
+
+        prepared_data = rollup_object.prepare(dataframe)
         concat_data = rollup_object.merge(concat_data, prepared_data)
 
     return concat_data

--- a/metrics_utility/anonymized_rollups/execution_environments_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/execution_environments_anonymized_rollup.py
@@ -26,7 +26,7 @@ class ExecutionEnvironmentsAnonymizedRollup(BaseAnonymizedRollup):
             }
 
         execution_environments_total = int(len(dataframe))
-        dataframe['managed'] = dataframe['managed'].map({'t': True, 'f': False})
+        dataframe['managed'] = dataframe['managed'].map({'t': True, 'f': False, True: True, False: False})
         execution_environments_default_total = int(dataframe['managed'].sum())
         execution_environments_custom_total = execution_environments_total - execution_environments_default_total
 

--- a/metrics_utility/library/README.md
+++ b/metrics_utility/library/README.md
@@ -11,8 +11,8 @@ It provides an abstraction over collectors, packaging and storage, extraction, r
 
 Collector is python function which accepts params, gathers data, and returns it in one of the supported formats.
 
-It either returns a python dict, which gets serialized into JSON,
-or a list of filenames of temporary files it created.
+It either returns a python dict (for snapshot collectors like config),
+or a pandas DataFrame (for SQL-based collectors).
 
 It's exported decorated to wrap calls into BaseCollector subclass instances, so that param passing can happen separately from .gather().
 The wrapper ensures that any calls to `my_collector(db=connection).gather()` do the same thing as an undecorated `my_collector(db=connection)` - this is so that initialization can happen before db locks are acquired.
@@ -28,14 +28,15 @@ Currently supported:
 
 Controller collectors (in `metrics_utility.library.collectors.controller`):
 * `config(db, billing_provider_params).gather() -> Dict`
-* `execution_environments(db, [output_dir]).gather() -> [filenames]`
-* `job_host_summary(db, since, until, [output_dir]).gather() -> [filenames]`
-* `job_host_summary_service(db, since, until, [output_dir]).gather() -> [filenames]`
-* `main_host(db, [output_dir]).gather() -> [filenames]`
-* `main_indirectmanagednodeaudit(db, since, until, [output_dir]).gather() -> [filenames]`
-* `main_jobevent(db, since, until, [output_dir]).gather() -> [filenames]`
-* `main_jobevent_service(db, since, until, [output_dir]).gather() -> [filenames]`
-* `unified_jobs(db, since, until, [output_dir]).gather() -> [filenames]`
+* `execution_environments(db).gather() -> DataFrame`
+* `job_host_summary(db, since, until).gather() -> DataFrame`
+* `job_host_summary_service(db, since, until).gather() -> DataFrame`
+* `main_host(db).gather() -> DataFrame`
+* `main_host_daily(db, since, until).gather() -> DataFrame`
+* `main_indirectmanagednodeaudit(db, since, until).gather() -> DataFrame`
+* `main_jobevent(db, since, until).gather() -> DataFrame`
+* `main_jobevent_service(db, since, until).gather() -> DataFrame`
+* `unified_jobs(db, since, until).gather() -> DataFrame`
 
 Other collectors (in `metrics_utility.library.collectors.others`):
 * `total_workers_vcpu(cluster_name, metering_enabled, prometheus_url, ca_cert_path, token) -> Dict`

--- a/metrics_utility/library/README.md
+++ b/metrics_utility/library/README.md
@@ -41,6 +41,17 @@ Controller collectors (in `metrics_utility.library.collectors.controller`):
 Other collectors (in `metrics_utility.library.collectors.others`):
 * `total_workers_vcpu(cluster_name, metering_enabled, prometheus_url, ca_cert_path, token) -> Dict`
 
+For CLI usage or when CSV files are needed, use the `dataframe_to_csv_files()` helper from `metrics_utility.library.csv_utils`:
+
+```python
+from metrics_utility.library.csv_utils import dataframe_to_csv_files
+
+df = execution_environments(db=db).gather()
+csv_files = dataframe_to_csv_files(df, 'main_executionenvironment', '/tmp/output')
+# Returns: ['/tmp/output/main_executionenvironment_table.csv']
+# or ['.._split0.csv', '.._split1.csv', ...] for large datasets
+```
+
 
 #### Package
 

--- a/metrics_utility/library/collectors/controller/config.py
+++ b/metrics_utility/library/collectors/controller/config.py
@@ -96,10 +96,10 @@ def _get_install_type():
     return 'traditional'
 
 
+# FIXME: psycopg.sql
 def _get_controller_settings(db, keys):
     settings = {}
     with db.cursor() as cursor:
-        # FIXME: psycopg.sql ?
         in_sql = "'" + "', '".join(keys) + "'"
         cursor.execute(f'SELECT key, value FROM conf_setting WHERE key IN ({in_sql})')
         for key, value in cursor.fetchall():

--- a/metrics_utility/library/collectors/controller/credentials_service.py
+++ b/metrics_utility/library/collectors/controller/credentials_service.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def credentials_service(*, db=None, since=None, until=None, output_dir=None):
+def credentials_service(*, db=None, since=None, until=None):
     query = f"""
         SELECT
             main_credentialtype.name as credential_type,
@@ -19,4 +19,4 @@ def credentials_service(*, db=None, since=None, until=None, output_dir=None):
         ORDER BY main_unifiedjob.id ASC, main_credentialtype.name ASC
     """
 
-    return copy_table(db=db, table='credentials', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/controller/execution_environments.py
+++ b/metrics_utility/library/collectors/controller/execution_environments.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def execution_environments(*, db=None, output_dir=None):
+def execution_environments(*, db=None):
     query = """
         SELECT
             id,
@@ -20,4 +20,4 @@ def execution_environments(*, db=None, output_dir=None):
         FROM main_executionenvironment
     """
 
-    return copy_table(db=db, table='main_executionenvironment', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/controller/job_host_summary.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def job_host_summary(*, db=None, since=None, until=None, output_dir=None):
+def job_host_summary(*, db=None, since=None, until=None):
     where = ' AND '.join(
         [
             f"main_jobhostsummary.modified >= '{since.isoformat()}'",
@@ -78,4 +78,4 @@ def job_host_summary(*, db=None, since=None, until=None, output_dir=None):
         ORDER BY main_jobhostsummary.modified ASC
     """
 
-    return copy_table(db=db, table='main_jobhostsummary', query=query, prepend_query=True, output_dir=output_dir)
+    return copy_table(db=db, query=query, prepend_query=True)

--- a/metrics_utility/library/collectors/controller/job_host_summary_service.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary_service.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def job_host_summary_service(*, db=None, since=None, until=None, output_dir=None):
+def job_host_summary_service(*, db=None, since=None, until=None):
     where = ' AND '.join(
         [
             f"mu.finished >= '{since.isoformat()}'",
@@ -85,4 +85,4 @@ def job_host_summary_service(*, db=None, since=None, until=None, output_dir=None
         ORDER BY mu.finished ASC
     """
 
-    return copy_table(db=db, table='main_jobhostsummary', query=query, prepend_query=True, output_dir=output_dir)
+    return copy_table(db=db, query=query, prepend_query=True)

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -87,13 +87,13 @@ def _main_host_query(where):
 
 
 @collector
-def main_host(*, db=None, output_dir=None):
+def main_host(*, db=None):
     query = _main_host_query("enabled='t'")
-    return copy_table(db=db, table='main_host', query=query, prepend_query=True, output_dir=output_dir)
+    return copy_table(db=db, query=query, prepend_query=True)
 
 
 @collector
-def main_host_daily(*, db=None, since=None, until=None, output_dir=None):
+def main_host_daily(*, db=None, since=None, until=None):
     # prefer running with until=False, to not skip hosts that keep being modified
 
     where = f"""
@@ -102,4 +102,4 @@ def main_host_daily(*, db=None, since=None, until=None, output_dir=None):
         OR {date_where('main_host.modified', since, until)})
     """
     query = _main_host_query(where)
-    return copy_table(db=db, table='main_host_daily', query=query, prepend_query=True, output_dir=output_dir)
+    return copy_table(db=db, query=query, prepend_query=True)

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output_dir=None):
+def main_indirectmanagednodeaudit(*, db=None, since=None, until=None):
     where = ' AND '.join(
         [
             f"main_indirectmanagednodeaudit.created >= '{since.isoformat()}'",
@@ -40,4 +40,4 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output_dir
         ORDER BY main_indirectmanagednodeaudit.created ASC
     """
 
-    return copy_table(db=db, table='main_indirectmanagednodeaudit', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/controller/main_jobevent.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def main_jobevent(*, db=None, since=None, until=None, output_dir=None):
+def main_jobevent(*, db=None, since=None, until=None):
     where = ' AND '.join(
         [
             f"main_jobhostsummary.modified >= '{since.isoformat()}'",
@@ -65,4 +65,4 @@ def main_jobevent(*, db=None, since=None, until=None, output_dir=None):
         )
         """
 
-    return copy_table(db=db, table='main_jobevent', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -4,7 +4,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
+def main_jobevent_service(*, db=None, since=None, until=None):
     """
     Collects job events for jobs that finished in the given time window.
 
@@ -160,4 +160,4 @@ def main_jobevent_service(*, db=None, since=None, until=None, output_dir=None):
         WHERE {where_clause}
     """
 
-    return copy_table(db=db, table='main_jobevent', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/controller/unified_jobs.py
+++ b/metrics_utility/library/collectors/controller/unified_jobs.py
@@ -2,7 +2,7 @@ from ..util import collector, copy_table
 
 
 @collector
-def unified_jobs(*, db=None, since=None, until=None, output_dir=None):
+def unified_jobs(*, db=None, since=None, until=None):
     query = f"""
         SELECT
             main_unifiedjob.id,
@@ -48,4 +48,4 @@ def unified_jobs(*, db=None, since=None, until=None, output_dir=None):
         ORDER BY main_unifiedjob.id ASC
     """
 
-    return copy_table(db=db, table='unified_jobs', query=query, output_dir=output_dir)
+    return copy_table(db=db, query=query)

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -51,8 +51,20 @@ def copy_table(db, query, params=None, prepend_query=False):
         with db.cursor() as cursor:
             cursor.execute(_yaml_json_functions())
 
-    # Use pandas read_sql for optimized DataFrame creation
-    df = pd.read_sql(query, db, params=params)
+    # Execute query and create DataFrame from results
+    # Using cursor approach since pd.read_sql doesn't work well with psycopg3
+    with db.cursor() as cursor:
+        cursor.execute(query, params)
+
+        # Get column names from cursor description
+        columns = [desc[0] for desc in cursor.description]
+
+        # Fetch all rows
+        rows = cursor.fetchall()
+
+        # Create DataFrame
+        df = pd.DataFrame(rows, columns=columns)
+
     return df
 
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -1,10 +1,3 @@
-import os
-import pathlib
-import tempfile
-
-from ..csv_file_splitter import CsvFileSplitter
-
-
 # FIXME: psycopg.sql
 def date_where(field, since, until):
     if since and until:
@@ -38,57 +31,29 @@ def collector(func):
     return constructor
 
 
-# FIXME: cleanup
-def init_tmp_dir():
-    tmp_dir = pathlib.Path(tempfile.mkdtemp(prefix='awx_analytics-'))
-    gather_dir = tmp_dir.joinpath('stage')
-    gather_dir.mkdir(mode=0o700)
-    return gather_dir
+def copy_table(db, query, params=None, prepend_query=False):
+    """
+    Execute SQL query and return data as pandas DataFrame.
 
+    Args:
+        db: psycopg db connection
+        query: SQL query to execute
+        params: (Optional) query params
+        prepend_query: (bool) Use when parse_yaml_field or is_valid_json are required by the query
 
-def copy_table(db, table, query, params=None, prepend_query=False, output_file=None, output_dir='.'):
-    file = output_file
-    if not output_file:
-        path = output_dir or init_tmp_dir()
-        file_path = os.path.join(path, table + '_table.csv')
-        file = CsvFileSplitter(filespec=file_path)
+    Returns:
+        pandas DataFrame with query results
+    """
+    import pandas as pd
 
-    with db.cursor() as cursor:
-        if prepend_query:
+    # Execute prepend_query if needed (custom PostgreSQL functions)
+    if prepend_query:
+        with db.cursor() as cursor:
             cursor.execute(_yaml_json_functions())
 
-        copy_query = f'COPY ({query}) TO STDOUT WITH CSV HEADER'
-
-        # FIXME: remove once 2.4 is no longer supported
-        if hasattr(cursor, 'copy_expert') and callable(cursor.copy_expert):
-            _copy_table_aap_2_4_and_below(cursor, copy_query, params, file)
-        else:
-            _copy_table_aap_2_5_and_above(cursor, copy_query, params, file)
-
-    if output_file:
-        return [output_file.name]
-    return file.file_list(keep_empty=True)
-
-
-def _copy_table_aap_2_4_and_below(cursor, query, params, file):
-    if params:
-        # copy_expert doesn't support params, make do (but no escaping)
-        for p in params:
-            if f'%({p})s' in query:
-                query = query.replace(f'%({p})s', f'"{params[p]}"')
-            if f'%({p})d' in query:
-                query = query.replace(f'%({p})d', str(int(params[p])))
-
-    # Automation Controller 4.4 and below use psycopg2 with .copy_expert() method
-    cursor.copy_expert(query, file)
-
-
-def _copy_table_aap_2_5_and_above(cursor, query, params, file):
-    # Automation Controller 4.5 and above use psycopg3 with .copy() method
-    with cursor.copy(query, params) as copy:
-        while data := copy.read():
-            byte_data = bytes(data)
-            file.write(byte_data.decode())
+    # Use pandas read_sql for optimized DataFrame creation
+    df = pd.read_sql(query, db, params=params)
+    return df
 
 
 def _yaml_json_functions():

--- a/metrics_utility/library/csv_utils.py
+++ b/metrics_utility/library/csv_utils.py
@@ -1,0 +1,45 @@
+"""CSV utilities for converting DataFrames to split CSV files."""
+
+import os
+
+from .csv_file_splitter import CsvFileSplitter
+
+
+def dataframe_to_csv_files(df, table_name, output_dir, max_file_size=200 * 1048576):
+    """
+    Convert pandas DataFrame to split CSV files.
+
+    Uses CsvFileSplitter to handle large datasets by creating multiple files
+    when size exceeds max_file_size.
+
+    Args:
+        df: pandas DataFrame to write
+        table_name: Base name for CSV files (e.g., 'main_executionenvironment')
+        output_dir: Directory to write files to
+        max_file_size: Maximum size per file in bytes (default: 200MB)
+
+    Returns:
+        List of file paths created. For small datasets returns one file,
+        for large datasets returns multiple files with _split0, _split1 suffixes.
+    """
+    import pandas as pd
+
+    file_path = os.path.join(output_dir, f'{table_name}_table.csv')
+
+    if df is None:
+        # just an empty file
+        with open(file_path, 'w'):
+            pass
+
+        return [file_path]
+
+    if isinstance(df, pd.DataFrame) and df.empty:
+        # empty file with headers only
+        df.to_csv(file_path, index=False)
+
+        return [file_path]
+
+    file = CsvFileSplitter(filespec=file_path, max_file_size=max_file_size)
+    df.to_csv(file, index=False)
+
+    return file.file_list(keep_empty=True)

--- a/metrics_utility/library/csv_utils.py
+++ b/metrics_utility/library/csv_utils.py
@@ -22,24 +22,15 @@ def dataframe_to_csv_files(df, table_name, output_dir, max_file_size=200 * 10485
         List of file paths created. For small datasets returns one file,
         for large datasets returns multiple files with _split0, _split1 suffixes.
     """
-    import pandas as pd
 
     file_path = os.path.join(output_dir, f'{table_name}_table.csv')
 
     if df is None:
-        # just an empty file
-        with open(file_path, 'w'):
-            pass
+        return []
 
-        return [file_path]
-
-    if isinstance(df, pd.DataFrame) and df.empty:
-        # empty file with headers only
-        df.to_csv(file_path, index=False)
-
-        return [file_path]
+    if df.empty and len(df.columns) == 0:
+        return []
 
     file = CsvFileSplitter(filespec=file_path, max_file_size=max_file_size)
     df.to_csv(file, index=False)
-
     return file.file_list(keep_empty=True)

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -1,7 +1,6 @@
 import csv
 import glob
 import os
-import tempfile
 
 from datetime import datetime, timezone
 
@@ -102,10 +101,20 @@ def _parse_expected_csv(expected_lines):
     return expected_rows[0], expected_rows[1:]
 
 
-def _read_actual_csv(csv_file_path):
-    """Read and parse actual CSV file."""
-    with open(csv_file_path, 'r') as f:
-        text = f.read().splitlines()
+def _read_dataframe(df):
+    # Convert boolean columns from True/False to t/f
+    # Convert float columns that are actually integers to Int64
+    df_copy = df.copy()
+    for col in df_copy.columns:
+        if df_copy[col].dtype == 'bool':
+            df_copy[col] = df_copy[col].map({True: 't', False: 'f'})
+        elif df_copy[col].dtype in ['float64', 'float32']:
+            # If all non-null values are whole numbers, convert to nullable int
+            non_null_values = df_copy[col].dropna()
+            if len(non_null_values) > 0 and (non_null_values == non_null_values.astype(int)).all():
+                df_copy[col] = df_copy[col].astype('Int64')
+
+    text = df_copy.to_csv(index=False).splitlines()
     reader = csv.reader(text)
     rows = list(reader)
     return rows[0], rows[1:], text
@@ -164,14 +173,15 @@ def _validate_rows(actual_data_sorted, expected_data_sorted, header, skip_column
             )
 
 
-def validate_csv_file(csv_file_path, expected_lines, skip_columns_names):
-    """Validate CSV file directly.
+def validate_dataframe(df, expected_lines, skip_columns_names):
+    """Validate DataFrame
 
+    df: pandas DataFrame to validate
     expected_lines: list of strings where first is header, rest rows
     skip_columns_names: iterable of column names to skip comparison
     """
     expected_header, expected_data = _parse_expected_csv(expected_lines)
-    header, actual_data, text = _read_actual_csv(csv_file_path)
+    header, actual_data, text = _read_dataframe(df)
 
     _print_comparison(text, expected_lines)
     _validate_header(header, expected_header)
@@ -204,24 +214,24 @@ jobs_lines = [
     ),
     (
         '1,,job,2,default_org_2025-06-13,,4,default_inventory_2025-06-13,'
-        '2025-06-13 10:00:00+00,default_unified_job_2025-06-13,1,manual,,auto,'
-        'controller1,f,pending,f,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,0.000,,,'
+        '2025-06-13 10:00:00+00:00,default_unified_job_2025-06-13,1,manual,,auto,'
+        'controller1,f,pending,f,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,0.000,,,'
         '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
         '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,5,'
         'default_unified_job_template_2025-06-13,git'
     ),
     (
         '2,,job,2,default_org_2025-06-13,,4,default_inventory_2025-06-13,'
-        '2025-06-13 10:00:00+00,default_unified_job_2025-06-13,1,scheduled,,auto,'
-        'controller1,f,pending,f,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,0.000,,,'
+        '2025-06-13 10:00:00+00:00,default_unified_job_2025-06-13,1,scheduled,,auto,'
+        'controller1,f,pending,f,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,0.000,,,'
         '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
         '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,10,'
         'default_unified_job_template_2025-06-13,git'
     ),
     (
         '3,,job,2,default_org_2025-06-13,,4,default_inventory_2025-06-13,'
-        '2025-06-13 10:00:00+00,default_unified_job_2025-06-13,1,workflow,,auto,'
-        'controller1,f,pending,f,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,0.000,,,'
+        '2025-06-13 10:00:00+00:00,default_unified_job_2025-06-13,1,workflow,,auto,'
+        'controller1,f,pending,f,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,0.000,,,'
         '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
         '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,20,'
         'default_unified_job_template_2025-06-13,git'
@@ -247,21 +257,13 @@ def test_unified_jobs_command(cleanup_glob):
     until = datetime(2025, 6, 14, tzinfo=timezone.utc)
 
     # Run the new collector directly
-    with tempfile.TemporaryDirectory() as tmpdir:
-        collector_instance = unified_jobs(db=connection, since=since, until=until, output_dir=tmpdir)
-        csv_files = collector_instance.gather()
+    collector_instance = unified_jobs(db=connection, since=since, until=until)
+    df = collector_instance.gather()
 
-        # Find the unified_jobs CSV file (generated as unified_jobs_table.csv)
-        csv_file = None
-        for f in csv_files:
-            if 'unified_jobs_table.csv' in f or f.endswith('unified_jobs_table.csv'):
-                csv_file = f
-                break
+    assert df is not None, 'unified_jobs returned None'
 
-        assert csv_file is not None, f'unified_jobs CSV not found in {csv_files}'
-
-        # Validate CSV content
-        validate_csv_file(csv_file, jobs_lines, json_lines_skip_ids_columns)
+    # Validate DataFrame content
+    validate_dataframe(df, jobs_lines, json_lines_skip_ids_columns)
 
 
 jobs_host_summary_service_lines = [
@@ -273,44 +275,44 @@ jobs_host_summary_service_lines = [
         'organization_name,project_remote_id,project_name,model'
     ),
     (
-        '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,'
+        '1,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
         '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
+        '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
-        '2,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,'
+        '2,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
         '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
+        '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
-        '3,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,'
+        '3,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
         '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
+        '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
-        '4,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,'
+        '4,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
         '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
+        '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
-        '5,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_1_2025-06-13,'
+        '5,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
         '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
+        '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
-        '6,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,default_host_2_2025-06-13,'
+        '6,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
         '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
-        '2025-06-13 10:00:00+00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
+        '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
@@ -335,21 +337,13 @@ def test_job_host_summary_service_command(cleanup_glob):
     until = datetime(2025, 6, 14, tzinfo=timezone.utc)
 
     # Run the new collector directly
-    with tempfile.TemporaryDirectory() as tmpdir:
-        collector_instance = job_host_summary_service(db=connection, since=since, until=until, output_dir=tmpdir)
-        csv_files = collector_instance.gather()
+    collector_instance = job_host_summary_service(db=connection, since=since, until=until)
+    df = collector_instance.gather()
 
-        # Find the job_host_summary_service CSV file (generated as main_jobhostsummary_table.csv)
-        csv_file = None
-        for f in csv_files:
-            if 'main_jobhostsummary_table.csv' in f or f.endswith('main_jobhostsummary_table.csv'):
-                csv_file = f
-                break
+    assert df is not None, 'job_host_summary_service returned None'
 
-        assert csv_file is not None, f'job_host_summary_service CSV not found in {csv_files}'
-
-        # Validate CSV content
-        validate_csv_file(csv_file, jobs_host_summary_service_lines, jobs_host_summary_service_skip_columns)
+    # Validate DataFrame content
+    validate_dataframe(df, jobs_host_summary_service_lines, jobs_host_summary_service_skip_columns)
 
 
 main_jobevent_service_lines = [
@@ -357,78 +351,78 @@ main_jobevent_service_lines = [
     'task_action,resolved_action,resolved_role,duration,start,end,task_uuid,ignore_errors,failed,'
     'changed,playbook,play,task,role,job_remote_id,job_id,host_remote_id,host_id,'
     'host_name,warnings,deprecations,playbook_on_stats,job_failed,job_started',
-    '1,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    '1,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,1_default_host_1_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,1,1,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '2,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '2,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,1_default_host_1_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,1,1,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '3,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '3,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,1_default_host_2_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,1,1,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '4,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '4,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,1_default_host_2_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,1,1,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '5,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '5,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,2_default_host_1_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,2,2,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '6,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '6,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,2_default_host_1_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,2,2,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '7,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '7,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,2_default_host_2_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,2,2,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '8,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '8,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,2_default_host_2_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,2,2,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '9,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '9,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,3_default_host_1_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,3,3,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '10,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '10,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,3_default_host_1_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,3,3,31,31,'
-    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '11,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_1_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '11,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,ansible.builtin.yum,,,,,,3_default_host_2_2025-06-13_1,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,3,3,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '12,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '12,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     'UUID,,runner_on_ok,a10.acos_axapi.a10_slb_virtual_server,,,,,,3_default_host_2_2025-06-13_2,f,f,f,'
     'default_playbook.yml,default_play,default_task,default_role,3,3,32,32,'
-    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00',
-    '13,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    'default_host_2_2025-06-13,,,,f,2025-06-13 10:00:00+00:00',
+    '13,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     '13aac8b6-038d-4cbe-af99-67276d80d01b,,warning,,,,,,,,f,f,f,,,'
-    ',,1,1,,,,,,,f,2025-06-13 10:00:00+00',
-    '14,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    ',,1,1,,,,,,,f,2025-06-13 10:00:00+00:00',
+    '14,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     '8cdfc02a-8b52-4fe9-883a-1d6608f68c3f,,warning,,,,,,,,f,f,f,,,'
-    ',,2,2,,,,,,,f,2025-06-13 10:00:00+00',
-    '15,2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,'
-    '2025-06-13 10:00:00+00,2025-06-13 10:00:00+00,2.9.10,'
+    ',,2,2,,,,,,,f,2025-06-13 10:00:00+00:00',
+    '15,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,'
+    '2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,2.9.10,'
     '150d1d0c-dccb-4940-83ee-4d75c2f22493,,deprecated,,,,,,,,f,f,f,,,'
-    ',,3,3,,,,,,,f,2025-06-13 10:00:00+00',
+    ',,3,3,,,,,,,f,2025-06-13 10:00:00+00:00',
 ]
 
 
@@ -449,21 +443,13 @@ def test_main_jobevent_service_command(cleanup_glob):
     until = datetime(2025, 6, 14, tzinfo=timezone.utc)
 
     # Run the new collector directly
-    with tempfile.TemporaryDirectory() as tmpdir:
-        collector_instance = main_jobevent_service(db=connection, since=since, until=until, output_dir=tmpdir)
-        csv_files = collector_instance.gather()
+    collector_instance = main_jobevent_service(db=connection, since=since, until=until)
+    df = collector_instance.gather()
 
-        # Find the main_jobevent_service CSV file (generated as main_jobevent_table.csv)
-        csv_file = None
-        for f in csv_files:
-            if 'main_jobevent_table.csv' in f or f.endswith('main_jobevent_table.csv'):
-                csv_file = f
-                break
+    assert df is not None, 'main_jobevent_service returned None'
 
-        assert csv_file is not None, f'main_jobevent_service CSV not found in {csv_files}'
-
-        # Validate CSV content
-        validate_csv_file(csv_file, main_jobevent_service_lines, main_jobevent_service_skip_columns)
+    # Validate DataFrame content
+    validate_dataframe(df, main_jobevent_service_lines, main_jobevent_service_skip_columns)
 
 
 execution_environments_lines = [
@@ -525,18 +511,10 @@ def test_credentials_service_command(cleanup_glob):
     until = datetime(2025, 6, 14, tzinfo=timezone.utc)
 
     # Run the new collector directly
-    with tempfile.TemporaryDirectory() as tmpdir:
-        collector_instance = credentials_service(db=connection, since=since, until=until, output_dir=tmpdir)
-        csv_files = collector_instance.gather()
+    collector_instance = credentials_service(db=connection, since=since, until=until)
+    df = collector_instance.gather()
 
-        # Find the credentials_service CSV file (generated as credentials_table.csv)
-        csv_file = None
-        for f in csv_files:
-            if 'credentials_table.csv' in f or f.endswith('credentials_table.csv'):
-                csv_file = f
-                break
+    assert df is not None, 'credentials_service returned None'
 
-        assert csv_file is not None, f'credentials_service CSV not found in {csv_files}'
-
-        # Validate CSV content
-        validate_csv_file(csv_file, credentials_service_lines, credentials_service_skip_columns)
+    # Validate DataFrame content
+    validate_dataframe(df, credentials_service_lines, credentials_service_skip_columns)

--- a/metrics_utility/test/library/test_collectors_execution_environments.py
+++ b/metrics_utility/test/library/test_collectors_execution_environments.py
@@ -37,7 +37,6 @@ def test_execution_environments_calls_copy_table(mock_copy_table):
 
     # Should return the DataFrame from copy_table
     assert isinstance(result, pd.DataFrame)
-    assert len(result) == 2
 
 
 @patch('metrics_utility.library.collectors.controller.execution_environments.copy_table')

--- a/metrics_utility/test/library/test_collectors_execution_environments.py
+++ b/metrics_utility/test/library/test_collectors_execution_environments.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.execution_environments import execution_environments
 
 
@@ -15,22 +17,12 @@ def test_execution_environments_basic():
     assert instance.kwargs['db'] == mock_db
 
 
-def test_execution_environments_with_output_dir():
-    """Test execution_environments with custom output_dir."""
-    mock_db = MagicMock()
-    output_dir = '/tmp/test_output'
-
-    instance = execution_environments(db=mock_db, output_dir=output_dir)
-
-    assert instance.kwargs['db'] == mock_db
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.execution_environments.copy_table')
 def test_execution_environments_calls_copy_table(mock_copy_table):
     """Test that execution_environments calls copy_table with correct parameters."""
     mock_db = MagicMock()
-    mock_copy_table.return_value = ['/tmp/main_executionenvironment_table.csv']
+    # Return a DataFrame instead of file paths
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2], 'name': ['ee1', 'ee2']})
 
     instance = execution_environments(db=mock_db)
     result = instance.gather()
@@ -41,12 +33,11 @@ def test_execution_environments_calls_copy_table(mock_copy_table):
 
     # Verify parameters
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_executionenvironment'
     assert 'query' in call_args[1]
-    assert call_args[1]['output_dir'] is None
 
-    # Should return the result from copy_table
-    assert result == ['/tmp/main_executionenvironment_table.csv']
+    # Should return the DataFrame from copy_table
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
 
 
 @patch('metrics_utility.library.collectors.controller.execution_environments.copy_table')
@@ -69,17 +60,3 @@ def test_execution_environments_query_structure(mock_copy_table):
     assert 'modified' in query
     assert 'image' in query
     assert 'name' in query
-
-
-@patch('metrics_utility.library.collectors.controller.execution_environments.copy_table')
-def test_execution_environments_with_output_dir_passed_to_copy_table(mock_copy_table):
-    """Test that output_dir is passed to copy_table."""
-    mock_db = MagicMock()
-    output_dir = '/custom/output'
-    mock_copy_table.return_value = []
-
-    instance = execution_environments(db=mock_db, output_dir=output_dir)
-    instance.gather()
-
-    call_args = mock_copy_table.call_args
-    assert call_args[1]['output_dir'] == output_dir

--- a/metrics_utility/test/library/test_collectors_job_host_summary.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary.py
@@ -20,18 +20,6 @@ def test_job_host_summary_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_job_host_summary_with_output_dir():
-    """Test job_host_summary with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = job_host_summary(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.job_host_summary.copy_table')
 def test_job_host_summary_calls_copy_table(mock_copy_table):
     """Test that job_host_summary calls copy_table with correct parameters."""
@@ -47,7 +35,6 @@ def test_job_host_summary_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_jobhostsummary'
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_jobhostsummary_table.csv']

--- a/metrics_utility/test/library/test_collectors_job_host_summary.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.job_host_summary import job_host_summary
 
 
@@ -26,7 +28,7 @@ def test_job_host_summary_calls_copy_table(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 1, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = ['/tmp/main_jobhostsummary_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2], 'host_id': [10, 20]})
 
     instance = job_host_summary(db=mock_db, since=since, until=until)
     result = instance.gather()
@@ -37,7 +39,7 @@ def test_job_host_summary_calls_copy_table(mock_copy_table):
     assert call_args[1]['db'] == mock_db
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_jobhostsummary_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.job_host_summary.copy_table')
@@ -46,7 +48,7 @@ def test_job_host_summary_query_contains_time_range(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 1, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary(db=mock_db, since=since, until=until)
     instance.gather()
@@ -67,7 +69,7 @@ def test_job_host_summary_query_structure(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary(db=mock_db, since=since, until=until)
     instance.gather()
@@ -91,7 +93,7 @@ def test_job_host_summary_isoformat(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 6, 15, 12, 30, 45, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 6, 16, 14, 45, 30, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary(db=mock_db, since=since, until=until)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_job_host_summary_service.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary_service.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.job_host_summary_service import job_host_summary_service
 
 
@@ -26,7 +28,7 @@ def test_job_host_summary_service_calls_copy_table(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 1, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = ['/tmp/main_jobhostsummary_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2], 'host_id': [10, 20], 'job_id': [100, 101]})
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     result = instance.gather()
@@ -37,7 +39,7 @@ def test_job_host_summary_service_calls_copy_table(mock_copy_table):
     assert call_args[1]['db'] == mock_db
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_jobhostsummary_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.job_host_summary_service.copy_table')
@@ -46,7 +48,7 @@ def test_job_host_summary_service_query_contains_time_range(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 3, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 3, 15, 18, 30, 0, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()
@@ -67,7 +69,7 @@ def test_job_host_summary_service_query_structure(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()
@@ -95,7 +97,7 @@ def test_job_host_summary_service_filters_by_finished_jobs(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()
@@ -113,7 +115,7 @@ def test_job_host_summary_service_uses_yaml_json_functions(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()
@@ -132,7 +134,7 @@ def test_job_host_summary_service_orders_by_finished(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()
@@ -151,7 +153,7 @@ def test_job_host_summary_service_isoformat(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 7, 20, 8, 15, 30, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 7, 21, 16, 45, 0, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = job_host_summary_service(db=mock_db, since=since, until=until)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_job_host_summary_service.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary_service.py
@@ -20,18 +20,6 @@ def test_job_host_summary_service_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_job_host_summary_service_with_output_dir():
-    """Test job_host_summary_service with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = job_host_summary_service(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.job_host_summary_service.copy_table')
 def test_job_host_summary_service_calls_copy_table(mock_copy_table):
     """Test that job_host_summary_service calls copy_table with correct parameters."""
@@ -47,7 +35,6 @@ def test_job_host_summary_service_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_jobhostsummary'
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_jobhostsummary_table.csv']

--- a/metrics_utility/test/library/test_collectors_main_host.py
+++ b/metrics_utility/test/library/test_collectors_main_host.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.main_host import main_host
 
 
@@ -18,7 +20,7 @@ def test_main_host_basic():
 def test_main_host_calls_copy_table(mock_copy_table):
     """Test that main_host calls copy_table with correct parameters."""
     mock_db = MagicMock()
-    mock_copy_table.return_value = ['/tmp/main_host_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2, 3], 'name': ['host1', 'host2', 'host3']})
 
     instance = main_host(db=mock_db)
     result = instance.gather()
@@ -29,14 +31,14 @@ def test_main_host_calls_copy_table(mock_copy_table):
     assert call_args[1]['db'] == mock_db
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_host_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.main_host.copy_table')
 def test_main_host_query_structure(mock_copy_table):
     """Test that the SQL query has expected structure."""
     mock_db = MagicMock()
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_host(db=mock_db)
     instance.gather()
@@ -60,7 +62,7 @@ def test_main_host_query_structure(mock_copy_table):
 def test_main_host_filters_enabled_hosts(mock_copy_table):
     """Test that query filters for enabled hosts."""
     mock_db = MagicMock()
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_host(db=mock_db)
     instance.gather()
@@ -76,7 +78,7 @@ def test_main_host_filters_enabled_hosts(mock_copy_table):
 def test_main_host_uses_yaml_json_functions(mock_copy_table):
     """Test that query uses metrics_utility helper functions."""
     mock_db = MagicMock()
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_host(db=mock_db)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_main_host.py
+++ b/metrics_utility/test/library/test_collectors_main_host.py
@@ -14,16 +14,6 @@ def test_main_host_basic():
     assert instance.kwargs['db'] == mock_db
 
 
-def test_main_host_with_output_dir():
-    """Test main_host with custom output_dir."""
-    mock_db = MagicMock()
-    output_dir = '/tmp/test_output'
-
-    instance = main_host(db=mock_db, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.main_host.copy_table')
 def test_main_host_calls_copy_table(mock_copy_table):
     """Test that main_host calls copy_table with correct parameters."""
@@ -37,7 +27,6 @@ def test_main_host_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_host'
     assert call_args[1]['prepend_query'] is True
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_host_table.csv']

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -20,18 +20,6 @@ def test_main_indirectmanagednodeaudit_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_main_indirectmanagednodeaudit_with_output_dir():
-    """Test main_indirectmanagednodeaudit with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit.copy_table')
 def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_table):
     """Test that main_indirectmanagednodeaudit calls copy_table."""
@@ -47,7 +35,6 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_indirectmanagednodeaudit'
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_indirectmanagednodeaudit_table.csv']
 

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit import main_indirectmanagednodeaudit
 
 
@@ -26,7 +28,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = ['/tmp/main_indirectmanagednodeaudit_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
     instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
     result = instance.gather()
@@ -36,7 +38,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_table):
 
     assert call_args[1]['db'] == mock_db
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_indirectmanagednodeaudit_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit.copy_table')
@@ -45,7 +47,7 @@ def test_main_indirectmanagednodeaudit_query_contains_time_range(mock_copy_table
     mock_db = MagicMock()
     since = datetime.datetime(2024, 3, 15, 10, 30, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 3, 16, 18, 45, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
     instance.gather()
@@ -66,7 +68,7 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_main_jobevent.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent.py
@@ -20,18 +20,6 @@ def test_main_jobevent_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_main_jobevent_with_output_dir():
-    """Test main_jobevent with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = main_jobevent(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.main_jobevent.copy_table')
 def test_main_jobevent_calls_copy_table(mock_copy_table):
     """Test that main_jobevent calls copy_table."""
@@ -47,7 +35,6 @@ def test_main_jobevent_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_jobevent'
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_jobevent_table.csv']
 

--- a/metrics_utility/test/library/test_collectors_main_jobevent.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.main_jobevent import main_jobevent
 
 
@@ -26,7 +28,7 @@ def test_main_jobevent_calls_copy_table(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = ['/tmp/main_jobevent_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2, 3], 'event': ['ok', 'failed', 'ok']})
 
     instance = main_jobevent(db=mock_db, since=since, until=until)
     result = instance.gather()
@@ -36,7 +38,7 @@ def test_main_jobevent_calls_copy_table(mock_copy_table):
 
     assert call_args[1]['db'] == mock_db
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_jobevent_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent.copy_table')
@@ -45,7 +47,7 @@ def test_main_jobevent_query_contains_time_range(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 5, 1, 8, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 5, 2, 20, 30, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_jobevent(db=mock_db, since=since, until=until)
     instance.gather()
@@ -66,7 +68,7 @@ def test_main_jobevent_query_structure(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_jobevent(db=mock_db, since=since, until=until)
     instance.gather()
@@ -96,7 +98,7 @@ def test_main_jobevent_filters_event_types(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_jobevent(db=mock_db, since=since, until=until)
     instance.gather()
@@ -118,7 +120,7 @@ def test_main_jobevent_unicode_escape_handling(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = main_jobevent(db=mock_db, since=since, until=until)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.main_jobevent_service import main_jobevent_service
 
 
@@ -30,7 +32,7 @@ def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
 
     # No jobs found
     mock_cursor.fetchall.return_value = []
-    mock_copy_table.return_value = ['/tmp/main_jobevent_table.csv']
+    mock_copy_table.return_value = pd.DataFrame()
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -38,7 +40,7 @@ def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
     instance = main_jobevent_service(db=mock_db, since=since, until=until)
     result = instance.gather()
 
-    # Should still call copy_table to generate CSV with headers (even if 0 rows)
+    # Should still call copy_table to generate DataFrame (even if 0 rows)
     mock_copy_table.assert_called_once()
 
     # Verify the query has FALSE conditions (returns 0 rows but maintains schema)
@@ -46,8 +48,8 @@ def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
     query = call_args[1]['query']
     assert 'FALSE' in query  # Should have FALSE for empty job set
 
-    # Should return CSV file path
-    assert result == ['/tmp/main_jobevent_table.csv']
+    # Should return DataFrame
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
@@ -63,7 +65,7 @@ def test_main_jobevent_service_with_jobs_calls_copy_table(mock_copy_table):
     job_created2 = datetime.datetime(2024, 1, 16, 14, 45, tzinfo=datetime.timezone.utc)
     mock_cursor.fetchall.return_value = [(100, job_created1), (101, job_created2)]
 
-    mock_copy_table.return_value = ['/tmp/main_jobevent_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2, 3], 'job_id': [100, 100, 101]})
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -77,7 +79,7 @@ def test_main_jobevent_service_with_jobs_calls_copy_table(mock_copy_table):
 
     assert call_args[1]['db'] == mock_db
     assert 'query' in call_args[1]
-    assert result == ['/tmp/main_jobevent_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
@@ -90,7 +92,7 @@ def test_main_jobevent_service_query_structure(mock_copy_table):
 
     job_created = datetime.datetime(2024, 1, 15, 10, 30, tzinfo=datetime.timezone.utc)
     mock_cursor.fetchall.return_value = [(100, job_created)]
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -128,7 +130,7 @@ def test_main_jobevent_service_builds_temp_table_and_hourly_ranges(mock_copy_tab
     job_created1 = datetime.datetime(2024, 1, 15, 10, 30, 45, tzinfo=datetime.timezone.utc)
     job_created2 = datetime.datetime(2024, 1, 16, 14, 45, 30, tzinfo=datetime.timezone.utc)
     mock_cursor.fetchall.return_value = [(100, job_created1), (200, job_created2)]
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -199,7 +201,7 @@ def test_main_jobevent_service_playbook_stats_handling(mock_copy_table):
 
     job_created = datetime.datetime(2024, 1, 15, tzinfo=datetime.timezone.utc)
     mock_cursor.fetchall.return_value = [(100, job_created)]
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)

--- a/metrics_utility/test/library/test_collectors_main_jobevent_service.py
+++ b/metrics_utility/test/library/test_collectors_main_jobevent_service.py
@@ -20,18 +20,6 @@ def test_main_jobevent_service_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_main_jobevent_service_with_output_dir():
-    """Test main_jobevent_service with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = main_jobevent_service(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.main_jobevent_service.copy_table')
 def test_main_jobevent_service_no_jobs_returns_none(mock_copy_table):
     """Test that collector returns empty CSV with headers when no jobs are found."""
@@ -67,8 +55,6 @@ def test_main_jobevent_service_with_jobs_calls_copy_table(mock_copy_table):
     """Test that collector calls copy_table when jobs are found."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
-    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
-    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -90,7 +76,6 @@ def test_main_jobevent_service_with_jobs_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'main_jobevent'
     assert 'query' in call_args[1]
     assert result == ['/tmp/main_jobevent_table.csv']
 
@@ -100,8 +85,6 @@ def test_main_jobevent_service_query_structure(mock_copy_table):
     """Test that the SQL query has expected structure."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
-    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
-    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -211,8 +194,6 @@ def test_main_jobevent_service_playbook_stats_handling(mock_copy_table):
     """Test that query handles playbook_on_stats event specially."""
     mock_db = MagicMock()
     mock_cursor = MagicMock()
-    # Configure mock cursor to simulate psycopg3 (no copy_expert method)
-    del mock_cursor.copy_expert
     mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/metrics_utility/test/library/test_collectors_unified_jobs.py
+++ b/metrics_utility/test/library/test_collectors_unified_jobs.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 from metrics_utility.library.collectors.controller.unified_jobs import unified_jobs
 
 
@@ -26,7 +28,7 @@ def test_unified_jobs_calls_copy_table(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = ['/tmp/unified_jobs_table.csv']
+    mock_copy_table.return_value = pd.DataFrame({'id': [1, 2], 'name': ['job1', 'job2']})
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     result = instance.gather()
@@ -36,7 +38,7 @@ def test_unified_jobs_calls_copy_table(mock_copy_table):
 
     assert call_args[1]['db'] == mock_db
     assert 'query' in call_args[1]
-    assert result == ['/tmp/unified_jobs_table.csv']
+    assert isinstance(result, pd.DataFrame)
 
 
 @patch('metrics_utility.library.collectors.controller.unified_jobs.copy_table')
@@ -45,7 +47,7 @@ def test_unified_jobs_query_contains_time_range(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 6, 1, 12, 0, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 6, 2, 14, 30, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     instance.gather()
@@ -66,7 +68,7 @@ def test_unified_jobs_uses_finished_filter(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     instance.gather()
@@ -85,7 +87,7 @@ def test_unified_jobs_query_structure(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     instance.gather()
@@ -109,7 +111,7 @@ def test_unified_jobs_includes_all_jobs(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     instance.gather()
@@ -128,7 +130,7 @@ def test_unified_jobs_includes_execution_environment(mock_copy_table):
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    mock_copy_table.return_value = []
+    mock_copy_table.return_value = pd.DataFrame()
 
     instance = unified_jobs(db=mock_db, since=since, until=until)
     instance.gather()

--- a/metrics_utility/test/library/test_collectors_unified_jobs.py
+++ b/metrics_utility/test/library/test_collectors_unified_jobs.py
@@ -20,18 +20,6 @@ def test_unified_jobs_basic():
     assert instance.kwargs['until'] == until
 
 
-def test_unified_jobs_with_output_dir():
-    """Test unified_jobs with custom output_dir."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
-    output_dir = '/tmp/test_output'
-
-    instance = unified_jobs(db=mock_db, since=since, until=until, output_dir=output_dir)
-
-    assert instance.kwargs['output_dir'] == output_dir
-
-
 @patch('metrics_utility.library.collectors.controller.unified_jobs.copy_table')
 def test_unified_jobs_calls_copy_table(mock_copy_table):
     """Test that unified_jobs calls copy_table."""
@@ -47,7 +35,6 @@ def test_unified_jobs_calls_copy_table(mock_copy_table):
     call_args = mock_copy_table.call_args
 
     assert call_args[1]['db'] == mock_db
-    assert call_args[1]['table'] == 'unified_jobs'
     assert 'query' in call_args[1]
     assert result == ['/tmp/unified_jobs_table.csv']
 

--- a/metrics_utility/test/library/test_collectors_util.py
+++ b/metrics_utility/test/library/test_collectors_util.py
@@ -1,12 +1,8 @@
-import os
-import pathlib
-import tempfile
-
 from unittest.mock import MagicMock
 
 import pytest
 
-from metrics_utility.library.collectors.util import collector, init_tmp_dir
+from metrics_utility.library.collectors.util import collector
 
 
 def test_collector_decorator_basic():
@@ -121,68 +117,6 @@ def test_collector_decorator_staticmethod():
     assert hasattr(instance, 'fn')
     # Can call the original function directly
     assert instance.fn(value=10) == 20
-
-
-def test_init_tmp_dir():
-    """Test that init_tmp_dir creates proper directory structure."""
-    result = init_tmp_dir()
-
-    # Should return a Path object
-    assert isinstance(result, pathlib.Path)
-
-    # Directory should exist
-    assert result.exists()
-    assert result.is_dir()
-
-    # Should be named 'stage'
-    assert result.name == 'stage'
-
-    # Parent should have 'awx_analytics-' prefix
-    assert 'awx_analytics-' in result.parent.name
-
-    # Parent should be in temp directory
-    assert str(result.parent).startswith(tempfile.gettempdir())
-
-    # Cleanup
-    import shutil
-
-    shutil.rmtree(result.parent)
-
-
-def test_init_tmp_dir_permissions():
-    """Test that stage directory has correct permissions."""
-    result = init_tmp_dir()
-
-    # Check permissions (0o700)
-    stat_info = os.stat(result)
-    permissions = oct(stat_info.st_mode)[-3:]
-
-    assert permissions == '700'
-
-    # Cleanup
-    import shutil
-
-    shutil.rmtree(result.parent)
-
-
-def test_init_tmp_dir_unique():
-    """Test that init_tmp_dir creates unique directories."""
-    dir1 = init_tmp_dir()
-    dir2 = init_tmp_dir()
-
-    # Should be different directories
-    assert dir1 != dir2
-    assert dir1.parent != dir2.parent
-
-    # Both should exist
-    assert dir1.exists()
-    assert dir2.exists()
-
-    # Cleanup
-    import shutil
-
-    shutil.rmtree(dir1.parent)
-    shutil.rmtree(dir2.parent)
 
 
 def test_collector_decorator_exception_handling():

--- a/metrics_utility/test/library/test_csv_utils.py
+++ b/metrics_utility/test/library/test_csv_utils.py
@@ -1,0 +1,183 @@
+"""Tests for csv_utils module."""
+
+import os
+import tempfile
+
+import pandas as pd
+
+from metrics_utility.library.csv_utils import dataframe_to_csv_files
+
+
+def test_dataframe_to_csv_files_empty():
+    """Test that empty DataFrames create a file with headers only."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create empty DataFrame with schema
+        df = pd.DataFrame(columns=['col1', 'col2', 'col3'])
+
+        files = dataframe_to_csv_files(df, 'test_table', tmpdir)
+
+        assert len(files) == 1
+        assert os.path.exists(files[0])
+        assert 'test_table_table.csv' in files[0]
+
+        # Verify file has headers only
+        with open(files[0], 'r') as f:
+            content = f.read()
+            lines = content.strip().split('\n')
+            assert len(lines) == 1
+            assert lines[0] == 'col1,col2,col3'
+
+
+def test_dataframe_to_csv_files_none_input():
+    """Test that None input is handled gracefully."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = None
+
+        # Should not crash, should create empty file
+        files = dataframe_to_csv_files(df, 'test_table', tmpdir)
+
+        assert len(files) == 1
+        assert os.path.exists(files[0])
+
+
+def test_dataframe_to_csv_files_small():
+    """Test that small DataFrames create a single file without split suffix."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create small DataFrame
+        df = pd.DataFrame({'id': [1, 2, 3], 'name': ['Alice', 'Bob', 'Charlie'], 'value': [10.5, 20.3, 30.7]})
+
+        files = dataframe_to_csv_files(df, 'small_table', tmpdir)
+
+        # Should create single file without _split suffix
+        assert len(files) == 1
+        assert os.path.exists(files[0])
+        assert 'small_table_table.csv' in files[0]
+        assert '_split' not in files[0]
+
+        # Verify content
+        result_df = pd.read_csv(files[0])
+        assert len(result_df) == 3
+        assert list(result_df.columns) == ['id', 'name', 'value']
+        assert result_df['id'].tolist() == [1, 2, 3]
+
+
+def test_dataframe_to_csv_files_large_splitting():
+    """Test that large DataFrames are split into multiple files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create DataFrame large enough to trigger splitting
+        # Create 1000 rows with reasonably sized data
+        df = pd.DataFrame(
+            {
+                'id': range(1000),
+                'name': [f'user_{i:05d}' for i in range(1000)],
+                'description': ['This is a longer description field that takes up more space'] * 1000,
+                'value': [i * 1.5 for i in range(1000)],
+                'timestamp': pd.date_range('2024-01-01', periods=1000, freq='H'),
+            }
+        )
+
+        # Use small max_file_size to force splitting
+        files = dataframe_to_csv_files(df, 'large_table', tmpdir, max_file_size=10000)
+
+        # Should create multiple files with _split suffix
+        assert len(files) > 1
+
+        for file in files:
+            assert os.path.exists(file)
+            assert '_split' in file
+
+        # Verify all files have headers
+        for file in files:
+            result_df = pd.read_csv(file)
+            assert list(result_df.columns) == ['id', 'name', 'description', 'value', 'timestamp']
+
+        # Verify total row count matches when concatenated
+        all_dfs = [pd.read_csv(f) for f in files]
+        combined_df = pd.concat(all_dfs, ignore_index=True)
+        assert len(combined_df) == 1000
+
+
+def test_dataframe_to_csv_files_custom_output_dir():
+    """Test that files are created in the specified output directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        custom_dir = os.path.join(tmpdir, 'custom', 'subdir')
+        os.makedirs(custom_dir, exist_ok=True)
+
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+
+        files = dataframe_to_csv_files(df, 'test', custom_dir)
+
+        assert len(files) == 1
+        assert custom_dir in files[0]
+        assert os.path.exists(files[0])
+
+
+def test_dataframe_to_csv_files_preserves_data_types():
+    """Test that various pandas data types are properly written to CSV."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = pd.DataFrame(
+            {
+                'int_col': [1, 2, 3],
+                'float_col': [1.1, 2.2, 3.3],
+                'str_col': ['a', 'b', 'c'],
+                'bool_col': [True, False, True],
+                'datetime_col': pd.to_datetime(['2024-01-01', '2024-01-02', '2024-01-03']),
+            }
+        )
+
+        files = dataframe_to_csv_files(df, 'types_test', tmpdir)
+
+        # Read back and verify
+        result_df = pd.read_csv(files[0])
+
+        assert len(result_df) == 3
+        assert result_df['int_col'].tolist() == [1, 2, 3]
+        assert result_df['str_col'].tolist() == ['a', 'b', 'c']
+        assert result_df['bool_col'].tolist() == [True, False, True]
+
+
+def test_dataframe_to_csv_files_with_nulls():
+    """Test that DataFrames with null values are handled correctly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = pd.DataFrame({'id': [1, 2, 3], 'name': ['Alice', None, 'Charlie'], 'value': [10.5, 20.3, None]})
+
+        files = dataframe_to_csv_files(df, 'nulls_test', tmpdir)
+
+        # Read back and verify nulls are preserved
+        result_df = pd.read_csv(files[0])
+
+        assert len(result_df) == 3
+        assert pd.isna(result_df.loc[1, 'name'])
+        assert pd.isna(result_df.loc[2, 'value'])
+
+
+def test_dataframe_to_csv_files_special_characters():
+    """Test that DataFrames with special characters in data are properly escaped."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = pd.DataFrame({'text': ['normal', 'with,comma', 'with"quote', 'with\nnewline'], 'value': [1, 2, 3, 4]})
+
+        files = dataframe_to_csv_files(df, 'special_chars', tmpdir)
+
+        # Read back and verify special characters are preserved
+        result_df = pd.read_csv(files[0])
+
+        assert len(result_df) == 4
+        assert result_df['text'].tolist() == ['normal', 'with,comma', 'with"quote', 'with\nnewline']
+
+
+def test_dataframe_to_csv_files_table_name_formatting():
+    """Test that table names are correctly formatted in file names."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = pd.DataFrame({'col': [1, 2, 3]})
+
+        # Test various table name formats
+        test_cases = [
+            ('main_executionenvironment', 'main_executionenvironment_table.csv'),
+            ('unified_jobs', 'unified_jobs_table.csv'),
+            ('job_host_summary', 'job_host_summary_table.csv'),
+        ]
+
+        for table_name, expected_filename in test_cases:
+            files = dataframe_to_csv_files(df, table_name, tmpdir)
+            assert len(files) == 1
+            assert files[0].endswith(expected_filename)

--- a/metrics_utility/test/library/test_csv_utils.py
+++ b/metrics_utility/test/library/test_csv_utils.py
@@ -29,15 +29,14 @@ def test_dataframe_to_csv_files_empty():
 
 
 def test_dataframe_to_csv_files_none_input():
-    """Test that None input is handled gracefully."""
+    """Test that None input is handled gracefully by returning no files."""
     with tempfile.TemporaryDirectory() as tmpdir:
         df = None
 
-        # Should not crash, should create empty file
+        # Should not crash, should return empty list (no files created)
         files = dataframe_to_csv_files(df, 'test_table', tmpdir)
 
-        assert len(files) == 1
-        assert os.path.exists(files[0])
+        assert len(files) == 0
 
 
 def test_dataframe_to_csv_files_small():
@@ -181,3 +180,32 @@ def test_dataframe_to_csv_files_table_name_formatting():
             files = dataframe_to_csv_files(df, table_name, tmpdir)
             assert len(files) == 1
             assert files[0].endswith(expected_filename)
+
+
+def test_dataframe_to_csv_files_none_with_csv_compat():
+    """Test that None input doesn't break CSV compatibility path (no EmptyDataError)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create files from None - should return empty list
+        files = dataframe_to_csv_files(None, 'test_table', tmpdir)
+        assert len(files) == 0
+
+        # Verify that iterating over the files list (as in load_anonymized_rollup_data)
+        # works without errors
+        for file_path in files:
+            # This should never execute since files is empty
+            pd.read_csv(file_path)  # Would raise EmptyDataError if file was created
+
+        # Also test empty DataFrame with no columns
+        empty_df = pd.DataFrame()
+        files = dataframe_to_csv_files(empty_df, 'test_table', tmpdir)
+        assert len(files) == 0
+
+        # But empty DataFrame WITH columns should create a file with headers
+        df_with_columns = pd.DataFrame(columns=['a', 'b', 'c'])
+        files = dataframe_to_csv_files(df_with_columns, 'test_table', tmpdir)
+        assert len(files) == 1
+
+        # This file should be readable
+        result = pd.read_csv(files[0])
+        assert result.empty
+        assert list(result.columns) == ['a', 'b', 'c']


### PR DESCRIPTION
Related to ansible/metrics-service#92, AAP-62673

This changes library collector code so that:

* collectors no longer accept `output_dir`
* `copy_table` no longer takes `table`, `output_dir`, `output_file` nor `output_mode`
* `copy_table` no longer returns a list of files, it returns one pandas `DataFrame` now
* (psycopg2 compat code removed)
* (not using pandas `read_sql` because it requires a SQLAlchemy connection, not a psycopg one)

A `dataframe_to_csv_files` is added for compatibility - without streaming, but we can deal with this separately.
The CLI is unaffected.

Adjusted `load_anonymized_rollup_data` to deal with a DataFrame, a list of DataFrames, or a list of filenames, but the function is going away from prod code, probably - leaving cross-repo cleanup for separate PR.