### PR TITLE
Fix venv re-activation in perf tools

### DIFF
--- a/tools/anonymized_db_perf_data/clean_all_data.py
+++ b/tools/anonymized_db_perf_data/clean_all_data.py
@@ -16,9 +16,9 @@ sys.path.insert(0, str(current_dir))
 metrics_utility_path = current_dir.parent.parent
 sys.path.insert(0, str(metrics_utility_path))
 
-# Check for virtual environment and use it
+# Check for virtual environment and use it.. unless already using it
 venv_path = metrics_utility_path / '.venv'
-if venv_path.exists():
+if not os.getenv('VIRTUAL_ENV') and venv_path.exists():
     # Activate venv by updating PATH and VIRTUAL_ENV
     os.environ['VIRTUAL_ENV'] = str(venv_path)
     os.environ['PATH'] = f'{venv_path / "bin"}:{os.environ.get("PATH", "")}'
@@ -60,7 +60,7 @@ def main():
         print('  - Execution environments')
         print()
         response = input('Are you sure you want to continue? (yes/no): ')
-        if response.lower() != 'yes':
+        if response.lower() not in {'y', 'yes'}:
             print('Aborted.')
             return
 

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -163,9 +163,9 @@ if __name__ == '__main__':
     metrics_utility_path = current_dir.parent.parent
     sys.path.insert(0, str(metrics_utility_path))
 
-    # Check for virtual environment and use it
+    # Check for virtual environment and use it.. unless already using it
     venv_path = metrics_utility_path / '.venv'
-    if venv_path.exists():
+    if not os.getenv('VIRTUAL_ENV') and venv_path.exists():
         # Activate venv by updating PATH and VIRTUAL_ENV
         os.environ['VIRTUAL_ENV'] = str(venv_path)
         os.environ['PATH'] = f'{venv_path / "bin"}:{os.environ.get("PATH", "")}'

--- a/tools/anonymized_db_perf_data/run_perf.py
+++ b/tools/anonymized_db_perf_data/run_perf.py
@@ -31,9 +31,9 @@ sys.path.insert(0, str(current_dir))
 metrics_utility_path = current_dir.parent.parent
 sys.path.insert(0, str(metrics_utility_path))
 
-# Check for virtual environment and use it
+# Check for virtual environment and use it.. unless already using it
 venv_path = metrics_utility_path / '.venv'
-if venv_path.exists():
+if not os.getenv('VIRTUAL_ENV') and venv_path.exists():
     # Activate venv by updating PATH and VIRTUAL_ENV
     os.environ['VIRTUAL_ENV'] = str(venv_path)
     os.environ['PATH'] = f'{venv_path / "bin"}:{os.environ.get("PATH", "")}'

--- a/tools/anonymized_db_perf_data/verify_event_distribution.py
+++ b/tools/anonymized_db_perf_data/verify_event_distribution.py
@@ -19,9 +19,9 @@ sys.path.insert(0, str(current_dir))
 metrics_utility_path = current_dir.parent.parent
 sys.path.insert(0, str(metrics_utility_path))
 
-# Check for virtual environment and use it
+# Check for virtual environment and use it.. unless already using it
 venv_path = metrics_utility_path / '.venv'
-if venv_path.exists():
+if not os.getenv('VIRTUAL_ENV') and venv_path.exists():
     os.environ['VIRTUAL_ENV'] = str(venv_path)
     os.environ['PATH'] = f'{venv_path / "bin"}:{os.environ.get("PATH", "")}'
     site_packages = list(venv_path.glob('lib/python*/site-packages'))


### PR DESCRIPTION
Prevent re-activating virtualenv when already running inside one - by checking `VIRTUAL_ENV` before activation.

`clean_all_data.py`: accept 'y' as confirmation too
