### PR TITLE
coderabbit: move summary from PR description to first comment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+inheritance: true
+reviews:
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true


### PR DESCRIPTION
inherit coderabbit org config,
but change it to NOT edit PR description

(see also ansible/metrics-service#116 - setting a different `high_level_summary` value here, to see what does what)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration file to enable high-level summary reviews and inheritance behavior in the code review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->