### PR TITLE
Milan hardening3

### DIFF
--- a/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
@@ -1,6 +1,3 @@
-import hashlib
-import json
-
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
@@ -532,24 +529,6 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
             'json': json_data,
         }
 
-    def _parse_collections_data(self, installed_collections_data):
-        """
-        Parse collections data from row, handling JSON strings and dicts.
-        Returns dict or None if parsing fails.
-        """
-        if pd.isna(installed_collections_data) or not installed_collections_data:
-            return None
-
-        try:
-            if isinstance(installed_collections_data, str):
-                return json.loads(installed_collections_data)
-            if isinstance(installed_collections_data, dict):
-                return installed_collections_data
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-        return None
-
     def _init_collection_stats_entry(self):
         """Return a blank stats entry for a new collection+version key."""
         return {
@@ -650,26 +629,11 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         for collection_name, collection_info in collections_data.items():
             self._process_single_collection(collection_name, collection_info, collections_stats, failed, row_stats)
 
-    def _hash_installed_collections(self, raw):
-        """Compute a SHA-256 hash of the raw installed_collections string.
-
-        Used as a cache key to avoid re-parsing identical JSON payloads
-        (e.g. all jobs that share the same execution environment).
-        SHA-256 is used instead of the raw string to keep the cache memory-efficient
-        when the JSON payload is large.
-        """
-        return hashlib.sha256(raw.encode('utf-8', errors='replace')).hexdigest()
-
     def _process_collections_from_jobs(self, dataframe):
         """
         Extract unique collection name and version pairs from jobs dataframe.
         Count how many jobs use each unique collection+version combination,
         including failed and successful job counts.
-
-        Optimized version using itertuples() for better performance.
-        Additionally uses a hash-based cache to avoid re-parsing identical
-        installed_collections JSON payloads (common when many jobs share the
-        same execution environment).
 
         Returns a list of dicts with:
         - collection_name: str
@@ -684,11 +648,6 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         # Use dict for tracking job_count, jobs_failed_total, jobs_successful_total per collection+version
         collections_stats = {}
 
-        # Cache: SHA-256 hash of raw JSON string -> parsed collections dict
-        # Many jobs share the same installed_collections because they run on the
-        # same execution environment, so we avoid redundant json.loads() calls.
-        parse_cache = {}
-
         # Use itertuples() for fastest row iteration (10-100x faster than iterrows)
         # itertuples() creates namedtuples with column names as attributes
         # Column names with special characters are sanitized, but 'installed_collections' should work fine
@@ -698,25 +657,19 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
             if not installed_collections_data or pd.isna(installed_collections_data):
                 continue
 
-            # Use hash of the raw string as cache key to avoid storing large strings
-            raw = installed_collections_data if isinstance(installed_collections_data, str) else str(installed_collections_data)
-            cache_key = self._hash_installed_collections(raw)
+            if not isinstance(installed_collections_data, dict):
+                continue
 
-            if cache_key not in parse_cache:
-                parse_cache[cache_key] = self._parse_collections_data(installed_collections_data)
-
-            collections_data = parse_cache[cache_key]
-            if collections_data:
-                failed = bool(getattr(row, 'failed', False))
-                row_stats = {
-                    'job_duration_seconds': getattr(row, 'job_duration_seconds', None),
-                    'job_waiting_time_seconds': getattr(row, 'job_waiting_time_seconds', None),
-                    'jobs_never_started': bool(getattr(row, 'jobs_never_started', False)),
-                    'unified_job_template_id': getattr(row, 'unified_job_template_id', None),
-                    'inventory_id': getattr(row, 'inventory_id', None),
-                    'ansible_version': getattr(row, 'ansible_version', None),
-                }
-                self._process_collections_dict(collections_data, collections_stats, failed, row_stats)
+            failed = bool(getattr(row, 'failed', False))
+            row_stats = {
+                'job_duration_seconds': getattr(row, 'job_duration_seconds', None),
+                'job_waiting_time_seconds': getattr(row, 'job_waiting_time_seconds', None),
+                'jobs_never_started': bool(getattr(row, 'jobs_never_started', False)),
+                'unified_job_template_id': getattr(row, 'unified_job_template_id', None),
+                'inventory_id': getattr(row, 'inventory_id', None),
+                'ansible_version': getattr(row, 'ansible_version', None),
+            }
+            self._process_collections_dict(installed_collections_data, collections_stats, failed, row_stats)
 
         # Convert dict to list of dicts, converting sets to sorted lists
         result = [

--- a/metrics_utility/automation_controller_billing/helpers.py
+++ b/metrics_utility/automation_controller_billing/helpers.py
@@ -47,6 +47,9 @@ def _datetime_hook(d):
 
 
 def parse_json_array(x):
+    # Already a list (e.g. jsonb column returned as Python list via psycopg3 JsonbLoader)
+    if isinstance(x, list):
+        return x
     if pd.isnull(x):
         return []
     try:
@@ -56,7 +59,7 @@ def parse_json_array(x):
             return parsed
         else:
             return []
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         return []
 
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -119,6 +119,7 @@ def _copy_table_pandas(db, query):
         # JSON in C before Python sees the data - no Python-level json.loads() needed.
         try:
             from psycopg.types.json import JsonbLoader
+
             cursor.cursor.adapters.register_loader('jsonb', JsonbLoader)
         except (ImportError, AttributeError):
             pass  # psycopg2 or non-psycopg3 backend: jsonb already returns dicts

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -112,6 +112,17 @@ def _copy_table_pandas(db, query):
     # Execute query and create DataFrame from results
     # Using cursor approach since pd.read_sql doesn't work well with psycopg3
     with db.cursor() as cursor:
+        # Django's psycopg3 backend globally registers TextLoader for jsonb so that
+        # JSONField can apply custom decoders (see psycopg_any.get_adapters_template).
+        # This means jsonb columns come back as raw JSON strings instead of Python dicts.
+        # We restore native jsonb->dict conversion at the cursor level so psycopg3 parses
+        # JSON in C before Python sees the data - no Python-level json.loads() needed.
+        try:
+            from psycopg.types.json import JsonbLoader
+            cursor.cursor.adapters.register_loader('jsonb', JsonbLoader)
+        except (ImportError, AttributeError):
+            pass  # psycopg2 or non-psycopg3 backend: jsonb already returns dicts
+
         cursor.execute(query)
 
         # Get column names from cursor description

--- a/metrics_utility/library/dataframes/base_traditional.py
+++ b/metrics_utility/library/dataframes/base_traditional.py
@@ -154,6 +154,9 @@ def merge_setdicts(x):
 
 
 def parse_json_array(x):
+    # Already a list (e.g. jsonb column returned as Python list via psycopg3 JsonbLoader)
+    if isinstance(x, list):
+        return x
     if pd.isnull(x):
         return []
     try:
@@ -163,7 +166,7 @@ def parse_json_array(x):
             return parsed
         else:
             return []
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         return []
 
 

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -102,6 +102,12 @@ def _parse_expected_csv(expected_lines):
     return expected_rows[0], expected_rows[1:]
 
 
+def _is_float_whole_numbers(series):
+    """Return True if all non-null float values are whole numbers."""
+    non_null_values = series.dropna()
+    return len(non_null_values) > 0 and (non_null_values == non_null_values.astype(int)).all()
+
+
 def _read_dataframe(df):
     # Convert boolean columns from True/False to t/f
     # Convert float columns that are actually integers to Int64
@@ -112,8 +118,7 @@ def _read_dataframe(df):
             df_copy[col] = df_copy[col].map({True: 't', False: 'f'})
         elif df_copy[col].dtype in ['float64', 'float32']:
             # If all non-null values are whole numbers, convert to nullable int
-            non_null_values = df_copy[col].dropna()
-            if len(non_null_values) > 0 and (non_null_values == non_null_values.astype(int)).all():
+            if _is_float_whole_numbers(df_copy[col]):
                 df_copy[col] = df_copy[col].astype('Int64')
         elif df_copy[col].dtype == 'object':
             # Serialize dicts/lists to JSON strings so that to_csv() produces valid JSON

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -1,5 +1,6 @@
 import csv
 import glob
+import json
 import os
 
 from datetime import datetime, timezone
@@ -104,6 +105,7 @@ def _parse_expected_csv(expected_lines):
 def _read_dataframe(df):
     # Convert boolean columns from True/False to t/f
     # Convert float columns that are actually integers to Int64
+    # Serialize dict/list columns to JSON so they match the expected CSV format
     df_copy = df.copy()
     for col in df_copy.columns:
         if df_copy[col].dtype == 'bool':
@@ -113,6 +115,13 @@ def _read_dataframe(df):
             non_null_values = df_copy[col].dropna()
             if len(non_null_values) > 0 and (non_null_values == non_null_values.astype(int)).all():
                 df_copy[col] = df_copy[col].astype('Int64')
+        elif df_copy[col].dtype == 'object':
+            # Serialize dicts/lists to JSON strings so that to_csv() produces valid JSON
+            # instead of Python repr() (single quotes vs double quotes)
+            if df_copy[col].apply(lambda x: isinstance(x, (dict, list))).any():
+                df_copy[col] = df_copy[col].apply(
+                    lambda x: json.dumps(x, sort_keys=True) if isinstance(x, (dict, list)) else x
+                )
 
     text = df_copy.to_csv(index=False).splitlines()
     reader = csv.reader(text)

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -119,9 +119,7 @@ def _read_dataframe(df):
             # Serialize dicts/lists to JSON strings so that to_csv() produces valid JSON
             # instead of Python repr() (single quotes vs double quotes)
             if df_copy[col].apply(lambda x: isinstance(x, (dict, list))).any():
-                df_copy[col] = df_copy[col].apply(
-                    lambda x: json.dumps(x, sort_keys=True) if isinstance(x, (dict, list)) else x
-                )
+                df_copy[col] = df_copy[col].apply(lambda x: json.dumps(x, sort_keys=True) if isinstance(x, (dict, list)) else x)
 
     text = df_copy.to_csv(index=False).splitlines()
     reader = csv.reader(text)

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -227,7 +227,7 @@ class TestCopyTablePandasPsycopg:
 
     def test_import_error_silently_ignored(self):
         """When psycopg is not importable, execution continues without error."""
-        mock_db, mock_cursor = self._make_mock_db()
+        mock_db, _ = self._make_mock_db()
 
         with patch.dict('sys.modules', {'psycopg': None}):
             result = _copy_table_pandas(mock_db, 'SELECT id, data FROM test')

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -62,8 +62,8 @@ class TestEnsureFunctions:
     def test_cursor_cleanup(self):
         """Test that cursor context manager is used properly."""
         mock_db = MagicMock()
-        mock_cursor = MagicMock()
-        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        _ = MagicMock()
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=_)
         mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
         ensure_functions(mock_db)

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -192,6 +192,72 @@ class TestCopyTableFiles:
             mock_splitter_instance.file_list.assert_called_once_with(keep_empty=True)
 
 
+class TestCopyTablePandasPsycopg:
+    """Test _copy_table_pandas psycopg3 jsonb-loader branch."""
+
+    def _make_mock_db(self):
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cursor.description = [('id',), ('data',)]
+        mock_cursor.fetchall.return_value = [(1, {'key': 'value'})]
+        return mock_db, mock_cursor
+
+    def test_psycopg3_jsonb_loader_registered_when_available(self):
+        """When psycopg is importable, JsonbLoader is registered on the cursor."""
+        mock_db, mock_cursor = self._make_mock_db()
+
+        mock_jsonb_loader = MagicMock()
+
+        mock_psycopg_types_json = MagicMock(JsonbLoader=mock_jsonb_loader)
+        with patch.dict(
+            'sys.modules',
+            {
+                'psycopg': MagicMock(),
+                'psycopg.types': MagicMock(),
+                'psycopg.types.json': mock_psycopg_types_json,
+            },
+        ):
+            result = _copy_table_pandas(mock_db, 'SELECT id, data FROM test')
+
+        # register_loader should have been called on the inner cursor
+        mock_cursor.cursor.adapters.register_loader.assert_called_once_with('jsonb', mock_jsonb_loader)
+        assert isinstance(result, pd.DataFrame)
+
+    def test_import_error_silently_ignored(self):
+        """When psycopg is not importable, execution continues without error."""
+        mock_db, mock_cursor = self._make_mock_db()
+
+        with patch.dict('sys.modules', {'psycopg': None}):
+            result = _copy_table_pandas(mock_db, 'SELECT id, data FROM test')
+
+        # Should still return a DataFrame despite the ImportError
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ['id', 'data']
+
+    def test_attribute_error_silently_ignored(self):
+        """When cursor lacks the .cursor.adapters attribute, execution continues."""
+        mock_db, mock_cursor = self._make_mock_db()
+        # Make register_loader raise AttributeError (e.g. psycopg2 cursor has no .cursor)
+        mock_cursor.cursor.adapters.register_loader.side_effect = AttributeError('no adapters')
+
+        mock_jsonb_loader = MagicMock()
+
+        mock_psycopg_types_json = MagicMock(JsonbLoader=mock_jsonb_loader)
+        with patch.dict(
+            'sys.modules',
+            {
+                'psycopg': MagicMock(),
+                'psycopg.types': MagicMock(),
+                'psycopg.types.json': mock_psycopg_types_json,
+            },
+        ):
+            result = _copy_table_pandas(mock_db, 'SELECT id, data FROM test')
+
+        assert isinstance(result, pd.DataFrame)
+
+
 class TestCopyTablePandas:
     """Test _copy_table_pandas function."""
 

--- a/metrics_utility/test/library/test_dataframes_base_traditional.py
+++ b/metrics_utility/test/library/test_dataframes_base_traditional.py
@@ -21,7 +21,7 @@ class TestParseJsonArray:
     def test_list_input_returned_as_is(self):
         """Already-a-list input (psycopg3 JsonbLoader path) is returned unchanged."""
         value = ['a', 'b', 'c']
-        assert parse_json_array(value) is value
+        assert parse_json_array(value) == value
 
     def test_empty_list_input(self):
         """Empty list is returned unchanged."""
@@ -67,7 +67,7 @@ class TestParseJson:
 
     def test_dict_returned_as_is(self):
         d = {'x': 42}
-        assert parse_json(d) is d
+        assert parse_json(d) == d
 
     def test_none_returns_empty_dict(self):
         assert parse_json(None) == {}

--- a/metrics_utility/test/library/test_dataframes_base_traditional.py
+++ b/metrics_utility/test/library/test_dataframes_base_traditional.py
@@ -1,0 +1,188 @@
+"""Test suite for base_traditional dataframe helpers."""
+
+import numpy as np
+
+from metrics_utility.library.dataframes.base_traditional import (
+    combine_json,
+    combine_json_values,
+    combine_set,
+    merge_arrays,
+    merge_json_sets,
+    merge_setdicts,
+    merge_sets,
+    parse_json,
+    parse_json_array,
+)
+
+
+class TestParseJsonArray:
+    """Tests for parse_json_array."""
+
+    def test_list_input_returned_as_is(self):
+        """Already-a-list input (psycopg3 JsonbLoader path) is returned unchanged."""
+        value = ['a', 'b', 'c']
+        assert parse_json_array(value) is value
+
+    def test_empty_list_input(self):
+        """Empty list is returned unchanged."""
+        value = []
+        assert parse_json_array(value) == []
+
+    def test_null_returns_empty_list(self):
+        """None / pd.NA produces an empty list."""
+        assert parse_json_array(None) == []
+        assert parse_json_array(np.nan) == []
+
+    def test_valid_json_list_string(self):
+        """A JSON-encoded list string is parsed correctly."""
+        assert parse_json_array('["x", "y"]') == ['x', 'y']
+
+    def test_valid_json_non_list_string_returns_empty(self):
+        """A JSON-encoded dict (not a list) returns []."""
+        assert parse_json_array('{"key": "value"}') == []
+
+    def test_invalid_json_string_returns_empty(self):
+        """Malformed JSON returns []."""
+        assert parse_json_array('not-json') == []
+
+    def test_type_error_returns_empty(self):
+        """Non-string, non-null, non-list input triggers TypeError in json.loads → []."""
+        # json.loads(5) raises TypeError in Python 3
+        assert parse_json_array(5) == []
+
+    def test_object_raises_type_error_returns_empty(self):
+        """An object that causes TypeError in json.loads (e.g. a tuple) returns []."""
+        # json.loads(('a', 'b')) raises TypeError; pd.isnull on a tuple is False
+        assert parse_json_array(('a', 'b')) == []
+
+
+class TestParseJson:
+    """Tests for parse_json."""
+
+    def test_valid_json_string(self):
+        assert parse_json('{"a": 1}') == {'a': 1}
+
+    def test_invalid_json_string_returns_empty_dict(self):
+        assert parse_json('bad json') == {}
+
+    def test_dict_returned_as_is(self):
+        d = {'x': 42}
+        assert parse_json(d) is d
+
+    def test_none_returns_empty_dict(self):
+        assert parse_json(None) == {}
+
+    def test_integer_returns_empty_dict(self):
+        assert parse_json(123) == {}
+
+
+class TestCombineJson:
+    """Tests for combine_json."""
+
+    def test_two_dicts_merged(self):
+        assert combine_json({'a': 1}, {'b': 2}) == {'a': 1, 'b': 2}
+
+    def test_second_overwrites_first(self):
+        assert combine_json({'a': 1}, {'a': 99}) == {'a': 99}
+
+    def test_non_dict_inputs_ignored(self):
+        assert combine_json(None, {'b': 2}) == {'b': 2}
+        assert combine_json({'a': 1}, None) == {'a': 1}
+        assert combine_json(None, None) == {}
+
+
+class TestCombineSet:
+    """Tests for combine_set."""
+
+    def test_two_sets_unioned(self):
+        assert combine_set({1, 2}, {3, 4}) == {1, 2, 3, 4}
+
+    def test_list_inputs_converted_to_sets(self):
+        assert combine_set([1, 2], [2, 3]) == {1, 2, 3}
+
+    def test_non_set_non_list_treated_as_empty(self):
+        assert combine_set(None, {5}) == {5}
+        assert combine_set({1}, None) == {1}
+
+    def test_both_empty(self):
+        assert combine_set(None, None) == set()
+
+
+class TestCombineJsonValues:
+    """Tests for combine_json_values."""
+
+    def test_values_collected_into_sets(self):
+        result = combine_json_values({'os': 'linux'}, {'os': 'windows'})
+        assert result == {'os': {'linux', 'windows'}}
+
+    def test_none_values_ignored(self):
+        result = combine_json_values({'key': None}, {'key': 'value'})
+        assert result == {'key': {'value'}}
+
+    def test_empty_string_values_ignored(self):
+        result = combine_json_values({'key': ''}, {'key': 'val'})
+        assert result == {'key': {'val'}}
+
+    def test_set_values_merged(self):
+        result = combine_json_values({'tags': {'a', 'b'}}, {'tags': {'c'}})
+        assert result == {'tags': {'a', 'b', 'c'}}
+
+    def test_non_dict_inputs_skipped(self):
+        result = combine_json_values(None, {'k': 'v'})
+        assert result == {'k': {'v'}}
+
+
+class TestMergeSets:
+    """Tests for merge_sets."""
+
+    def test_merges_multiple_sets(self):
+        assert merge_sets([{1, 2}, {3}, {2, 4}]) == {1, 2, 3, 4}
+
+    def test_single_set(self):
+        assert merge_sets([{7, 8}]) == {7, 8}
+
+    def test_empty_list(self):
+        assert merge_sets([]) == set()
+
+
+class TestMergeSetdicts:
+    """Tests for merge_setdicts."""
+
+    def test_reduces_list_of_dicts(self):
+        result = merge_setdicts([{'os': 'linux'}, {'os': 'linux', 'arch': 'x86'}])
+        assert result == {'os': {'linux'}, 'arch': {'x86'}}
+
+
+class TestMergeJsonSets:
+    """Tests for merge_json_sets."""
+
+    def test_dict_values_collected(self):
+        result = merge_json_sets(['{"os": "linux"}', '{"os": "windows"}'])
+        assert result == {'os': {'linux', 'windows'}}
+
+    def test_na_value_ignored(self):
+        result = merge_json_sets(['{"os": "NA"}'])
+        assert result == {}
+
+    def test_none_value_ignored(self):
+        result = merge_json_sets(['{"os": null}'])
+        assert result == {}
+
+    def test_already_dict(self):
+        result = merge_json_sets([{'os': 'linux'}])
+        assert result == {'os': {'linux'}}
+
+
+class TestMergeArrays:
+    """Tests for merge_arrays."""
+
+    def test_flattens_and_deduplicates(self):
+        result = merge_arrays([['a', 'b'], ['b', 'c']])
+        assert set(result) == {'a', 'b', 'c'}
+
+    def test_none_values_filtered(self):
+        result = merge_arrays([None, ['x'], ['y']])
+        assert set(result) == {'x', 'y'}
+
+    def test_empty_input(self):
+        assert merge_arrays([]) == []

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job1.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job1.py
@@ -50,7 +50,6 @@
 #   - Retried tasks: 3 (Host2 Task 1, Host3 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -72,11 +71,9 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.15.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.15.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job1.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job1.py
@@ -51,7 +51,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job2.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job2.py
@@ -51,7 +51,6 @@
 #   - Retried tasks: 3 (Host2 Task 2, Host3 Task 1, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -73,11 +72,9 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.15.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.15.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job2.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job2.py
@@ -52,7 +52,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job3.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job3.py
@@ -58,7 +58,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job3.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job3.py
@@ -57,7 +57,6 @@
 #   - Retried tasks: 2 (Host2 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -79,13 +78,11 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.15.0'},
-                'community.general': {'version': '7.0.0'},
-                'community.weird': {'version': '1.0.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.15.0'},
+            'community.general': {'version': '7.0.0'},
+            'community.weird': {'version': '1.0.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job4.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job4.py
@@ -53,7 +53,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job4.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job4.py
@@ -52,7 +52,6 @@
 #   - Retried tasks: 2 (Host2 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -74,11 +73,9 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.16.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.16.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job5.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job5.py
@@ -52,7 +52,6 @@
 #   - Retried tasks: 3 (Host2 Task 1, Host3 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -74,11 +73,9 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.16.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.16.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job5.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job5.py
@@ -53,7 +53,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job6.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job6.py
@@ -57,7 +57,6 @@
 #   - Retried tasks: 2 (Host2 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -79,13 +78,11 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.17.0'},
-                'community.general': {'version': '8.0.0'},
-                'community.weird': {'version': '1.1.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.17.0'},
+            'community.general': {'version': '8.0.0'},
+            'community.weird': {'version': '1.1.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job6.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job6.py
@@ -58,7 +58,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job7.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job7.py
@@ -58,7 +58,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job7.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job7.py
@@ -57,7 +57,6 @@
 #   - Retried tasks: 2 (Host2 Task 3, Host4 Task 4)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -79,13 +78,11 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'manual',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.18.0'},
-                'community.general': {'version': '9.0.0'},
-                'community.weird': {'version': '1.2.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.18.0'},
+            'community.general': {'version': '9.0.0'},
+            'community.weird': {'version': '1.2.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job8.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job8.py
@@ -52,7 +52,6 @@
 #   - Retried tasks: 3 (Host2 Task 1, Host3 Task 2, Host4 Task 3)
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
-import json
 
 
 # Jobs dataset
@@ -74,11 +73,9 @@ jobs = [
         'inventory_name': 'test-inventory',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.19.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.19.0'},
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/job8.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/job8.py
@@ -53,7 +53,6 @@
 #   Note: Unreachable (dark) tasks are NOT retried per common_data.md rules
 
 
-
 # Jobs dataset
 jobs = [
     {

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -383,6 +383,79 @@ def _validate_jobs_by_installed_collections_versions(json_data):
         assert isinstance(collection['ansible_versions'], list)
 
 
+def _validate_jobs_by_installed_collections_versions_values(json_data):
+    """Validate jobs_by_installed_collections_versions actual values for multi-hour data (6 jobs total).
+
+    Test data installed_collections:
+      10:00 hour – job 1 & 2: ansible.builtin@2.9.10, a10.acos_axapi@1.0.0
+                   job 3:     ansible.builtin@2.9.10, a10.acos_axapi@1.0.0, redhat.rhel_system_roles@1.23.0
+      11:00 hour – job 1 & 2: ansible.builtin@2.9.10, a10.acos_axapi@1.0.0, redhat.rhel_system_roles@1.23.0
+                   job 3:     ansible.builtin@2.9.10, a10.acos_axapi@1.0.0
+
+    Expected after anonymization:
+      - a10.acos_axapi 1.0.0           → 6 jobs (all)
+      - Custom Custom (ansible.builtin) → 6 jobs (all, anonymized because not in collections.json)
+      - redhat.rhel_system_roles 1.23.0 → 3 jobs (job3 from 10h + jobs 1&2 from 11h)
+    """
+    print('--- Validating jobs_by_installed_collections_versions data values (multi-hour) ---')
+    items = json_data.get('jobs_by_installed_collections_versions', [])
+    assert len(items) == 3, f'Should have 3 installed-collection entries, got {len(items)}: {[i.get("name") for i in items]}'
+
+    by_name_version = {(i['name'], i['version']): i for i in items}
+
+    # --- a10.acos_axapi@1.0.0 (known community collection, present in all 6 jobs) ---
+    a10 = by_name_version.get(('a10.acos_axapi', '1.0.0'))
+    assert a10 is not None, 'Should have a10.acos_axapi 1.0.0 entry'
+    assert a10['jobs_total'] == 6, f'a10.acos_axapi should have 6 jobs, got {a10["jobs_total"]}'
+    assert a10['jobs_failed_total'] == 1, f'a10.acos_axapi should have 1 failed job, got {a10["jobs_failed_total"]}'
+    assert a10['jobs_successful_total'] == 5, f'a10.acos_axapi should have 5 successful jobs, got {a10["jobs_successful_total"]}'
+    assert a10['jobs_never_started_total'] == 0
+    assert a10['jobs_duration_total_seconds'] == pytest.approx(720.0, rel=1e-6), (
+        f'a10.acos_axapi jobs_duration_total_seconds should be 720s, got {a10["jobs_duration_total_seconds"]}'
+    )
+    assert a10['job_duration_maximum_seconds'] == pytest.approx(180.0, rel=1e-6)
+    assert a10['job_duration_minimum_seconds'] == pytest.approx(80.0, rel=1e-6)
+    assert a10['job_waiting_time_total_seconds'] == pytest.approx(120.0, rel=1e-6)
+    assert a10['templates_total'] == 1
+    assert a10['inventories_total'] == 1
+    assert isinstance(a10['ansible_versions'], list)
+    assert '2.9.10' in a10['ansible_versions']
+
+    # --- Custom/Custom (ansible.builtin anonymized, present in all 6 jobs) ---
+    custom = by_name_version.get(('Custom', 'Custom'))
+    assert custom is not None, 'Should have a Custom/Custom entry (ansible.builtin anonymized)'
+    assert custom['jobs_total'] == 6, f'Custom should have 6 jobs, got {custom["jobs_total"]}'
+    assert custom['jobs_failed_total'] == 1, f'Custom should have 1 failed job, got {custom["jobs_failed_total"]}'
+    assert custom['jobs_successful_total'] == 5, f'Custom should have 5 successful jobs, got {custom["jobs_successful_total"]}'
+    assert custom['jobs_never_started_total'] == 0
+    assert custom['jobs_duration_total_seconds'] == pytest.approx(720.0, rel=1e-6)
+    assert custom['job_duration_maximum_seconds'] == pytest.approx(180.0, rel=1e-6)
+    assert custom['job_duration_minimum_seconds'] == pytest.approx(80.0, rel=1e-6)
+    assert custom['job_waiting_time_total_seconds'] == pytest.approx(120.0, rel=1e-6)
+    assert custom['templates_total'] == 1
+    assert custom['inventories_total'] == 1
+    assert isinstance(custom['ansible_versions'], list)
+    assert '2.9.10' in custom['ansible_versions']
+
+    # --- redhat.rhel_system_roles@1.23.0 (present in 3 of 6 jobs) ---
+    rhel = by_name_version.get(('redhat.rhel_system_roles', '1.23.0'))
+    assert rhel is not None, 'Should have redhat.rhel_system_roles 1.23.0 entry'
+    assert rhel['jobs_total'] == 3, f'redhat.rhel_system_roles should have 3 jobs, got {rhel["jobs_total"]}'
+    assert rhel['jobs_failed_total'] == 1, f'redhat.rhel_system_roles should have 1 failed job, got {rhel["jobs_failed_total"]}'
+    assert rhel['jobs_successful_total'] == 2, f'redhat.rhel_system_roles should have 2 successful jobs, got {rhel["jobs_successful_total"]}'
+    assert rhel['jobs_never_started_total'] == 0
+    assert rhel['jobs_duration_total_seconds'] == pytest.approx(340.0, rel=1e-6), (
+        f'redhat.rhel_system_roles jobs_duration_total_seconds should be 340s, got {rhel["jobs_duration_total_seconds"]}'
+    )
+    assert rhel['job_duration_maximum_seconds'] == pytest.approx(150.0, rel=1e-6)
+    assert rhel['job_duration_minimum_seconds'] == pytest.approx(90.0, rel=1e-6)
+    assert rhel['job_waiting_time_total_seconds'] == pytest.approx(60.0, rel=1e-6)
+    assert rhel['templates_total'] == 1
+    assert rhel['inventories_total'] == 1
+    assert isinstance(rhel['ansible_versions'], list)
+    assert '2.9.10' in rhel['ansible_versions']
+
+
 def _validate_role_stats_and_jobs_by_installed_collections_versions(json_data):
     """Validate anonymized role_stats and jobs_by_installed_collections_versions."""
     _validate_role_stats(json_data)
@@ -919,6 +992,7 @@ def _validate_all_data(json_data, statistics):
     _validate_module_stats_values_multi_hour(json_data)
     _validate_collection_stats_values_multi_hour(json_data)
     _validate_role_stats_and_jobs_by_installed_collections_versions(json_data)
+    _validate_jobs_by_installed_collections_versions_values(json_data)
 
     print('--- Validating playbooks_total ---')
     assert statistics['rollup_period_playbooks_total'] == 1, 'Should have 1 total playbook'
@@ -1013,6 +1087,8 @@ def test_from_gather_to_json(cleanup_glob):
     print('Computing anonymized rollup from collected data...')
     json_data = compute_anonymized_rollup_from_raw_data(input_data, salt)
     print('✓ Anonymized rollup computed successfully')
+    print('\n--- Anonymized rollup JSON ---')
+    print(json.dumps(json_data, indent=2))
 
     # Save JSON output
     since = datetime(2025, 6, 13, 10, 0, 0)

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -1,5 +1,3 @@
-import json
-
 import pandas as pd
 import pytest
 
@@ -25,12 +23,10 @@ jobs = [
         'inventory_name': 'inventory1',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},
-                'community.general': {'version': '1.0.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},
+            'community.general': {'version': '1.0.0'},
+        },
     },  # duration 3s, wait 0s
     {
         'id': 2,
@@ -49,13 +45,11 @@ jobs = [
         'inventory_name': 'inventory1',
         'inventory_id': 1,
         'scm_type': 'svn',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},  # Same version as job 1
-                'community.general': {'version': '2.0.0'},  # Different version - same collection
-                'ansible.windows': {'version': '1.0.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},  # Same version as job 1
+            'community.general': {'version': '2.0.0'},  # Different version - same collection
+            'ansible.windows': {'version': '1.0.0'},
+        },
     },  # duration 5s (failed), wait 2s
     # controller A, ansible 2.11.0, template T2
     {
@@ -75,13 +69,11 @@ jobs = [
         'inventory_name': 'inventory2',
         'inventory_id': 2,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},  # Same version as jobs 1 and 2
-                'community.general': {'version': '2.0.0'},  # Same version as job 2
-                'community.aws': {'version': '1.5.0'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},  # Same version as jobs 1 and 2
+            'community.general': {'version': '2.0.0'},  # Same version as job 2
+            'community.aws': {'version': '1.5.0'},
+        },
     },  # duration 7s, wait 4s
     # controller B, ansible 2.12.0, template T1
     {
@@ -101,12 +93,10 @@ jobs = [
         'inventory_name': 'inventory1',
         'inventory_id': 1,
         'scm_type': 'git',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},  # Same version as other jobs
-                'community.general': {'version': '1.0.0'},  # Same version as job 1
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},  # Same version as other jobs
+            'community.general': {'version': '1.0.0'},  # Same version as job 1
+        },
     },  # duration 2s, wait 1s
     # invalid rows (should be filtered out)
     {
@@ -125,11 +115,9 @@ jobs = [
         'inventory_name': 'inventory3',
         'inventory_id': 3,
         'scm_type': 'manual',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},
+        },
     },
     {
         'id': 6,
@@ -147,12 +135,10 @@ jobs = [
         'inventory_name': 'inventory3',
         'inventory_id': 3,
         'scm_type': 'unknown',
-        'installed_collections': json.dumps(
-            {
-                'ansible.builtin': {'version': '2.9.10'},
-                'community.general': {'version': '3.0.0'},  # Another version of community.general
-            }
-        ),
+        'installed_collections': {
+            'ansible.builtin': {'version': '2.9.10'},
+            'community.general': {'version': '3.0.0'},  # Another version of community.general
+        },
     },
 ]
 

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -18,6 +18,7 @@ Enhanced Assertions:
 - Prints full JSON output to terminal for inspection
 """
 
+import json
 import os
 import shutil
 
@@ -59,10 +60,12 @@ def _create_csv_files_from_split_data(data_dir, jobs, events, execution_environm
     jobs_csv_files = []
     csv1 = create_csv_file(jobs_part1, f'{data_dir}/part1_unified_jobs.csv')
     if csv1:
-        jobs_csv_files.append(csv1)
+        # Parse JSON columns (e.g. installed_collections) back to dicts,
+        # since the prepare function expects dicts, not JSON strings.
+        jobs_csv_files.append(load_csv_with_json_columns(csv1))
     csv2 = create_csv_file(jobs_part2, f'{data_dir}/part2_unified_jobs.csv')
     if csv2:
-        jobs_csv_files.append(csv2)
+        jobs_csv_files.append(load_csv_with_json_columns(csv2))
 
     events_part1 = events[:8]
     events_part2 = events[8:16]
@@ -642,9 +645,36 @@ def create_csv_file(data_list, csv_path):
 
     # Convert list of dicts to DataFrame then to CSV
     df = pd.DataFrame(data_list)
+
+    # Serialize dict/list values to JSON strings so the CSV contains valid JSON
+    # (pandas default repr produces single-quoted Python strings, not valid JSON)
+    for col in df.columns:
+        if df[col].apply(lambda x: isinstance(x, (dict, list))).any():
+            df[col] = df[col].apply(lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x)
+
     df.to_csv(csv_path, index=False, encoding='utf-8')
 
     return csv_path
+
+
+def load_csv_with_json_columns(csv_path):
+    """
+    Load a CSV file and parse JSON string columns back to Python objects.
+
+    This is needed because when dicts/lists are written to CSV they become JSON
+    strings, but the rollup prepare functions expect Python dicts/lists.
+    """
+    df = pd.read_csv(csv_path, encoding='utf-8')
+    for col in df.columns:
+        non_null = df[col].dropna()
+        if len(non_null) == 0:
+            continue
+        first_val = non_null.iloc[0]
+        if isinstance(first_val, str) and first_val.startswith(('{', '[')):
+            df[col] = df[col].apply(
+                lambda x: json.loads(x) if isinstance(x, str) else x
+            )
+    return df
 
 
 def test_multiple_csv_files_concatenation(cleanup_test_data):

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -671,9 +671,7 @@ def load_csv_with_json_columns(csv_path):
             continue
         first_val = non_null.iloc[0]
         if isinstance(first_val, str) and first_val.startswith(('{', '[')):
-            df[col] = df[col].apply(
-                lambda x: json.loads(x) if isinstance(x, str) else x
-            )
+            df[col] = df[col].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
     return df
 
 

--- a/metrics_utility/test/test_automation_controller_billing_helpers.py
+++ b/metrics_utility/test/test_automation_controller_billing_helpers.py
@@ -1,11 +1,14 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+
 from django.db import DatabaseError
 
 from metrics_utility.automation_controller_billing.helpers import (
     _datetime_hook,
     get_last_entries_from_db,
+    parse_json_array,
 )
 
 
@@ -96,6 +99,56 @@ class TestDatetimeHook:
         assert str(result['config']).startswith('2024-01-01')
         assert str(result['jobs']).startswith('2024-01-02')
         assert str(result['hosts']).startswith('2024-01-03')
+
+
+class TestParseJsonArray:
+    """Test cases for parse_json_array function."""
+
+    def test_list_input_returned_unchanged(self):
+        """A Python list (psycopg3 JsonbLoader path) is returned as-is."""
+        value = ['event1', 'event2']
+        assert parse_json_array(value) is value
+
+    def test_empty_list_returned_unchanged(self):
+        """An empty list is returned as-is."""
+        assert parse_json_array([]) == []
+
+    def test_null_returns_empty_list(self):
+        """None / NaN produces an empty list."""
+        assert parse_json_array(None) == []
+        assert parse_json_array(np.nan) == []
+
+    def test_valid_json_list_string_parsed(self):
+        """A JSON-encoded list string is parsed into a Python list."""
+        assert parse_json_array('["a", "b", "c"]') == ['a', 'b', 'c']
+
+    def test_valid_json_non_list_returns_empty(self):
+        """A valid JSON value that is not a list returns []."""
+        assert parse_json_array('{"key": "value"}') == []
+
+    def test_invalid_json_string_returns_empty(self):
+        """Malformed JSON returns []."""
+        assert parse_json_array('not-json!!!') == []
+
+    def test_type_error_returns_empty(self):
+        """Non-string, non-null, non-list input that causes TypeError in json.loads returns []."""
+        assert parse_json_array(42) == []
+
+
+class TestDatetimeHookTypeError:
+    """Additional _datetime_hook tests covering the TypeError branch."""
+
+    def test_non_string_value_kept_as_is(self):
+        """A non-string value (e.g. int) that parse_datetime raises TypeError for is kept."""
+        result = _datetime_hook({'count': 5})
+        # parse_datetime(5) raises TypeError → value is stored unchanged
+        assert result == {'count': 5}
+
+    def test_mixed_string_and_non_string(self):
+        """Dict with both datetime strings and non-string values is handled correctly."""
+        result = _datetime_hook({'ts': '2024-01-01T00:00:00Z', 'num': 99})
+        assert result['ts'] == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+        assert result['num'] == 99
 
 
 class TestIntegration:

--- a/metrics_utility/test/test_automation_controller_billing_helpers.py
+++ b/metrics_utility/test/test_automation_controller_billing_helpers.py
@@ -107,7 +107,7 @@ class TestParseJsonArray:
     def test_list_input_returned_unchanged(self):
         """A Python list (psycopg3 JsonbLoader path) is returned as-is."""
         value = ['event1', 'event2']
-        assert parse_json_array(value) is value
+        assert parse_json_array(value) == value
 
     def test_empty_list_returned_unchanged(self):
         """An empty list is returned as-is."""


### PR DESCRIPTION
[AAP-[66352](https://issues.redhat.com/browse/AAP-66352)]

Adds some extra tests, but mainly it overwrittes django basic JSON parsing for our cursor, now cursor is returning dict of json instead of parsable text. It should override only cursor behavior, not the global behavior.

Anonymized rollup now expects only dict for installed collections in unified jobs.

This is important perf boost, because:

1) There are too many jobs and number of installed collections is large and also grows with how large customer is, this makes our time complexity N*M, which does not scale well (N = jobs, M = collections)

2) Previous optimization used cache for already parsed json  (compares hash of json with cache), but it seems that jsonb does not guarantee the same json for the same jsonb (keys order can vary and such...)
