### PR TITLE
job_host_summary_service: drop need for ensure_functions

### DIFF
--- a/metrics_utility/anonymized_rollups/helpers.py
+++ b/metrics_utility/anonymized_rollups/helpers.py
@@ -2,7 +2,11 @@
 Helper utilities for anonymized rollups.
 """
 
+import json
 import math
+
+import pandas as pd
+import yaml
 
 
 try:
@@ -11,6 +15,48 @@ try:
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
+
+
+def parse_yaml_json(variables_data):
+    """
+    Parse the variables field from raw YAML or JSON format.
+
+    Args:
+        variables_data: Raw variables field (YAML string, JSON string, dict, or None)
+
+    Returns:
+        dict: Parsed variables as a dictionary, or None if parsing fails
+    """
+    # Handle None, NaN, or empty string
+    if pd.isna(variables_data) or not variables_data:
+        return None
+
+    # If already a dict, return as-is
+    if isinstance(variables_data, dict):
+        return variables_data
+
+    # Must be a string at this point
+    if not isinstance(variables_data, str):
+        return None
+
+    # Try JSON first (faster and more common)
+    try:
+        parsed = json.loads(variables_data)
+        if isinstance(parsed, dict):
+            return parsed
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    # Try YAML if JSON failed
+    try:
+        parsed = yaml.safe_load(variables_data)
+        if isinstance(parsed, dict):
+            return parsed
+    except (yaml.YAMLError, TypeError, ValueError):
+        pass
+
+    # Both parsing attempts failed
+    return None
 
 
 def sanitize_json(obj):

--- a/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobhostsummary_anonymized_rollup.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
-from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.anonymized_rollups.helpers import parse_yaml_json, sanitize_json
 
 
 class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
@@ -203,6 +203,25 @@ class JobHostSummaryAnonymizedRollup(BaseAnonymizedRollup):
             dataframe['launch_type'] = 'unknown'
 
         # Keep ansible_version column name (no rename needed)
+
+        # Parse variables field if present
+        if 'variables' in dataframe.columns:
+            # Parse each row's variables field and extract both fields in one pass
+            def extract_variables(variables):
+                parsed = parse_yaml_json(variables)
+                if isinstance(parsed, dict):
+                    return pd.Series(
+                        {'ansible_host_variable': parsed.get('ansible_host'), 'ansible_connection_variable': parsed.get('ansible_connection')}
+                    )
+                return pd.Series({'ansible_host_variable': None, 'ansible_connection_variable': None})
+
+            dataframe[['ansible_host_variable', 'ansible_connection_variable']] = dataframe['variables'].apply(extract_variables)
+
+            # Drop the raw variables column (no longer needed, saves memory)
+            dataframe.drop(columns=['variables'], inplace=True)
+        else:
+            dataframe['ansible_host_variable'] = None
+            dataframe['ansible_connection_variable'] = None
 
         # Compute host_outcome
         dataframe['host_outcome'] = 'successful'

--- a/metrics_utility/library/collectors/controller/job_host_summary_service.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary_service.py
@@ -1,4 +1,4 @@
-from ..util import DataframeOutput, collector, ensure_functions
+from ..util import DataframeOutput, collector
 
 
 @collector
@@ -25,20 +25,9 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
                 FROM main_jobhostsummary mjs
                 JOIN filtered_jobs fj ON fj.id = mjs.job_id
             ),
-            --
+            -- ansible_host_variable & ansible_connection_variable
             hosts_variables AS (
-                SELECT
-                    fh.host_id,
-                    CASE
-                        WHEN metrics_utility_is_valid_json(h.variables)
-                        THEN h.variables::jsonb->>'ansible_host'
-                        ELSE metrics_utility_parse_yaml_field(h.variables, 'ansible_host')
-                    END AS ansible_host_variable,
-                    CASE
-                        WHEN metrics_utility_is_valid_json(h.variables)
-                        THEN h.variables::jsonb->>'ansible_connection'
-                        ELSE metrics_utility_parse_yaml_field(h.variables, 'ansible_connection')
-                    END AS ansible_connection_variable
+                SELECT fh.host_id, h.variables
                 FROM filtered_hosts fh
                 LEFT JOIN main_host h ON h.id = fh.host_id
             )
@@ -48,8 +37,7 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
             mjs.modified,
             mjs.host_name,
             mjs.host_id AS host_remote_id,
-            hv.ansible_host_variable,
-            hv.ansible_connection_variable,
+            hv.variables,
             mjs.changed,
             mjs.dark,
             mjs.failures,
@@ -85,5 +73,4 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
         ORDER BY mu.finished ASC
     """
 
-    ensure_functions(db)
     return output.sql(db, query)

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -295,92 +295,91 @@ def test_unified_jobs_command(cleanup_glob):
 
 jobs_host_summary_service_lines = [
     (
-        'id,created,modified,host_name,host_remote_id,ansible_host_variable,'
-        'ansible_connection_variable,changed,dark,failures,ok,processed,skipped,'
+        'id,created,modified,host_name,host_remote_id,variables,changed,dark,failures,ok,processed,skipped,'
         'failed,ignored,rescued,job_created,job_remote_id,job_template_remote_id,'
         'job_template_name,ansible_version,launch_type,inventory_remote_id,inventory_name,organization_remote_id,'
         'organization_name,project_remote_id,project_name,model'
     ),
     (
         '1,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '2,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '3,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '4,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '5,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,1,0,0,0,t,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,1,0,0,0,t,0,0,'
         '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '6,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,1,0,0,0,t,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,1,0,0,0,t,0,0,'
         '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '7,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,4,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '8,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,4,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '9,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,5,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '10,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,5,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '11,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,6,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '12,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,{"ansible_host":"default_host","ansible_connection":"default_connection"},0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,6,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'

--- a/metrics_utility/test/library/test_collectors_job_host_summary_service.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary_service.py
@@ -109,8 +109,8 @@ def test_job_host_summary_service_filters_by_finished_jobs(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_job_host_summary_service_uses_yaml_json_functions(mock_copy_pandas):
-    """Test that query uses metrics_utility helper functions."""
+def test_job_host_summary_service_doesnt_yaml_json_functions(mock_copy_pandas):
+    """Test that query doesn't use metrics_utility SQL helper functions."""
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -123,8 +123,8 @@ def test_job_host_summary_service_uses_yaml_json_functions(mock_copy_pandas):
     query = call_args[0][1]
 
     # Should use helper functions for parsing YAML/JSON
-    assert 'metrics_utility_is_valid_json' in query
-    assert 'metrics_utility_parse_yaml_field' in query
+    assert 'metrics_utility_is_valid_json' not in query
+    assert 'metrics_utility_parse_yaml_field' not in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')


### PR DESCRIPTION
`ensure_functions(db)` needs writeable DB access - which we won't have in the service

Replacing with python

EDIT: but the fields were unused, replacing with #347 :)
