### PR TITLE
Add function to check schema privileges before creating functions in …

### DIFF
--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -86,8 +86,15 @@ def collector(func):
     return constructor
 
 
+def _can_create_functions(db):
+    with db.cursor() as cursor:
+        cursor.execute("SELECT has_schema_privilege(current_user, 'public', 'CREATE')")
+        return cursor.fetchone()[0]
+
+
 def ensure_functions(db):
-    # Execute prepend_query if needed (custom PostgreSQL functions)
+    if not _can_create_functions(db):
+        return
     with db.cursor() as cursor:
         cursor.execute(_yaml_json_functions())
 


### PR DESCRIPTION
…ensure_functions

This update introduces a new helper function, _can_create_functions, which checks if the current user has the necessary privileges to create functions in the database. The ensure_functions function now returns early if the user lacks these privileges, enhancing security and preventing unnecessary execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a privilege check that can change runtime behavior by silently skipping installation of required PostgreSQL helper functions when the connected role lacks `CREATE` on `public`, which could surface as missing-function errors in downstream queries.
> 
> **Overview**
> Adds `_can_create_functions(db)` to check `has_schema_privilege(current_user, 'public', 'CREATE')` before attempting to install custom PostgreSQL functions.
> 
> Updates `ensure_functions` to return early when the current DB user lacks permission, avoiding failed `CREATE OR REPLACE FUNCTION` executions under restricted roles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383cc5759faf7c4c19967c1aff4a108dc5be8d5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->