### PR TITLE
job_host_summary_service: drop need for ensure functions

### DIFF
--- a/metrics_utility/library/collectors/controller/job_host_summary_service.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary_service.py
@@ -1,4 +1,4 @@
-from ..util import DataframeOutput, collector, ensure_functions
+from ..util import DataframeOutput, collector
 
 
 @collector
@@ -24,23 +24,6 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
                 SELECT DISTINCT mjs.host_id
                 FROM main_jobhostsummary mjs
                 JOIN filtered_jobs fj ON fj.id = mjs.job_id
-            ),
-            --
-            hosts_variables AS (
-                SELECT
-                    fh.host_id,
-                    CASE
-                        WHEN metrics_utility_is_valid_json(h.variables)
-                        THEN h.variables::jsonb->>'ansible_host'
-                        ELSE metrics_utility_parse_yaml_field(h.variables, 'ansible_host')
-                    END AS ansible_host_variable,
-                    CASE
-                        WHEN metrics_utility_is_valid_json(h.variables)
-                        THEN h.variables::jsonb->>'ansible_connection'
-                        ELSE metrics_utility_parse_yaml_field(h.variables, 'ansible_connection')
-                    END AS ansible_connection_variable
-                FROM filtered_hosts fh
-                LEFT JOIN main_host h ON h.id = fh.host_id
             )
         SELECT
             mjs.id,
@@ -48,8 +31,6 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
             mjs.modified,
             mjs.host_name,
             mjs.host_id AS host_remote_id,
-            hv.ansible_host_variable,
-            hv.ansible_connection_variable,
             mjs.changed,
             mjs.dark,
             mjs.failures,
@@ -81,9 +62,7 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
         LEFT JOIN main_unifiedjobtemplate AS mup ON mup.id = mj.project_id
         LEFT JOIN main_inventory mi ON mi.id = mj.inventory_id
         LEFT JOIN main_organization mo ON mo.id = mu.organization_id
-        LEFT JOIN hosts_variables hv ON hv.host_id = mjs.host_id
         ORDER BY mu.finished ASC
     """
 
-    ensure_functions(db)
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/job_host_summary_service.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary_service.py
@@ -18,12 +18,6 @@ def job_host_summary_service(*, db=None, since=None, until=None, output=Datafram
                 FROM main_unifiedjob mu
                 WHERE {where}
                 AND mu.finished IS NOT NULL
-            ),
-            -- Then: only host summaries that belong to those jobs (uses index on main_jobhostsummary.job_id)
-            filtered_hosts AS (
-                SELECT DISTINCT mjs.host_id
-                FROM main_jobhostsummary mjs
-                JOIN filtered_jobs fj ON fj.id = mjs.job_id
             )
         SELECT
             mjs.id,

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -295,92 +295,91 @@ def test_unified_jobs_command(cleanup_glob):
 
 jobs_host_summary_service_lines = [
     (
-        'id,created,modified,host_name,host_remote_id,ansible_host_variable,'
-        'ansible_connection_variable,changed,dark,failures,ok,processed,skipped,'
+        'id,created,modified,host_name,host_remote_id,changed,dark,failures,ok,processed,skipped,'
         'failed,ignored,rescued,job_created,job_remote_id,job_template_remote_id,'
         'job_template_name,ansible_version,launch_type,inventory_remote_id,inventory_name,organization_remote_id,'
         'organization_name,project_remote_id,project_name,model'
     ),
     (
         '1,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '2,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,1,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '3,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '4,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 10:00:00+00:00,2,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '5,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,1,0,0,0,t,0,0,'
+        '31,0,0,1,0,0,0,t,0,0,'
         '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '6,2025-06-13 10:00:00+00:00,2025-06-13 10:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,1,0,0,0,t,0,0,'
+        '32,0,0,1,0,0,0,t,0,0,'
         '2025-06-13 10:00:00+00:00,3,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '7,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,4,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '8,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,4,1,default_unified_job_template_2025-06-13,2.9.10,manual,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '9,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,5,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '10,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,5,1,default_unified_job_template_2025-06-13,2.9.10,scheduled,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '11,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_1_2025-06-13,'
-        '31,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '31,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,6,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'
     ),
     (
         '12,2025-06-13 11:00:00+00:00,2025-06-13 11:00:00+00:00,default_host_2_2025-06-13,'
-        '32,default_ansible_host,default_ansible_connection,0,0,0,1,0,0,f,0,0,'
+        '32,0,0,0,1,0,0,f,0,0,'
         '2025-06-13 11:00:00+00:00,6,1,default_unified_job_template_2025-06-13,2.9.10,workflow,4,'
         'default_inventory_2025-06-13,2,default_org_2025-06-13,1,'
         'default_unified_job_template_2025-06-13,job'

--- a/metrics_utility/test/library/test_collectors_job_host_summary_service.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary_service.py
@@ -109,8 +109,8 @@ def test_job_host_summary_service_filters_by_finished_jobs(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_job_host_summary_service_uses_yaml_json_functions(mock_copy_pandas):
-    """Test that query uses metrics_utility helper functions."""
+def test_job_host_summary_service_doesnt_yaml_json_functions(mock_copy_pandas):
+    """Test that query doesn't use metrics_utility SQL helper functions."""
     mock_db = MagicMock()
     since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
@@ -123,8 +123,8 @@ def test_job_host_summary_service_uses_yaml_json_functions(mock_copy_pandas):
     query = call_args[0][1]
 
     # Should use helper functions for parsing YAML/JSON
-    assert 'metrics_utility_is_valid_json' in query
-    assert 'metrics_utility_parse_yaml_field' in query
+    assert 'metrics_utility_is_valid_json' not in query
+    assert 'metrics_utility_parse_yaml_field' not in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')

--- a/metrics_utility/test/library/test_collectors_job_host_summary_service.py
+++ b/metrics_utility/test/library/test_collectors_job_host_summary_service.py
@@ -79,8 +79,6 @@ def test_job_host_summary_service_query_structure(mock_copy_pandas):
     # Should have CTEs for filtering
     assert 'WITH' in query
     assert 'filtered_jobs' in query
-    assert 'filtered_hosts' in query
-    assert 'hosts_variables' in query
 
     # Should query expected tables
     assert 'main_jobhostsummary' in query


### PR DESCRIPTION
needs writeable DB access, but unused, removing

The values seem unused.

(Alternative to #345 )

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `job_host_summary_service` output schema by dropping `ansible_*_variable` fields and removes the DB-side function bootstrap, which could break downstream consumers expecting those columns. Query logic is otherwise simplified, so runtime risk is mainly compatibility/regression in reports relying on the removed fields.
> 
> **Overview**
> **Simplifies `job_host_summary_service` SQL and removes write-required behavior.** The collector no longer builds `filtered_hosts`/`hosts_variables` CTEs or joins `main_host` to extract `ansible_host` / `ansible_connection` variables, and it stops calling `ensure_functions(db)` (so it no longer tries to create custom YAML/JSON SQL helper functions).
> 
> Tests and expected gathered CSV output are updated to reflect the removed columns and to assert that the helper SQL functions are *not* referenced in the generated query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a58430f7fd28540124dac93346d05ab3fb5d321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->