### PR TITLE
Refactor JobsAnonymizedRollup to improve numeric column handling and execution environment ID checks. Updated casting to prevent coercion errors in pandas and streamlined NaN checks for EE ID.

### DIFF
--- a/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
@@ -28,8 +28,15 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
             numeric = pd.to_numeric(dataframe[col], errors='coerce')
             mask = numeric.notna()
             if mask.any():
-                # Convert only the numeric rows to integer strings; leave NaN rows untouched
-                dataframe.loc[mask, col] = numeric[mask].astype(int).astype(str)
+                # Cast to object dtype first so that assigning string values does not
+                # trigger a StringArray → int64 coercion error in pandas 2.2+/3.x,
+                # which occurs when the original column dtype is int64 and pandas
+                # tries to cast the assigned StringArray back to int64.
+                dataframe[col] = dataframe[col].astype(object)
+                # Use to_numpy(dtype=float) to escape any nullable Float64Dtype and
+                # produce a plain numpy float array before converting to int strings,
+                # ensuring the result is an object array rather than a StringArray.
+                dataframe.loc[mask, col] = numeric[mask].to_numpy(dtype=float).astype(int).astype(str)
 
         return dataframe
 
@@ -663,7 +670,7 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         Falls back to hashing the raw string for rows that have no EE id.
         """
         ee_id = getattr(row, 'execution_environment_id', None)
-        if ee_id is not None and not (isinstance(ee_id, float) and pd.isna(ee_id)):
+        if ee_id is not None and not pd.isna(ee_id):
             return ('ee', int(ee_id))
         raw = installed_collections_data if isinstance(installed_collections_data, str) else str(installed_collections_data)
         return ('raw', hash(raw))


### PR DESCRIPTION
collection failure is a StringArray → int64 type
  coercion bug in the unified_jobs collector

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pandas dtype conversion and cache-key selection in the jobs rollup, which can subtly affect aggregation/serialization outputs across different pandas versions.
> 
> **Overview**
> Improves `JobsAnonymizedRollup` ID normalization by forcing ID columns to `object` and converting numeric masks via `to_numpy(dtype=float)` before string-casting, avoiding pandas 2.2+/3.x `StringArray → int64` coercion failures during assignment.
> 
> Simplifies the execution-environment cache-key guard by replacing the custom float/NaN check with `pd.isna`, ensuring `execution_environment_id` is only used when it’s truly non-null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26f12e5e2192c627c5fb0927f46824367e6c7c9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->