### PR TITLE
[stable-0.7] Update jobs_anonymized_rollup.py

### DIFF
--- a/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/jobs_anonymized_rollup.py
@@ -28,8 +28,15 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
             numeric = pd.to_numeric(dataframe[col], errors='coerce')
             mask = numeric.notna()
             if mask.any():
-                # Convert only the numeric rows to integer strings; leave NaN rows untouched
-                dataframe.loc[mask, col] = numeric[mask].astype(int).astype(str)
+                # Cast to object dtype first so that assigning string values does not
+                # trigger a StringArray → int64 coercion error in pandas 2.2+/3.x,
+                # which occurs when the original column dtype is int64 and pandas
+                # tries to cast the assigned StringArray back to int64.
+                dataframe[col] = dataframe[col].astype(object)
+                # Use to_numpy(dtype=float) to escape any nullable Float64Dtype and
+                # produce a plain numpy float array before converting to int strings,
+                # ensuring the result is an object array rather than a StringArray.
+                dataframe.loc[mask, col] = numeric[mask].to_numpy(dtype=float).astype(int).astype(str)
 
         return dataframe
 
@@ -663,7 +670,7 @@ class JobsAnonymizedRollup(BaseAnonymizedRollup):
         Falls back to hashing the raw string for rows that have no EE id.
         """
         ee_id = getattr(row, 'execution_environment_id', None)
-        if ee_id is not None and not (isinstance(ee_id, float) and pd.isna(ee_id)):
+        if ee_id is not None and not pd.isna(ee_id):
             return ('ee', int(ee_id))
         raw = installed_collections_data if isinstance(installed_collections_data, str) else str(installed_collections_data)
         return ('raw', hash(raw))


### PR DESCRIPTION
Minor change to make unified jobs work correctly for all panda's installs 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfixes limited to dataframe preprocessing and cache-key generation; behavior should be equivalent except for improved handling of pandas dtypes/NaNs.
> 
> **Overview**
> Improves `JobsAnonymizedRollup` compatibility with newer pandas by making ID-to-string conversion robust: ID columns are explicitly cast to `object` and the numeric mask is converted via `to_numpy(dtype=float)` before assigning stringified ints, avoiding pandas 2.2+/3.x dtype coercion errors.
> 
> Also simplifies/strengthens `_get_collection_cache_key` NaN detection for `execution_environment_id` by relying on `pd.isna`, ensuring EE-based cache keys are used whenever the value is present and not missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27c3fcbbc7a2b88bb6de89db1ffaa5f54dec1283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->