### PR TITLE
collectors: unify on date interpolation through `date_where`

### DIFF
--- a/metrics_utility/library/collectors/controller/credentials_service.py
+++ b/metrics_utility/library/collectors/controller/credentials_service.py
@@ -1,4 +1,4 @@
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
@@ -11,8 +11,7 @@ def credentials_service(*, db=None, since=None, until=None, output=DataframeOutp
         JOIN main_credential ON main_credential.id = main_unifiedjob_credentials.credential_id
         JOIN main_credentialtype ON main_credentialtype.id = main_credential.credential_type_id
         WHERE
-            main_unifiedjob.finished >= '{since.isoformat()}'
-            AND main_unifiedjob.finished < '{until.isoformat()}'
+            {date_where('main_unifiedjob.finished', since, until)}
             AND main_credentialtype.managed = true
     """
 

--- a/metrics_utility/library/collectors/controller/job_host_summary.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary.py
@@ -1,14 +1,9 @@
-from ..util import DataframeOutput, collector, ensure_functions
+from ..util import DataframeOutput, collector, date_where, ensure_functions
 
 
 @collector
 def job_host_summary(*, db=None, since=None, until=None, output=DataframeOutput()):
-    where = ' AND '.join(
-        [
-            f"main_jobhostsummary.modified >= '{since.isoformat()}'",
-            f"main_jobhostsummary.modified < '{until.isoformat()}'",
-        ]
-    )
+    where = date_where('main_jobhostsummary.modified', since, until)
 
     # TODO: controler needs to have an index on main_jobhostsummary.modified
     query = f"""
@@ -78,5 +73,6 @@ def job_host_summary(*, db=None, since=None, until=None, output=DataframeOutput(
         ORDER BY main_jobhostsummary.modified ASC
     """
 
+    # ensure_functions writes to DB, cannot be used in service (readonly DB)
     ensure_functions(db)
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/job_host_summary_service.py
+++ b/metrics_utility/library/collectors/controller/job_host_summary_service.py
@@ -1,22 +1,15 @@
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
 def job_host_summary_service(*, db=None, since=None, until=None, output=DataframeOutput()):
-    where = ' AND '.join(
-        [
-            f"mu.finished >= '{since.isoformat()}'",
-            f"mu.finished < '{until.isoformat()}'",
-        ]
-    )
-
     query = f"""
         WITH
             -- First: restrict to jobs that FINISHED in the window (uses index on main_unifiedjob.finished if present)
             filtered_jobs AS (
                 SELECT mu.id
                 FROM main_unifiedjob mu
-                WHERE {where}
+                WHERE {date_where('mu.finished', since, until)}
                 AND mu.finished IS NOT NULL
             )
         SELECT

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -90,6 +90,7 @@ def _main_host_query(where):
 def main_host(*, db=None, output=DataframeOutput()):
     query = _main_host_query("enabled='t'")
 
+    # ensure_functions writes to DB, cannot be used in service (readonly DB)
     ensure_functions(db)
     return output.sql(db, query)
 
@@ -105,5 +106,6 @@ def main_host_daily(*, db=None, since=None, until=None, output=DataframeOutput()
     """
     query = _main_host_query(where)
 
+    # ensure_functions writes to DB, cannot be used in service (readonly DB)
     ensure_functions(db)
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -97,7 +97,7 @@ def main_host(*, db=None, output=DataframeOutput()):
 
 @collector
 def main_host_daily(*, db=None, since=None, until=None, output=DataframeOutput()):
-    # prefer running with until=False, to not skip hosts that keep being modified
+    # prefer running with until=None, to not skip hosts that keep being modified
 
     where = f"""
         enabled='t'

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,15 +1,8 @@
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
 def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
-    where = ' AND '.join(
-        [
-            f"main_indirectmanagednodeaudit.created >= '{since.isoformat()}'",
-            f"main_indirectmanagednodeaudit.created < '{until.isoformat()}'",
-        ]
-    )
-
     query = f"""
         SELECT
             main_indirectmanagednodeaudit.id,
@@ -36,7 +29,7 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=Dat
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
-        WHERE {where}
+        WHERE {date_where('main_indirectmanagednodeaudit.created', since, until)}
         ORDER BY main_indirectmanagednodeaudit.created ASC
     """
 

--- a/metrics_utility/library/collectors/controller/main_jobevent.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent.py
@@ -1,15 +1,8 @@
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
 def main_jobevent(*, db=None, since=None, until=None, output=DataframeOutput()):
-    where = ' AND '.join(
-        [
-            f"main_jobhostsummary.modified >= '{since.isoformat()}'",
-            f"main_jobhostsummary.modified < '{until.isoformat()}'",
-        ]
-    )
-
     query = f"""
         WITH job_scope AS (
             SELECT
@@ -21,7 +14,7 @@ def main_jobevent(*, db=None, since=None, until=None, output=DataframeOutput()):
                 main_jobhostsummary.host_name
             FROM main_jobhostsummary
             JOIN main_unifiedjob ON main_unifiedjob.id = main_jobhostsummary.job_id
-            WHERE {where}
+            WHERE {date_where('main_jobhostsummary.modified', since, until)}
         )
         SELECT
             job_scope.main_jobhostsummary_id,

--- a/metrics_utility/library/collectors/controller/unified_jobs.py
+++ b/metrics_utility/library/collectors/controller/unified_jobs.py
@@ -1,4 +1,4 @@
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
@@ -44,8 +44,7 @@ def unified_jobs(*, db=None, since=None, until=None, output=DataframeOutput()):
         LEFT JOIN main_project ON main_job.project_id = main_project.unifiedjobtemplate_ptr_id
         LEFT JOIN main_unifiedjobtemplate AS mut ON mut.id = main_unifiedjob.unified_job_template_id
         WHERE
-            main_unifiedjob.finished >= '{since.isoformat()}'
-            AND main_unifiedjob.finished < '{until.isoformat()}'
+            {date_where('main_unifiedjob.finished', since, until)}
         ORDER BY main_unifiedjob.id ASC
     """
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -53,16 +53,16 @@ class CollectionOutput(DictOutput):
         return _copy_table_files(db, query, filespec)
 
 
-# FIXME: psycopg.sql
+# NOTE: `field` should be a hardcoded column name
 def date_where(field, since, until):
     if since and until:
-        return f'( "{field}" >= \'{since.isoformat()}\' AND "{field}" < \'{until.isoformat()}\' )'
+        return f"( {field} >= '{since.isoformat()}' AND {field} < '{until.isoformat()}' )"
 
     if since:
-        return f'( "{field}" >= \'{since.isoformat()}\' )'
+        return f"( {field} >= '{since.isoformat()}' )"
 
     if until:
-        return f'( "{field}" < \'{until.isoformat()}\' )'
+        return f"( {field} < '{until.isoformat()}' )"
 
     return 'true'
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -1,5 +1,7 @@
 import tempfile
 
+from datetime import datetime
+
 from ..csv_file_splitter import CsvFileSplitter
 
 
@@ -55,6 +57,12 @@ class CollectionOutput(DictOutput):
 
 # NOTE: `field` should be a hardcoded column name
 def date_where(field, since, until):
+    for name, value in [('since', since), ('until', until)]:
+        if value is not None and not isinstance(value, datetime):
+            raise TypeError(f'date_where: {name} must be a datetime, got {type(value).__name__}')
+        if value is not None and value.tzinfo is None:
+            raise ValueError(f'date_where: {name} must be timezone-aware')
+
     if since and until:
         return f"( {field} >= '{since.isoformat()}' AND {field} < '{until.isoformat()}' )"
 

--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -2,8 +2,6 @@ import csv
 import glob
 import os
 
-from datetime import datetime, timezone
-
 import pytest
 
 from django.db import connection
@@ -13,7 +11,7 @@ from metrics_utility.library.collectors.controller.job_host_summary_service impo
 from metrics_utility.library.collectors.controller.main_jobevent_service import main_jobevent_service
 from metrics_utility.library.collectors.controller.unified_jobs import unified_jobs
 from metrics_utility.test.gather.test_jobhostsummary_gather import SafeTarFile
-from metrics_utility.test.util import run_gather_ext
+from metrics_utility.test.util import run_gather_ext, utcdt
 
 
 env_vars = {
@@ -281,8 +279,8 @@ json_lines_skip_ids_columns = [
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_unified_jobs_command(cleanup_glob):
     """Build and validate unified_jobs output from new library collector."""
-    since = datetime(2025, 6, 12, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 14, tzinfo=timezone.utc)
+    since = utcdt('2025-06-12')
+    until = utcdt('2025-06-14')
 
     # Run the new collector directly
     collector_instance = unified_jobs(db=connection, since=since, until=until)
@@ -402,8 +400,8 @@ jobs_host_summary_service_skip_columns = [
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_job_host_summary_service_command(cleanup_glob):
     """Build and validate job_host_summary_service output from new library collector."""
-    since = datetime(2025, 6, 12, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 14, tzinfo=timezone.utc)
+    since = utcdt('2025-06-12')
+    until = utcdt('2025-06-14')
 
     # Run the new collector directly
     collector_instance = job_host_summary_service(db=connection, since=since, until=until)
@@ -580,8 +578,8 @@ main_jobevent_service_skip_columns = [
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_main_jobevent_service_command(cleanup_glob):
     """Build and validate main_jobevent_service output from new library collector."""
-    since = datetime(2025, 6, 12, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 14, tzinfo=timezone.utc)
+    since = utcdt('2025-06-12')
+    until = utcdt('2025-06-14')
 
     # Run the new collector directly
     collector_instance = main_jobevent_service(db=connection, since=since, until=until)
@@ -643,8 +641,8 @@ credentials_service_skip_columns = []
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_credentials_service_command(cleanup_glob):
     """Build and validate credentials_service output from new library collector."""
-    since = datetime(2025, 6, 12, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 14, tzinfo=timezone.utc)
+    since = utcdt('2025-06-12')
+    until = utcdt('2025-06-14')
 
     # Run the new collector directly
     collector_instance = credentials_service(db=connection, since=since, until=until)

--- a/metrics_utility/test/gather/test_total_workers_vcpu.py
+++ b/metrics_utility/test/gather/test_total_workers_vcpu.py
@@ -7,7 +7,7 @@ from metrics_utility.automation_controller_billing.collectors import cli_total_w
 from metrics_utility.exceptions import MetricsException, MissingRequiredEnvVar
 from metrics_utility.library.collectors.others.total_workers_vcpu import get_hour_boundaries
 from metrics_utility.library.collectors.util import DictOutput
-from metrics_utility.test.util import temporary_env
+from metrics_utility.test.util import temporary_env, utcdt
 
 
 class TestTotalWorkersVcpu:
@@ -123,14 +123,13 @@ class TestGetHourBoundaries:
     def test_get_hour_boundaries_calculation(self):
         """Test that get_hour_boundaries correctly calculates previous hour boundaries."""
         # Test with a specific timestamp: 2023-12-25 15:30:45 UTC
-        test_datetime = datetime(2023, 12, 25, 15, 30, 45, tzinfo=timezone.utc)
-        current_ts = test_datetime.timestamp()
+        current_ts = utcdt('2023-12-25T15:30:45').timestamp()
 
         prev_hour_start, prev_hour_end = get_hour_boundaries(current_ts)
 
         # Previous hour should be 14:00:00 to 14:59:59.999
-        expected_prev_hour_start = datetime(2023, 12, 25, 14, 0, 0, tzinfo=timezone.utc).timestamp()
-        expected_prev_hour_end = datetime(2023, 12, 25, 14, 59, 59, 999000, tzinfo=timezone.utc).timestamp()
+        expected_prev_hour_start = utcdt('2023-12-25T14:00:00').timestamp()
+        expected_prev_hour_end = utcdt('2023-12-25T14:59:59.999').timestamp()
 
         assert prev_hour_start == pytest.approx(expected_prev_hour_start, rel=0, abs=1e-6)
         assert prev_hour_end == pytest.approx(expected_prev_hour_end, rel=0, abs=1e-6)
@@ -138,14 +137,13 @@ class TestGetHourBoundaries:
     def test_get_hour_boundaries_at_hour_boundary(self):
         """Test get_hour_boundaries when current time is exactly at hour boundary."""
         # Test at exactly 15:00:00
-        test_datetime = datetime(2023, 12, 25, 15, 0, 0, tzinfo=timezone.utc)
-        current_ts = test_datetime.timestamp()
+        current_ts = utcdt('2023-12-25T15:00:00').timestamp()
 
         prev_hour_start, prev_hour_end = get_hour_boundaries(current_ts)
 
         # Previous hour should be 14:00:00 to 14:59:59.999
-        expected_prev_hour_start = datetime(2023, 12, 25, 14, 0, 0, tzinfo=timezone.utc).timestamp()
-        expected_prev_hour_end = datetime(2023, 12, 25, 14, 59, 59, 999000, tzinfo=timezone.utc).timestamp()
+        expected_prev_hour_start = utcdt('2023-12-25T14:00:00').timestamp()
+        expected_prev_hour_end = utcdt('2023-12-25T14:59:59.999').timestamp()
 
         assert prev_hour_start == pytest.approx(expected_prev_hour_start, rel=0, abs=1e-6)
         assert prev_hour_end == pytest.approx(expected_prev_hour_end, rel=0, abs=1e-6)

--- a/metrics_utility/test/library/test_collectors_total_workers_vcpu_helpers.py
+++ b/metrics_utility/test/library/test_collectors_total_workers_vcpu_helpers.py
@@ -1,6 +1,5 @@
 """Tests for helper functions in total_workers_vcpu module."""
 
-from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +9,7 @@ from metrics_utility.library.collectors.others.total_workers_vcpu import (
     get_total_workers_cpu,
     timestamp_format,
 )
+from metrics_utility.test.util import utcdt
 
 
 class TestTimestampFormat:
@@ -18,8 +18,7 @@ class TestTimestampFormat:
     def test_timestamp_format_basic(self):
         """Test basic timestamp formatting."""
         # 2024-01-01 12:30:45.123 UTC
-        dt = datetime(2024, 1, 1, 12, 30, 45, 123000, tzinfo=timezone.utc)
-        ts = dt.timestamp()
+        ts = utcdt('2024-01-01T12:30:45.123').timestamp()
 
         result = timestamp_format(ts)
 
@@ -28,8 +27,7 @@ class TestTimestampFormat:
 
     def test_timestamp_format_midnight(self):
         """Test formatting midnight timestamp."""
-        dt = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        ts = dt.timestamp()
+        ts = utcdt('2024-01-01').timestamp()
 
         result = timestamp_format(ts)
 
@@ -37,8 +35,7 @@ class TestTimestampFormat:
 
     def test_timestamp_format_with_milliseconds(self):
         """Test formatting preserves milliseconds."""
-        dt = datetime(2024, 1, 1, 12, 30, 45, 999000, tzinfo=timezone.utc)
-        ts = dt.timestamp()
+        ts = utcdt('2024-01-01T12:30:45.999').timestamp()
 
         result = timestamp_format(ts)
 
@@ -47,8 +44,7 @@ class TestTimestampFormat:
 
     def test_timestamp_format_no_timezone_offset(self):
         """Test that +00:00 is replaced with Z."""
-        dt = datetime(2024, 6, 15, 8, 45, 30, 500000, tzinfo=timezone.utc)
-        ts = dt.timestamp()
+        ts = utcdt('2024-06-15T08:45:30.500').timestamp()
 
         result = timestamp_format(ts)
 

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -1,9 +1,10 @@
 """Test suite for collector utility helper functions."""
 
-from datetime import datetime
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from metrics_utility.library.collectors.util import (
     _copy_table_files,
@@ -286,8 +287,8 @@ class TestDateWhere:
 
     def test_both_since_and_until(self):
         """Test date_where with both since and until produces range condition."""
-        since = datetime(2024, 1, 1, 0, 0, 0)
-        until = datetime(2024, 12, 31, 23, 59, 59)
+        since = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        until = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
         result = date_where('created_at', since, until)
 
@@ -298,7 +299,7 @@ class TestDateWhere:
 
     def test_only_since(self):
         """Test date_where with only since produces >= condition."""
-        since = datetime(2024, 6, 1, 12, 0, 0)
+        since = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
         result = date_where('modified_date', since, None)
 
@@ -308,7 +309,7 @@ class TestDateWhere:
 
     def test_only_until(self):
         """Test date_where with only until produces < condition."""
-        until = datetime(2024, 3, 15, 18, 30, 0)
+        until = datetime(2024, 3, 15, 18, 30, 0, tzinfo=timezone.utc)
 
         result = date_where('timestamp', None, until)
 
@@ -322,31 +323,26 @@ class TestDateWhere:
 
         assert result == 'true'
 
-    def test_isoformat_used(self):
-        """Test that datetime.isoformat() is used for date formatting."""
-        since = datetime(2024, 1, 15, 10, 30, 45)
-        until = datetime(2024, 2, 20, 14, 45, 30)
+    def test_rejects_naive_since(self):
+        with pytest.raises(ValueError, match='since must be timezone-aware'):
+            date_where('field', datetime(2024, 1, 1), None)
 
-        result = date_where('event_time', since, until)
+    def test_rejects_naive_until(self):
+        with pytest.raises(ValueError, match='until must be timezone-aware'):
+            date_where('field', None, datetime(2024, 1, 1))
 
-        # isoformat() produces strings like '2024-01-15T10:30:45'
-        assert '2024-01-15T10:30:45' in result
-        assert '2024-02-20T14:45:30' in result
+    def test_rejects_non_datetime_since(self):
+        with pytest.raises(TypeError, match='since must be a datetime, got str'):
+            date_where('field', '2024-01-01', None)
 
-    def test_since_and_until_format(self):
-        """Test the exact format of the range condition."""
-        since = datetime(2024, 1, 1, 0, 0, 0)
-        until = datetime(2024, 12, 31, 0, 0, 0)
-
-        result = date_where('field', since, until)
-
-        expected = f"( field >= '{since.isoformat()}' AND field < '{until.isoformat()}' )"
-        assert result == expected
+    def test_rejects_non_datetime_until(self):
+        with pytest.raises(TypeError, match='until must be a datetime, got date'):
+            date_where('field', None, date(2024, 1, 1))
 
     def test_dotted_table_column_reference(self):
         """Test that table.column references work correctly (not broken by quoting)."""
-        since = datetime(2024, 1, 1, 0, 0, 0)
-        until = datetime(2024, 12, 31, 0, 0, 0)
+        since = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        until = datetime(2024, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
 
         result = date_where('main_host.created', since, until)
 

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -291,8 +291,8 @@ class TestDateWhere:
 
         result = date_where('created_at', since, until)
 
-        assert '( "created_at" >=' in result
-        assert 'AND "created_at" <' in result
+        assert 'created_at >=' in result
+        assert 'AND created_at <' in result
         assert since.isoformat() in result
         assert until.isoformat() in result
 
@@ -302,7 +302,7 @@ class TestDateWhere:
 
         result = date_where('modified_date', since, None)
 
-        assert '( "modified_date" >=' in result
+        assert 'modified_date >=' in result
         assert since.isoformat() in result
         assert 'AND' not in result
 
@@ -312,7 +312,7 @@ class TestDateWhere:
 
         result = date_where('timestamp', None, until)
 
-        assert '( "timestamp" <' in result
+        assert 'timestamp <' in result
         assert until.isoformat() in result
         assert '>=' not in result
 
@@ -333,14 +333,6 @@ class TestDateWhere:
         assert '2024-01-15T10:30:45' in result
         assert '2024-02-20T14:45:30' in result
 
-    def test_field_name_quoted(self):
-        """Test that field name is properly quoted."""
-        since = datetime(2024, 1, 1)
-
-        result = date_where('my_field', since, None)
-
-        assert '"my_field"' in result
-
     def test_since_and_until_format(self):
         """Test the exact format of the range condition."""
         since = datetime(2024, 1, 1, 0, 0, 0)
@@ -348,5 +340,17 @@ class TestDateWhere:
 
         result = date_where('field', since, until)
 
-        expected = f'( "field" >= \'{since.isoformat()}\' AND "field" < \'{until.isoformat()}\' )'
+        expected = f"( field >= '{since.isoformat()}' AND field < '{until.isoformat()}' )"
         assert result == expected
+
+    def test_dotted_table_column_reference(self):
+        """Test that table.column references work correctly (not broken by quoting)."""
+        since = datetime(2024, 1, 1, 0, 0, 0)
+        until = datetime(2024, 12, 31, 0, 0, 0)
+
+        result = date_where('main_host.created', since, until)
+
+        assert 'main_host.created >=' in result
+        assert 'main_host.created <' in result
+        # must NOT be quoted as "main_host.created" — PostgreSQL would treat that as a single identifier
+        assert '"main_host.created"' not in result

--- a/metrics_utility/test/library/test_collectors_util_helpers.py
+++ b/metrics_utility/test/library/test_collectors_util_helpers.py
@@ -1,6 +1,6 @@
 """Test suite for collector utility helper functions."""
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -12,6 +12,7 @@ from metrics_utility.library.collectors.util import (
     date_where,
     ensure_functions,
 )
+from metrics_utility.test.util import utcdt
 
 
 class TestEnsureFunctions:
@@ -287,8 +288,8 @@ class TestDateWhere:
 
     def test_both_since_and_until(self):
         """Test date_where with both since and until produces range condition."""
-        since = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        until = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        since = utcdt('2024-01-01')
+        until = utcdt('2024-12-31T23:59:59')
 
         result = date_where('created_at', since, until)
 
@@ -299,7 +300,7 @@ class TestDateWhere:
 
     def test_only_since(self):
         """Test date_where with only since produces >= condition."""
-        since = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        since = utcdt('2024-06-01T12:00:00')
 
         result = date_where('modified_date', since, None)
 
@@ -309,7 +310,7 @@ class TestDateWhere:
 
     def test_only_until(self):
         """Test date_where with only until produces < condition."""
-        until = datetime(2024, 3, 15, 18, 30, 0, tzinfo=timezone.utc)
+        until = utcdt('2024-03-15T18:30:00')
 
         result = date_where('timestamp', None, until)
 
@@ -341,8 +342,8 @@ class TestDateWhere:
 
     def test_dotted_table_column_reference(self):
         """Test that table.column references work correctly (not broken by quoting)."""
-        since = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        until = datetime(2024, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
+        since = utcdt('2024-01-01')
+        until = utcdt('2024-12-31')
 
         result = date_where('main_host.created', since, until)
 

--- a/metrics_utility/test/library/test_instants.py
+++ b/metrics_utility/test/library/test_instants.py
@@ -18,6 +18,7 @@ from metrics_utility.library.instants import (
     this_week,
     weeks_ago,
 )
+from metrics_utility.test.util import utcdt
 
 
 def test_now_returns_datetime_with_timezone():
@@ -99,12 +100,11 @@ def test_last_hour_without_relative_to():
 
 def test_last_hour_with_relative_to():
     """Test that last_hour() accepts a relative_to parameter."""
-    reference_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-    result = last_hour(relative_to=reference_time)
+    result = last_hour(relative_to=utcdt('2025-01-15T12:00:00'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
-    assert result == datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-15T11:00:00')
 
 
 def test_last_day_without_relative_to():
@@ -125,12 +125,11 @@ def test_last_day_without_relative_to():
 
 def test_last_day_with_relative_to():
     """Test that last_day() accepts a relative_to parameter."""
-    reference_time = datetime(2025, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
-    result = last_day(relative_to=reference_time)
+    result = last_day(relative_to=utcdt('2025-01-15'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
-    assert result == datetime(2025, 1, 14, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-14')
 
 
 def test_last_week_without_relative_to():
@@ -153,13 +152,12 @@ def test_last_week_without_relative_to():
 def test_last_week_with_relative_to():
     """Test that last_week() accepts a relative_to parameter."""
     # Monday, Jan 13, 2025 at midnight
-    reference_time = datetime(2025, 1, 13, 0, 0, 0, tzinfo=timezone.utc)
-    result = last_week(relative_to=reference_time)
+    result = last_week(relative_to=utcdt('2025-01-13'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be Monday, Jan 6, 2025 at midnight
-    assert result == datetime(2025, 1, 6, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-06')
     assert result.weekday() == 0  # Monday
 
 
@@ -187,25 +185,23 @@ def test_last_month_without_relative_to():
 def test_last_month_with_relative_to():
     """Test that last_month() accepts a relative_to parameter."""
     # March 1, 2025 at midnight
-    reference_time = datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
-    result = last_month(relative_to=reference_time)
+    result = last_month(relative_to=utcdt('2025-03-01'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be February 1, 2025 at midnight
-    assert result == datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-02-01')
 
 
 def test_last_month_year_boundary():
     """Test that last_month() correctly handles year boundaries."""
     # January 1, 2025 at midnight
-    reference_time = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    result = last_month(relative_to=reference_time)
+    result = last_month(relative_to=utcdt('2025-01-01'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be December 1, 2024 at midnight
-    assert result == datetime(2024, 12, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2024-12-01')
 
 
 def test_hours_ago():
@@ -225,12 +221,11 @@ def test_hours_ago():
 
 def test_hours_ago_with_relative_to():
     """Test that hours_ago(n) accepts a relative_to parameter."""
-    reference_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-    result = hours_ago(3, relative_to=reference_time)
+    result = hours_ago(3, relative_to=utcdt('2025-01-15T12:00:00'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
-    assert result == datetime(2025, 1, 15, 9, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-15T09:00:00')
 
 
 def test_days_ago():
@@ -251,12 +246,11 @@ def test_days_ago():
 
 def test_days_ago_with_relative_to():
     """Test that days_ago(n) accepts a relative_to parameter."""
-    reference_time = datetime(2025, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
-    result = days_ago(5, relative_to=reference_time)
+    result = days_ago(5, relative_to=utcdt('2025-01-15'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
-    assert result == datetime(2025, 1, 10, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-10')
 
 
 def test_weeks_ago():
@@ -279,13 +273,12 @@ def test_weeks_ago():
 def test_weeks_ago_with_relative_to():
     """Test that weeks_ago(n) accepts a relative_to parameter."""
     # Monday, Jan 20, 2025 at midnight
-    reference_time = datetime(2025, 1, 20, 0, 0, 0, tzinfo=timezone.utc)
-    result = weeks_ago(2, relative_to=reference_time)
+    result = weeks_ago(2, relative_to=utcdt('2025-01-20'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be Monday, Jan 6, 2025 at midnight
-    assert result == datetime(2025, 1, 6, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-06')
     assert result.weekday() == 0  # Monday
 
 
@@ -315,25 +308,23 @@ def test_months_ago():
 def test_months_ago_with_relative_to():
     """Test that months_ago(n) accepts a relative_to parameter."""
     # May 1, 2025 at midnight
-    reference_time = datetime(2025, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
-    result = months_ago(2, relative_to=reference_time)
+    result = months_ago(2, relative_to=utcdt('2025-05-01'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be exactly March 1, 2025
-    assert result == datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-03-01')
 
 
 def test_months_ago_year_boundary():
     """Test that months_ago correctly handles year boundaries."""
     # February 1, 2025 at midnight
-    reference_time = datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
-    result = months_ago(3, relative_to=reference_time)
+    result = months_ago(3, relative_to=utcdt('2025-02-01'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
     # Should be November 1, 2024
-    assert result == datetime(2024, 11, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2024-11-01')
 
 
 def test_minutes_ago():
@@ -352,17 +343,16 @@ def test_minutes_ago():
 
 def test_minutes_ago_with_relative_to():
     """Test that minutes_ago(n) accepts a relative_to parameter."""
-    reference_time = datetime(2025, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
-    result = minutes_ago(10, relative_to=reference_time)
+    result = minutes_ago(10, relative_to=utcdt('2025-01-15T12:30:00'))
 
     assert isinstance(result, datetime)
     assert result.tzinfo == timezone.utc
-    assert result == datetime(2025, 1, 15, 12, 20, 0, tzinfo=timezone.utc)
+    assert result == utcdt('2025-01-15T12:20:00')
 
 
 def test_iso_converts_datetime_to_string():
     """Test that iso() converts a datetime to ISO 8601 string."""
-    dt = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+    dt = utcdt('2025-01-15T12:30:45')
     result = iso(dt)
 
     assert isinstance(result, str)
@@ -371,7 +361,7 @@ def test_iso_converts_datetime_to_string():
 
 def test_iso_preserves_timezone():
     """Test that iso() preserves timezone information in the output."""
-    dt = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+    dt = utcdt('2025-01-15T12:30:45')
     result = iso(dt)
 
     # The ISO string should contain timezone information

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -3,7 +3,7 @@ import os
 import re
 import shutil
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -987,8 +987,8 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Define two hourly intervals: 10:00-11:00 and 11:00-12:00
     time_intervals = [
-        (datetime(2025, 6, 13, 10, 0, 0), datetime(2025, 6, 13, 11, 0, 0)),
-        (datetime(2025, 6, 13, 11, 0, 0), datetime(2025, 6, 13, 12, 0, 0)),
+        (datetime(2025, 6, 13, 10, 0, 0, tzinfo=timezone.utc), datetime(2025, 6, 13, 11, 0, 0, tzinfo=timezone.utc)),
+        (datetime(2025, 6, 13, 11, 0, 0, tzinfo=timezone.utc), datetime(2025, 6, 13, 12, 0, 0, tzinfo=timezone.utc)),
     ]
 
     # Map collector names to input_data keys expected by compute_anonymized_rollup_from_raw_data
@@ -1015,8 +1015,8 @@ def test_from_gather_to_json(cleanup_glob):
     print('✓ Anonymized rollup computed successfully')
 
     # Save JSON output
-    since = datetime(2025, 6, 13, 10, 0, 0)
-    until = datetime(2025, 6, 13, 12, 0, 0)
+    since = datetime(2025, 6, 13, 10, 0, 0, tzinfo=timezone.utc)
+    until = datetime(2025, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
     _save_json_output(json_data, since, until)
 
     # Validate all data

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -3,8 +3,6 @@ import os
 import re
 import shutil
 
-from datetime import datetime, timezone
-
 import pandas as pd
 import pytest
 
@@ -20,6 +18,7 @@ from metrics_utility.library.collectors.controller import (
     table_metadata,
     unified_jobs,
 )
+from metrics_utility.test.util import utcdt
 
 
 def _is_valid_version(version_str):
@@ -987,8 +986,8 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Define two hourly intervals: 10:00-11:00 and 11:00-12:00
     time_intervals = [
-        (datetime(2025, 6, 13, 10, 0, 0, tzinfo=timezone.utc), datetime(2025, 6, 13, 11, 0, 0, tzinfo=timezone.utc)),
-        (datetime(2025, 6, 13, 11, 0, 0, tzinfo=timezone.utc), datetime(2025, 6, 13, 12, 0, 0, tzinfo=timezone.utc)),
+        (utcdt('2025-06-13T10:00:00'), utcdt('2025-06-13T11:00:00')),
+        (utcdt('2025-06-13T11:00:00'), utcdt('2025-06-13T12:00:00')),
     ]
 
     # Map collector names to input_data keys expected by compute_anonymized_rollup_from_raw_data
@@ -1015,8 +1014,8 @@ def test_from_gather_to_json(cleanup_glob):
     print('✓ Anonymized rollup computed successfully')
 
     # Save JSON output
-    since = datetime(2025, 6, 13, 10, 0, 0, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+    since = utcdt('2025-06-13T10:00:00')
+    until = utcdt('2025-06-13T12:00:00')
     _save_json_output(json_data, since, until)
 
     # Validate all data

--- a/metrics_utility/test/test_anonymized_rollups/test_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_json.py
@@ -1,6 +1,6 @@
 import json
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -93,8 +93,8 @@ def test_json_serialization_roundtrip(cleanup_glob):
     roundtrip for each collector's prepare output.
     """
     # Time range for data collection
-    since = datetime(2025, 6, 13, 0, 0, 0)
-    until = datetime(2025, 6, 14, 0, 0, 0)
+    since = datetime(2025, 6, 13, 0, 0, 0, tzinfo=timezone.utc)
+    until = datetime(2025, 6, 14, 0, 0, 0, tzinfo=timezone.utc)
 
     db = connection
 

--- a/metrics_utility/test/test_anonymized_rollups/test_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_json.py
@@ -1,7 +1,5 @@
 import json
 
-from datetime import datetime, timezone
-
 import pandas as pd
 import pytest
 
@@ -25,6 +23,7 @@ from metrics_utility.library.collectors.controller import (
     table_metadata,
     unified_jobs,
 )
+from metrics_utility.test.util import utcdt
 
 
 def _deep_compare(obj1, obj2, path=''):
@@ -93,8 +92,8 @@ def test_json_serialization_roundtrip(cleanup_glob):
     roundtrip for each collector's prepare output.
     """
     # Time range for data collection
-    since = datetime(2025, 6, 13, 0, 0, 0, tzinfo=timezone.utc)
-    until = datetime(2025, 6, 14, 0, 0, 0, tzinfo=timezone.utc)
+    since = utcdt('2025-06-13')
+    until = utcdt('2025-06-14')
 
     db = connection
 

--- a/metrics_utility/test/test_automation_controller_billing_helpers.py
+++ b/metrics_utility/test/test_automation_controller_billing_helpers.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from django.db import DatabaseError
@@ -7,6 +6,7 @@ from metrics_utility.automation_controller_billing.helpers import (
     _datetime_hook,
     get_last_entries_from_db,
 )
+from metrics_utility.test.util import utcdt
 
 
 class TestGetLastEntriesFromDb:
@@ -25,9 +25,9 @@ class TestGetLastEntriesFromDb:
 
         # Assert - _datetime_hook parses datetime strings to datetime objects
         expected_result = {
-            'config': datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
-            'hosts': datetime(2024, 1, 3, 0, 0, tzinfo=timezone.utc),
-            'jobs': datetime(2024, 1, 2, 0, 0, tzinfo=timezone.utc),
+            'config': utcdt('2024-01-01'),
+            'hosts': utcdt('2024-01-03'),
+            'jobs': utcdt('2024-01-02'),
         }
         assert result == expected_result
         mock_cursor.execute.assert_called_once()
@@ -117,7 +117,7 @@ class TestIntegration:
         # Assert all return expected realistic data
         # _datetime_hook parses datetime strings to datetime objects
         expected_entries = {
-            'config': datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
-            'jobs': datetime(2024, 1, 2, 0, 0, tzinfo=timezone.utc),
+            'config': utcdt('2024-01-01'),
+            'jobs': utcdt('2024-01-02'),
         }
         assert entries == expected_entries

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -11,6 +11,14 @@ import pandas as pd
 import pytest
 
 
+def utcdt(s):
+    """Parse an ISO date/datetime string as UTC. Assumes UTC if no timezone given."""
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 @contextmanager
 def temporary_env(new_env):
     """Temporarily update os.environ with new_env."""


### PR DESCRIPTION
6 collectors manually interpolated since/until timestamps, refactored them all to use `date_where`

And fixed `date_where` field quoting - it wrapped field names in double quotes, but "table.column" is not valid in postgres Removed the quoting since all callers pass hardcoded internal strings, and added a comment that the auto checks should catch in the future.

(Also added a comment to each remaining `ensure_functions` use.)

Make `date_where` throw an exception when not given a datetime | None, or when missing timezone info.
(And add a `utcdt` tests helper that always returns a datetime with timezone)