### PR TITLE
CLI - bump `config` collector version to 2.0 in the manifest

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -93,7 +93,7 @@ def until_slicing(_key, _last_gather, **kwargs):
 
 
 # FIXME: move this one to caller?
-@register('config', '1.0', format='json', config=True)
+@register('config', '2.0', format='json', config=True)
 def cli_config(since, until, output):
     # runs once, used in all the tarballs
     # FIXME: , billing_provider_params={dict} rather than {} getting overwritten in collector.gather


### PR DESCRIPTION
Related to #242, #349, #354

seems that we've introduced a breaking change in #242, because some config collector fields were previously not considered nullable, and now they are, by virtue of not always (or usually) being available through the db

formalizing by changing the version to 2.0 (affects `manifest.json` in the tarballs)
2.0 means all the fields are nullable :)