### PR TITLE
library.lock - docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ db = ... # django.db.connection / psycopg 3
 
 dir_storage = storage.StorageDirectory(base_path='./out')
 
-with lock(db=db, key='my-unique-key'):
+with lock('my-unique-key', wait=False, db=db) as acquired:
+    if not acquired:
+        raise "too bad" # or use wait=True instead
+
     # dict, will be converted to json
     config_dict = config(db=db).gather()
 

--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -79,10 +79,6 @@ class Collector(base.Collector):
 
         return True
 
-    @staticmethod
-    def db_connection():
-        return connection
-
     @classmethod
     def registered_collectors(cls, module=None):
         from metrics_utility.automation_controller_billing import collectors

--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -86,17 +86,6 @@ class Collector:
 
         return self.collections.get('config') is not None
 
-    @staticmethod
-    @abstractmethod
-    def db_connection():
-        """
-        DB connection for advisory lock. Can be
-        - django.db.connection or
-        - sqlalchemy.engine.base.Engine.raw_connection()
-        - etc.
-        """
-        pass
-
     def gather(self, dest=None, subset=None, since=None, until=None):
         """Entry point for gathering
 

--- a/metrics_utility/library/lock.py
+++ b/metrics_utility/library/lock.py
@@ -7,7 +7,7 @@ def lock(
     wait=False,
     db=None,
 ):
-    # Acquire the lock and yield to caller
+    """Acquire the lock and yield to caller"""
 
     if not isinstance(key, str):
         raise ValueError('Cannot use %s as a lock id' % key)
@@ -31,6 +31,7 @@ def lock(
             acquired = cursor.fetchone()[0]
         else:
             acquired = True
+
         try:
             yield acquired
         finally:

--- a/metrics_utility/test/base/classes/analytics_collector.py
+++ b/metrics_utility/test/base/classes/analytics_collector.py
@@ -5,10 +5,6 @@ from metrics_utility.base import Collector
 
 class AnalyticsCollector(Collector):
     @staticmethod
-    def db_connection():
-        return None
-
-    @staticmethod
     def _package_class():
         return Package
 

--- a/metrics_utility/test/library/test_lock.py
+++ b/metrics_utility/test/library/test_lock.py
@@ -22,15 +22,15 @@ class TestCollectorLocks:
 
         mock_connection.cursor.return_value = mock_cursor_context
 
-        with lock('my_string_key', False, db=mock_connection) as acquired:
+        with lock('my_string_key', wait=False, db=mock_connection) as acquired:
             assert acquired is True
         executed_sql = mock_cursor.execute.call_args_list[0][0][0]  # This returns the argument for the first call to execute
         assert 'SELECT hashtext(%s)::bigint' in executed_sql
         assert 'my_string_key' not in executed_sql
 
     def test_acquire_lock(self):
-        with lock('test', False, db=connection) as acquired:
+        with lock('test', wait=False, db=connection) as acquired:
             assert acquired is not None
             with pytest.raises(Exception):
-                with lock('test', False, db=connection):
+                with lock('test', wait=False, db=connection):
                     assert False, 'this should be unreachable'

--- a/workers/0-gather-controller-crc.py
+++ b/workers/0-gather-controller-crc.py
@@ -21,7 +21,7 @@ until = library.instants.this_day()
 collector = library.collectors.controller.anonymous(db=controller_db, since=since, until=until, custom_params=True)
 
 # DB lock, in *our* DB
-with library.lock(db=metrics_db, key=worker_key):
+with library.lock(worker_key, wait=True, db=metrics_db):
     # run gather, get json (buffer/string/filelist)
     data = collector.gather()
 

--- a/workers/1-gather-controller-full.py
+++ b/workers/1-gather-controller-full.py
@@ -38,7 +38,7 @@ with library.tempdir(prefix=worker_key):
     )
 
     # we *may* want to wait=False and abort the task instead
-    with library.lock(db=metrics_db, key=worker_key, wait=True):
+    with library.lock(worker_key, wait=True, db=metrics_db):
         while not package.done():  # 100M-sized tarballs
             # actually calls collectors gather
             with package.next() as tarball:

--- a/workers/5-report-renewal.py
+++ b/workers/5-report-renewal.py
@@ -19,7 +19,7 @@ until = library.instants.now()
 dataframe = library.dataframes.DataframeHostMetric()
 collector = library.collectors.controller.host_metric(db=controller_db, since=since)
 
-with library.lock(db=metrics_db, key=worker_key):
+with library.lock(worker_key, wait=True, db=metrics_db):
     dataframe.add(collector.gather())
 
 with library.tempdir(prefix=worker_key):


### PR DESCRIPTION
Doesn't actually change `library.lock`, just all the examples and docs using different assumptions than the actual function.

And drop unused `db_connection` method from collector.py.