### PR TITLE
Add more METRICS_UTILITY_DB_ env vars, warn if present in controller venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,14 @@ clean:
 psql:
 	${CONTAINER_ENGINE} compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
 
-.PHONY: help sync test coverage lint fix compose clean psql
+pcompose:
+	podman-compose -f tools/docker/docker-compose.yaml up
+
+pclean:
+	podman-compose -f tools/docker/docker-compose.yaml down -v
+
+ppsql:
+	podman-compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
+
+
+.PHONY: help sync test coverage lint fix compose clean psql pcompose pclean ppsql

--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -19,6 +19,13 @@ def prepare():
             mock_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'mock_awx'))
             sys.path.append(mock_path)
 
+    db_env_vars = [key for key in os.environ if key.startswith('METRICS_UTILITY_DB_')]
+    if spec is not None and db_env_vars:
+        sys.stderr.write(
+            f'Warning: {", ".join(db_env_vars)} ignored because Automation Controller modules were found. '
+            'These only take effect in standalone mode.\n'
+        )
+
     import django
 
     from awx import prepare_env

--- a/mock_awx/settings/__init__.py
+++ b/mock_awx/settings/__init__.py
@@ -4,11 +4,11 @@ import os
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'awx',
-        'USER': 'myuser',
-        'PASSWORD': 'mypassword',
+        'NAME': os.getenv('METRICS_UTILITY_DB_NAME', 'awx'),
+        'USER': os.getenv('METRICS_UTILITY_DB_USER', 'myuser'),
+        'PASSWORD': os.getenv('METRICS_UTILITY_DB_PASSWORD', 'mypassword'),
         'HOST': os.getenv('METRICS_UTILITY_DB_HOST', 'localhost'),
-        'PORT': '5432',
+        'PORT': os.getenv('METRICS_UTILITY_DB_PORT', '5432'),
     },
     # metrics-service database — same Postgres instance, different DB name/credentials.
     # Override any of these via environment variables:
@@ -26,6 +26,7 @@ DATABASES = {
         'PORT': os.getenv('METRICS_SERVICE_DB_PORT', '5432'),
     },
 }
+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 INSTALLED_APPS = ['awx.conf']
 LANGUAGE_CODE = 'en-us'


### PR DESCRIPTION
`mock_awx` is only used when a real awx venv is not present, and supports `METRICS_UTILITY_DB_HOST` to override the default localhost.

Add the rest - `_NAME`, `_USER`, `_PASSWORD`, `_POST` as well,
warn about their presence in non-dev modes.
