### PR TITLE
[AAP-69139] Update data generator for proper perf-testing

### DIFF
--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -79,7 +79,7 @@ def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffi
     create_instance()
 
     # Create execution environments with distinct installed_collections sets
-    ee_list = create_execution_environments()
+    ee_list = create_execution_environments(unique_suffix=unique_suffix)
 
     # Create one credential per built-in type
     credential_ids = create_credentials()

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -8,9 +8,13 @@ import uuid
 from datetime import datetime, timedelta
 
 from helpers import (
+    create_credentials,
+    create_execution_environments,
     create_hosts,
+    create_instance,
     create_inventory,
     create_job,
+    create_job_credentials,
     create_job_events,
     create_job_host_summaries,
     create_job_templates,
@@ -71,6 +75,15 @@ def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffi
     # Create hosts (depends on inventory)
     host_ids = create_hosts(inventory_id=inventory_id, host_count=host_count, unique_suffix=unique_suffix)
 
+    # Create one controller instance (needed by controller_version_service collector)
+    create_instance()
+
+    # Create execution environments with distinct installed_collections sets
+    ee_list = create_execution_environments()
+
+    # Create one credential per built-in type
+    credential_ids = create_credentials()
+
     print('=== Initial data created ===')
     print(f'Organization: Perf Test Organization {unique_suffix} (ID: {org_id})')
     print(f'Inventory: Perf Test Inventory {unique_suffix} (ID: {inventory_id})')
@@ -86,10 +99,12 @@ def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffi
         'host_count': host_count,
         'task_count': task_count,
         'unique_suffix': unique_suffix,
+        'ee_list': ee_list,  # [(ee_id, installed_collections), ...]
+        'credential_ids': credential_ids,
     }
 
 
-def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=10, start_date=None, end_date=None):
+def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=10, start_date=None, end_date=None, no_events=False):
     """Fill the database with performance test data.
 
     Note: This function does NOT clean existing data. Use clean_all_data.py to clean before filling.
@@ -109,20 +124,23 @@ def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=
     init_data = fill_init_data(host_count=host_count, task_count=task_count, template_count=template_count)
 
     for i in range(job_count):
-        fill_job(init_data, i, start_date, end_date)
+        fill_job(init_data, i, start_date, end_date, no_events=no_events)
 
     print_counts()
 
 
 def fill_job_data(init_data, job_index, start_date, end_date):
     """Create a job using the init_data IDs. Returns (job_id, job_created, job_finished)."""
-    # Randomly select a job template
     templates = init_data['templates']
     template_id = random.choice(list(templates.keys()))
     template_name = templates[template_id]
 
+    # Cycle through EEs so jobs are distributed across them
+    ee_list = init_data['ee_list']
+    ee_id, installed_collections = ee_list[job_index % len(ee_list)]
+
     job_id, job_created, job_finished = create_job(
-        name=template_name,  # Use template name as job name (AWX behavior)
+        name=template_name,
         inventory_id=init_data['inventory_id'],
         project_id=init_data['project_id'],
         org_id=init_data['org_id'],
@@ -130,6 +148,8 @@ def fill_job_data(init_data, job_index, start_date, end_date):
         job_template_id=template_id,
         start_date=start_date,
         end_date=end_date,
+        execution_environment_id=ee_id,
+        installed_collections=installed_collections,
     )
     return job_id, job_created, job_finished
 
@@ -142,10 +162,12 @@ def fill_jobevent(init_data, job_id, job_index, job_created):
     create_job_events(job_id, init_data['host_ids'], init_data['task_count'], job_index, job_created, unique_suffix=init_data.get('unique_suffix'))
 
 
-def fill_job(init_data, job_index, start_date, end_date):
+def fill_job(init_data, job_index, start_date, end_date, no_events=False):
     job_id, job_created, job_finished = fill_job_data(init_data, job_index, start_date, end_date)
     fill_jobhostsummary(init_data, job_id, job_created, job_finished)
-    fill_jobevent(init_data, job_id, job_index, job_created)
+    create_job_credentials(job_id, init_data['credential_ids'])
+    if not no_events:
+        fill_jobevent(init_data, job_id, job_index, job_created)
     return
 
 
@@ -187,6 +209,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--date', type=str, default=None, help='Constrain jobs to a single day (e.g. 2024-01-25). Default spreads across all of January 2024'
     )
+    parser.add_argument('--no-events', action='store_true', default=False, help='Skip generating job events')
 
     args = parser.parse_args()
 
@@ -206,4 +229,5 @@ if __name__ == '__main__':
         template_count=args.template_count,
         start_date=start_date,
         end_date=end_date,
+        no_events=args.no_events,
     )

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -781,9 +781,11 @@ def create_execution_environments(count=100, unique_suffix=None):
 
 def create_credentials():
     """Create one credential per built-in type and return their IDs."""
-    result = run('SELECT id FROM main_credentialtype WHERE managed = TRUE;')
+    result = run("SELECT id FROM main_credentialtype WHERE managed = TRUE AND name IN ('Machine', 'Vault', 'Amazon Web Services', 'Network');")
+    if not result:
+        raise RuntimeError('Failed to fetch built-in credential types')
     credential_ids = []
-    for (ct_id,) in result or []:
+    for (ct_id,) in result:
         sql = f"""
         INSERT INTO main_credential (created, modified, name, description, credential_type_id, inputs, managed)
         VALUES (NOW(), NOW(), 'Perf Test Credential', '', {ct_id}, '{{}}'::jsonb, FALSE)

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -735,13 +735,19 @@ def create_job_events(job_id, host_ids, task_count=50, job_index=0, job_created=
     print(f'Created {len(values)} job events ({task_count} tasks x {host_count} hosts)')
 
 
-# Sample installed_collections per EE. Jobs sharing the same EE must use the
-# same value — the rollup caches parsed collections once per execution_environment_id.
-SAMPLE_INSTALLED_COLLECTIONS = [
-    {'ansible.builtin': {'version': '2.9.10'}, 'a10.acos_axapi': {'version': '1.0.0'}, 'redhat.rhel_system_roles': {'version': '1.23.0'}},
-    {'ansible.builtin': {'version': '2.9.10'}, 'ansible.posix': {'version': '1.5.4'}, 'community.general': {'version': '7.5.0'}},
-    {'ansible.builtin': {'version': '2.15.0'}, 'amazon.aws': {'version': '7.1.0'}, 'ansible.netcommon': {'version': '5.0.0'}},
-]
+_COLLECTION_NAMESPACES = ['ansible', 'community', 'redhat', 'amazon', 'google', 'azure', 'cisco', 'f5', 'netapp', 'vmware']
+_COLLECTION_NAMES = ['posix', 'general', 'windows', 'network', 'cloud', 'storage', 'security', 'utils', 'netcommon', 'platform']
+
+
+def _random_installed_collections(seed, count=50):
+    """Generate a random installed_collections dict for an EE."""
+    rng = random.Random(seed)
+    collections = {}
+    while len(collections) < count:
+        key = f'{rng.choice(_COLLECTION_NAMESPACES)}.{rng.choice(_COLLECTION_NAMES)}'
+        if key not in collections:
+            collections[key] = {'version': f'{rng.randint(1, 5)}.{rng.randint(0, 9)}.{rng.randint(0, 9)}'}
+    return collections
 
 
 def create_execution_environment(name, image):
@@ -762,14 +768,14 @@ def create_execution_environment(name, image):
     return ee_id
 
 
-def create_execution_environments(count=3):
+def create_execution_environments(count=100):
     """Create execution environments and return list of (ee_id, installed_collections) tuples."""
     results = []
     for i in range(count):
         name = f'Perf Test EE {i + 1}'
         image = f'registry.example.com/perf-test-ee-{i + 1}:latest'
         ee_id = create_execution_environment(name, image)
-        results.append((ee_id, SAMPLE_INSTALLED_COLLECTIONS[i % len(SAMPLE_INSTALLED_COLLECTIONS)]))
+        results.append((ee_id, _random_installed_collections(seed=i)))
     return results
 
 

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -436,7 +436,16 @@ def create_hosts(inventory_id=None, host_count=1000, unique_suffix=None):
 
 
 def create_job(
-    name='Perf Test Job', inventory_id=None, project_id=None, org_id=None, job_index=0, job_template_id=None, start_date=None, end_date=None
+    name='Perf Test Job',
+    inventory_id=None,
+    project_id=None,
+    org_id=None,
+    job_index=0,
+    job_template_id=None,
+    start_date=None,
+    end_date=None,
+    execution_environment_id=None,
+    installed_collections=None,
 ):
     """Create a job (via unified_job) and return its auto-generated ID and timestamps."""
     # Get deterministic timestamps for this job
@@ -447,8 +456,9 @@ def create_job(
     started_str = started.strftime('%Y-%m-%d %H:%M:%S+00')
     finished_str = finished.strftime('%Y-%m-%d %H:%M:%S+00')
 
-    # unified_job_template_id can be NULL or reference a job template
     ujt_value = job_template_id if job_template_id else 'NULL'
+    ee_value = execution_environment_id if execution_environment_id else 'NULL'
+    collections_sql = f"'{json.dumps(installed_collections)}'::jsonb" if installed_collections else "'[]'::jsonb"
 
     # First create the unified job entry and get its ID
     sql_uj = f"""
@@ -458,7 +468,8 @@ def create_job(
         job_args, job_cwd, job_explanation, start_args, result_traceback,
         celery_task_id, execution_node, emitted_events, controller_node,
         dependencies_processed, organization_id, installed_collections,
-        ansible_version, task_impact, job_env, unified_job_template_id
+        ansible_version, task_impact, job_env, unified_job_template_id,
+        execution_environment_id
     )
     VALUES (
         '{created_str}', '{created_str}', '{name}', 'Performance testing job',
@@ -466,8 +477,9 @@ def create_job(
         'manual', FALSE, 'successful', FALSE, '{started_str}', '{finished_str}', {elapsed},
         '', '', '', '', '',
         '', 'localhost', 0, '',
-        TRUE, {org_id}, '[]'::jsonb,
-        '2.15.0', 1, '{{}}'::jsonb, {ujt_value}
+        TRUE, {org_id}, {collections_sql},
+        '2.15.0', 1, '{{}}'::jsonb, {ujt_value},
+        {ee_value}
     )
     RETURNING id;
     """
@@ -721,6 +733,91 @@ def create_job_events(job_id, host_ids, task_count=50, job_index=0, job_created=
     """
     run(sql)
     print(f'Created {len(values)} job events ({task_count} tasks x {host_count} hosts)')
+
+
+# Sample installed_collections per EE. Jobs sharing the same EE must use the
+# same value — the rollup caches parsed collections once per execution_environment_id.
+SAMPLE_INSTALLED_COLLECTIONS = [
+    {'ansible.builtin': {'version': '2.9.10'}, 'a10.acos_axapi': {'version': '1.0.0'}, 'redhat.rhel_system_roles': {'version': '1.23.0'}},
+    {'ansible.builtin': {'version': '2.9.10'}, 'ansible.posix': {'version': '1.5.4'}, 'community.general': {'version': '7.5.0'}},
+    {'ansible.builtin': {'version': '2.15.0'}, 'amazon.aws': {'version': '7.1.0'}, 'ansible.netcommon': {'version': '5.0.0'}},
+]
+
+
+def create_execution_environment(name, image):
+    """Create an execution environment row and return its ID."""
+    sql = f"""
+    INSERT INTO main_executionenvironment (
+        created, modified, name, description, image, managed, pull
+    )
+    VALUES (
+        NOW(), NOW(), '{name}', '', '{image}', FALSE, 'missing'
+    )
+    RETURNING id;
+    """
+    output = run(sql)
+    ee_id = parse_id(output)
+    if ee_id is None:
+        raise RuntimeError(f'Failed to create execution environment: {name}')
+    return ee_id
+
+
+def create_execution_environments(count=3):
+    """Create execution environments and return list of (ee_id, installed_collections) tuples."""
+    results = []
+    for i in range(count):
+        name = f'Perf Test EE {i + 1}'
+        image = f'registry.example.com/perf-test-ee-{i + 1}:latest'
+        ee_id = create_execution_environment(name, image)
+        results.append((ee_id, SAMPLE_INSTALLED_COLLECTIONS[i % len(SAMPLE_INSTALLED_COLLECTIONS)]))
+    return results
+
+
+def create_credentials():
+    """Create one credential per built-in type and return their IDs."""
+    result = run("SELECT id FROM main_credentialtype WHERE managed = TRUE;")
+    credential_ids = []
+    for (ct_id,) in (result or []):
+        sql = f"""
+        INSERT INTO main_credential (created, modified, name, description, credential_type_id, inputs, managed)
+        VALUES (NOW(), NOW(), 'Perf Test Credential', '', {ct_id}, '{{}}'::jsonb, FALSE)
+        RETURNING id;
+        """
+        credential_ids.append(parse_id(run(sql)))
+    return credential_ids
+
+
+def create_job_credentials(job_id, credential_ids):
+    """Link credentials to a job."""
+    if not credential_ids:
+        return
+    values = ', '.join(f'({job_id}, {cred_id})' for cred_id in credential_ids)
+    run(f"INSERT INTO main_unifiedjob_credentials (unifiedjob_id, credential_id) VALUES {values};")
+
+
+def create_instance(version='4.5.0', node_type='control'):
+    """Create a controller instance row for controller_version_service."""
+    instance_uuid = str(uuid.uuid4())
+    sql = f"""
+    INSERT INTO main_instance (
+        created, modified, uuid, hostname, version, node_type,
+        enabled, managed_by_policy, managed, ip_address,
+        cpu, memory, cpu_capacity, mem_capacity,
+        capacity, capacity_adjustment, errors, node_state
+    )
+    VALUES (
+        NOW(), NOW(), '{instance_uuid}', 'perf-test-controller', '{version}', '{node_type}',
+        TRUE, TRUE, FALSE, '',
+        0, 0, 0, 0,
+        0, 1.0, '', 'ready'
+    )
+    RETURNING id;
+    """
+    output = run(sql)
+    instance_id = parse_id(output)
+    if instance_id is None:
+        raise RuntimeError('Failed to create main_instance row')
+    return instance_id
 
 
 if __name__ == '__main__':

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -768,12 +768,12 @@ def create_execution_environment(name, image):
     return ee_id
 
 
-def create_execution_environments(count=100):
+def create_execution_environments(count=100, unique_suffix=None):
     """Create execution environments and return list of (ee_id, installed_collections) tuples."""
     results = []
     for i in range(count):
-        name = f'Perf Test EE {i + 1}'
-        image = f'registry.example.com/perf-test-ee-{i + 1}:latest'
+        name = f'Perf Test EE {i + 1} {unique_suffix}'
+        image = f'registry.example.com/perf-test-ee-{i + 1}-{unique_suffix}:latest'
         ee_id = create_execution_environment(name, image)
         results.append((ee_id, _random_installed_collections(seed=i)))
     return results
@@ -815,7 +815,7 @@ def create_instance(version='4.5.0', node_type='control'):
         capacity, capacity_adjustment, errors, node_state
     )
     VALUES (
-        NOW(), NOW(), '{instance_uuid}', 'perf-test-controller', '{version}', '{node_type}',
+        NOW(), NOW(), '{instance_uuid}', 'perf-test-controller-{instance_uuid}', '{version}', '{node_type}',
         TRUE, TRUE, FALSE, '',
         0, 0, 0, 0,
         0, 1.0, '', 'ready'

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -775,9 +775,9 @@ def create_execution_environments(count=3):
 
 def create_credentials():
     """Create one credential per built-in type and return their IDs."""
-    result = run("SELECT id FROM main_credentialtype WHERE managed = TRUE;")
+    result = run('SELECT id FROM main_credentialtype WHERE managed = TRUE;')
     credential_ids = []
-    for (ct_id,) in (result or []):
+    for (ct_id,) in result or []:
         sql = f"""
         INSERT INTO main_credential (created, modified, name, description, credential_type_id, inputs, managed)
         VALUES (NOW(), NOW(), 'Perf Test Credential', '', {ct_id}, '{{}}'::jsonb, FALSE)
@@ -792,7 +792,7 @@ def create_job_credentials(job_id, credential_ids):
     if not credential_ids:
         return
     values = ', '.join(f'({job_id}, {cred_id})' for cred_id in credential_ids)
-    run(f"INSERT INTO main_unifiedjob_credentials (unifiedjob_id, credential_id) VALUES {values};")
+    run(f'INSERT INTO main_unifiedjob_credentials (unifiedjob_id, credential_id) VALUES {values};')
 
 
 def create_instance(version='4.5.0', node_type='control'):

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -783,7 +783,10 @@ def create_credentials():
         VALUES (NOW(), NOW(), 'Perf Test Credential', '', {ct_id}, '{{}}'::jsonb, FALSE)
         RETURNING id;
         """
-        credential_ids.append(parse_id(run(sql)))
+        cred_id = parse_id(run(sql))
+        if cred_id is None:
+            raise RuntimeError(f'Failed to create credential for type {ct_id}')
+        credential_ids.append(cred_id)
     return credential_ids
 
 


### PR DESCRIPTION
[AAP-69139](https://redhat.atlassian.net/browse/AAP-69139)

## Description
Adds missing data to the tools/anonymized_db_perf_data performance test data generator so collectors have realistic data to run against during perf testing.

**Part 1**: Adds a main_instance row so the controller_version_service collector returns actual controller version data instead of empty results. 

  Changes
  - helpers.py — new create_instance() function
  - fill_perf_db_data.py — calls create_instance() once during fill_init_data()     

**Part 2**: Adds 100 execution environment rows with 50 randomly
  generated installed collections each, and sets installed_collections on each job matching its EE. Jobs cycle through EEs so all collection sets are represented. This exercises jobs_by_installed_collections_versions in the rollup output.

Changes
 - helpers.py — new create_execution_environment(), create_execution_environments(), and _random_installed_collections() functions; removed fixed
  SAMPLE_INSTALLED_COLLECTIONS constant                        
  - fill_perf_db_data.py — creates 100 EEs during fill_init_data(), jobs cycle through them with matching installed_collections 

**Part 3**: Adds credentials linked to each job using the 4 built-in credential types already seeded in the DB (Machine, Vault, Amazon Web Services, Network). This exercises rollup_period_credential_types in the rollup output.

Changes:
- helpers.py — new create_credentials() and  create_job_credentials() functions          
-  fill_perf_db_data.py — creates credentials during fill_init_data(), links all 4 built-in types to each job


Extra changes:
Also adds --no-events flag to skip event generation.     
- Fixed duplicate key errors (main_instance hostname and main_executionenvironment name) when the generator is run multiple times without cleaning — names now include the run's unique suffix
                  

## Test plan

  - Clean existing data: python tools/anonymized_db_perf_data/clean_all_data.py
  - Fill with test data: python tools/anonymized_db_perf_data/fill_perf_db_data.py        
  --job-count=1000 --host-count=20 --no-events
  - Confirm instance row: SELECT version, node_type, enabled FROM main_instance; →  expect 4.5.0 | control | t
  - Confirm EEs: SELECT COUNT(*) FROM main_executionenvironment; → expect 100 rows  
  - Confirm jobs have installed_collections and execution_environment_id set: SELECT id, execution_environment_id, installed_collections FROM main_unifiedjob LIMIT 5;        
  - Confirm credentials linked to jobs: SELECT ct.name FROM main_unifiedjob_credentials ujc JOIN main_credential c ON c.id = ujc.credential_id JOIN main_credentialtype ct ON ct.id = c.credential_type_id LIMIT 4; → expect Machine, Vault, Amazon Web Services, Network
  - Run the rollup and confirm controller_versions, rollup_period_credential_types, and jobs_by_installed_collections_versions are all non-empty in the output


### Prerequisites

<!-- List any specific setup required -->

### Steps to Test

1.
2.
3.

### Expected Results

<!-- Describe what should happen after following the steps -->

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
