### PR TITLE
[PENDING] Add cryptography dependency and implement mTLS support in PackageCRC

### DIFF
--- a/metrics_utility/automation_controller_billing/collector.py
+++ b/metrics_utility/automation_controller_billing/collector.py
@@ -71,10 +71,14 @@ class Collector(base.Collector):
         if not super()._gather_config():
             return False
 
-        # Extend the config collection to contain billing specific info:
+        # Extend the config collection to contain billing specific info.
+        # Strip mTLS key material — it is only needed at ship time and must never be
+        # included in the payload archive that is uploaded to the remote ingress endpoint.
+        _SENSITIVE_BILLING_KEYS = {'candlepin_cert_pem', 'candlepin_key_pem'}
+        safe_billing_provider_params = {k: v for k, v in (self.billing_provider_params or {}).items() if k not in _SENSITIVE_BILLING_KEYS}
         config_collection = self.collections['config']
         data = json.loads(config_collection.data)
-        data['billing_provider_params'] = self.billing_provider_params
+        data['billing_provider_params'] = safe_billing_provider_params
         config_collection._save_gathering(data)
 
         return True

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -99,6 +99,15 @@ class PackageCRC(base.Package):
             return super().ship()
 
         except requests.exceptions.SSLError as e:
+            # Before falling back, verify that service account credentials are present.
+            # In an mTLS-only deployment they won't be, and a blind retry would silently
+            # return False with no actionable error context for the operator.
+            if not self._get_rh_user() or not self._get_rh_password():
+                raise FailedToUploadPayload(
+                    f'mTLS upload failed and no service account credentials are configured to fall back to '
+                    f'(METRICS_UTILITY_SERVICE_ACCOUNT_ID / METRICS_UTILITY_SERVICE_ACCOUNT_SECRET are not set). '
+                    f'Original SSL error: {e}'
+                ) from e
             logger.error(f'mTLS upload failed ({e}); retrying with service account auth')
             self._resolved_auth_mode = self.SHIPPING_AUTH_SERVICE_ACCOUNT
             self._temp_cert_path = None

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -136,7 +136,7 @@ class PackageCRC(base.Package):
 
     def is_shipping_configured(self):
         # TODO: move to base, or children
-        ret = super()
+        ret = super().is_shipping_configured()
         if ret is False:
             return False
 

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -1,9 +1,13 @@
 import json
 import os
+import tempfile
+
+from datetime import datetime, timezone
 
 import requests
 
 from awx.main.utils import get_awx_http_client_headers
+from cryptography import x509
 from django.conf import settings
 
 import metrics_utility.base as base
@@ -12,11 +16,36 @@ from metrics_utility.exceptions import FailedToUploadPayload
 from metrics_utility.logger import logger
 
 
+def _is_cert_valid(cert_pem: str) -> bool:
+    """Return True if cert_pem is a parseable, non-expired X.509 certificate."""
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode('utf-8'))
+        if cert.not_valid_after_utc < datetime.now(timezone.utc):
+            logger.warning(f'Candlepin cert expired at {cert.not_valid_after_utc}; falling back to service account auth')
+            return False
+        return True
+    except Exception as e:
+        logger.warning(f'Could not parse Candlepin cert: {e}')
+        return False
+
+
 class PackageCRC(base.Package):
     CERT_PATH = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
     PAYLOAD_CONTENT_TYPE = 'application/vnd.redhat.aap-billing-controller.aap_billing_controller_payload+tgz'
 
     SHIPPING_AUTH_SERVICE_ACCOUNT = 'service-account'
+
+    def __init__(self, collector):
+        super().__init__(collector)
+        self._resolved_auth_mode = None
+        self._temp_cert_path = None
+        self._temp_key_path = None
+
+    def _candlepin_cert_pem(self):
+        return (self.collector.billing_provider_params or {}).get('candlepin_cert_pem')
+
+    def _candlepin_key_pem(self):
+        return (self.collector.billing_provider_params or {}).get('candlepin_key_pem')
 
     def _tarname_base(self):
         timestamp = self.collector.gather_until
@@ -40,18 +69,82 @@ class PackageCRC(base.Package):
     def _get_http_request_headers(self):
         return get_awx_http_client_headers()
 
-    def shipping_auth_mode(self):
-        # TODO make this as a configuration so we can use this for local testing,
-        # for now, uncomment when testin locally in docker
-        # return self.SHIPPING_AUTH_IDENTITY
+    def _get_client_certificates(self):
+        if self._temp_cert_path and self._temp_key_path:
+            return (self._temp_cert_path, self._temp_key_path)
+        return super()._get_client_certificates()
 
-        return self.SHIPPING_AUTH_SERVICE_ACCOUNT
+    def ship(self):
+        if self.shipping_auth_mode() == self.SHIPPING_AUTH_SERVICE_ACCOUNT:
+            return super().ship()
+
+        # mTLS path: write cert + key to secure temp files, then delegate to base ship().
+        # Temp files must remain on disk across _get_client_certificates() and the POST.
+        cert_fd = key_fd = cert_path = key_path = None
+        try:
+            cert_fd, cert_path = tempfile.mkstemp(prefix='metrics_cert_', suffix='.pem')
+            os.chmod(cert_path, 0o600)
+            with os.fdopen(cert_fd, 'w') as f:
+                f.write(self._candlepin_cert_pem())
+            cert_fd = None  # fdopen took ownership
+
+            key_fd, key_path = tempfile.mkstemp(prefix='metrics_key_', suffix='.pem')
+            os.chmod(key_path, 0o600)
+            with os.fdopen(key_fd, 'w') as f:
+                f.write(self._candlepin_key_pem())
+            key_fd = None
+
+            self._temp_cert_path = cert_path
+            self._temp_key_path = key_path
+            return super().ship()
+
+        except requests.exceptions.SSLError as e:
+            logger.error(f'mTLS upload failed ({e}); retrying with service account auth')
+            self._resolved_auth_mode = self.SHIPPING_AUTH_SERVICE_ACCOUNT
+            self._temp_cert_path = None
+            self._temp_key_path = None
+            return super().ship()
+
+        finally:
+            for fd in [cert_fd, key_fd]:
+                if fd is not None:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+            for path in [cert_path, key_path]:
+                if path and os.path.exists(path):
+                    try:
+                        os.unlink(path)
+                    except OSError as e:
+                        logger.warning(f'Could not remove temp cert file {path}: {e}')
+            self._temp_cert_path = None
+            self._temp_key_path = None
+
+    def shipping_auth_mode(self):
+        if self._resolved_auth_mode is not None:
+            return self._resolved_auth_mode
+
+        cert_pem = self._candlepin_cert_pem()
+        key_pem = self._candlepin_key_pem()
+        if cert_pem and key_pem and _is_cert_valid(cert_pem):
+            self._resolved_auth_mode = self.SHIPPING_AUTH_CERTIFICATES
+        else:
+            self._resolved_auth_mode = self.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+        return self._resolved_auth_mode
 
     def is_shipping_configured(self):
         # TODO: move to base, or children
         ret = super()
         if ret is False:
             return False
+
+        if self.shipping_auth_mode() == self.SHIPPING_AUTH_CERTIFICATES:
+            if not self.get_ingress_url():
+                logger.error('METRICS_UTILITY_CRC_INGRESS_URL is not set')
+                return False
+            return True
 
         if self.shipping_auth_mode() == self.SHIPPING_AUTH_SERVICE_ACCOUNT:
             if not self.get_ingress_url():
@@ -97,6 +190,18 @@ class PackageCRC(base.Package):
                 verify=self.CERT_PATH,
                 proxies=proxies,
                 headers=headers,
+                timeout=(31, 31),
+            )
+
+        elif self.shipping_auth_mode() == self.SHIPPING_AUTH_CERTIFICATES:
+            # session.cert is already set by base ship(); just POST with server cert verification.
+            proxies = {'https': self.get_proxy_url()} if self.get_proxy_url() else {}
+            response = session.post(
+                url,
+                files=files,
+                verify=self.CERT_PATH,
+                proxies=proxies,
+                headers=session.headers,
                 timeout=(31, 31),
             )
 

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -74,6 +74,23 @@ class PackageCRC(base.Package):
             return (self._temp_cert_path, self._temp_key_path)
         return super()._get_client_certificates()
 
+    def _cleanup_temp_pem_files(self, cert_fd, key_fd, cert_path, key_path):
+        """Close any still-open file descriptors and delete the temp PEM files."""
+        for fd in [cert_fd, key_fd]:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        for path in [cert_path, key_path]:
+            if path and os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except OSError as e:
+                    logger.warning(f'Could not remove temp cert file {path}: {e}')
+        self._temp_cert_path = None
+        self._temp_key_path = None
+
     def ship(self):
         if self.shipping_auth_mode() == self.SHIPPING_AUTH_SERVICE_ACCOUNT:
             return super().ship()
@@ -115,20 +132,7 @@ class PackageCRC(base.Package):
             return super().ship()
 
         finally:
-            for fd in [cert_fd, key_fd]:
-                if fd is not None:
-                    try:
-                        os.close(fd)
-                    except OSError:
-                        pass
-            for path in [cert_path, key_path]:
-                if path and os.path.exists(path):
-                    try:
-                        os.unlink(path)
-                    except OSError as e:
-                        logger.warning(f'Could not remove temp cert file {path}: {e}')
-            self._temp_cert_path = None
-            self._temp_key_path = None
+            self._cleanup_temp_pem_files(cert_fd, key_fd, cert_path, key_path)
 
     def shipping_auth_mode(self):
         if self._resolved_auth_mode is not None:

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import re
 
@@ -75,6 +76,11 @@ VALID_COLLECTORS = {
 VALID_SHIP_TARGET_BUILD = {'directory', 's3', 'controller_db'}
 VALID_SHIP_TARGET_GATHER = {'directory', 's3', 'crc'}
 
+# Keys in the conf_setting table where the Candlepin consumer identity cert is stored.
+# Update these to match the actual row keys used by the AAP controller.
+CANDLEPIN_CERT_SETTING_KEY = 'CANDLEPIN_CONSUMER_CERT'
+CANDLEPIN_KEY_SETTING_KEY = 'CANDLEPIN_CONSUMER_KEY'
+
 ship_path_description = 'place for collected data and built reports'
 
 
@@ -142,6 +148,27 @@ def handle_not_s3():
         logger.warning(f'Ignoring env variables used without METRICS_UTILITY_SHIP_TARGET="s3": {", ".join(surplus)}')
 
 
+def _fetch_candlepin_cert_from_db():
+    """Attempt to read the Candlepin consumer identity cert and key PEM from conf_setting.
+
+    Returns (cert_pem, key_pem) strings if found, or (None, None) on any error or absence.
+    This is best-effort: failures are logged as warnings and never propagate.
+    """
+    try:
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'SELECT key, value FROM conf_setting WHERE key IN (%s, %s)',
+                [CANDLEPIN_CERT_SETTING_KEY, CANDLEPIN_KEY_SETTING_KEY],
+            )
+            rows = {key: json.loads(value) for key, value in cursor.fetchall() if value}
+        return rows.get(CANDLEPIN_CERT_SETTING_KEY), rows.get(CANDLEPIN_KEY_SETTING_KEY)
+    except Exception as e:
+        logger.warning(f'Could not fetch Candlepin cert from DB: {e}')
+        return None, None
+
+
 def handle_crc_ship_target():
     billing_provider = os.getenv('METRICS_UTILITY_BILLING_PROVIDER')
     red_hat_org_id = os.getenv('METRICS_UTILITY_RED_HAT_ORG_ID')
@@ -163,6 +190,15 @@ def handle_crc_ship_target():
     if ship_path:
         allowed = '", "'.join(['controller_db', 'directory', 's3'])
         logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
+
+    # Attempt to load Candlepin mTLS credentials from the AAP DB (best-effort).
+    cert_pem, key_pem = _fetch_candlepin_cert_from_db()
+    if cert_pem and key_pem:
+        billing_provider_params['candlepin_cert_pem'] = cert_pem
+        billing_provider_params['candlepin_key_pem'] = key_pem
+        logger.info('Candlepin identity cert loaded from DB; mTLS will be attempted.')
+    else:
+        logger.info('No Candlepin identity cert found in DB; will use service account auth.')
 
     return billing_provider_params
 

--- a/metrics_utility/test/gather/test_package_crc.py
+++ b/metrics_utility/test/gather/test_package_crc.py
@@ -1,0 +1,360 @@
+import datetime
+import os
+import tempfile
+
+from datetime import timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+import metrics_utility.base.package as base_package
+
+from metrics_utility.automation_controller_billing.package.package_crc import PackageCRC, _is_cert_valid
+
+
+def _generate_cert(expired=False):
+    """Generate a self-signed X.509 certificate for testing."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    if expired:
+        not_before = datetime.datetime(2020, 1, 1, tzinfo=timezone.utc)
+        not_after = datetime.datetime(2021, 1, 1, tzinfo=timezone.utc)
+    else:
+        now = datetime.datetime.now(timezone.utc)
+        not_before = now
+        not_after = now + datetime.timedelta(days=365)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'test')]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'test')]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode('utf-8')
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode('utf-8')
+    return cert_pem, key_pem
+
+
+@pytest.fixture
+def valid_cert_pem():
+    cert_pem, _ = _generate_cert(expired=False)
+    return cert_pem
+
+
+@pytest.fixture
+def expired_cert_pem():
+    cert_pem, _ = _generate_cert(expired=True)
+    return cert_pem
+
+
+@pytest.fixture
+def valid_cert_and_key():
+    return _generate_cert(expired=False)
+
+
+def _make_package(cert_pem=None, key_pem=None):
+    """Create a PackageCRC with a mocked collector."""
+    collector = MagicMock()
+    params = {}
+    if cert_pem is not None:
+        params['candlepin_cert_pem'] = cert_pem
+    if key_pem is not None:
+        params['candlepin_key_pem'] = key_pem
+    collector.billing_provider_params = params
+    return PackageCRC(collector)
+
+
+class TestIsCertValid:
+    def test_valid_cert_returns_true(self, valid_cert_pem):
+        assert _is_cert_valid(valid_cert_pem) is True
+
+    def test_expired_cert_returns_false(self, expired_cert_pem):
+        assert _is_cert_valid(expired_cert_pem) is False
+
+    def test_invalid_pem_string_returns_false(self):
+        assert _is_cert_valid('not-a-cert') is False
+
+    def test_empty_string_returns_false(self):
+        assert _is_cert_valid('') is False
+
+    def test_expired_cert_logs_warning(self, expired_cert_pem):
+        with patch('metrics_utility.automation_controller_billing.package.package_crc.logger') as mock_logger:
+            _is_cert_valid(expired_cert_pem)
+        mock_logger.warning.assert_called_once()
+        assert 'expired' in mock_logger.warning.call_args[0][0]
+
+    def test_invalid_pem_logs_warning(self):
+        with patch('metrics_utility.automation_controller_billing.package.package_crc.logger') as mock_logger:
+            _is_cert_valid('not-a-cert')
+        mock_logger.warning.assert_called_once()
+        assert 'Could not parse' in mock_logger.warning.call_args[0][0]
+
+
+class TestShippingAuthMode:
+    def test_returns_certificates_when_valid_cert_and_key(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_CERTIFICATES
+
+    def test_returns_service_account_when_no_cert_or_key(self):
+        package = _make_package()
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+    def test_returns_service_account_when_cert_present_but_no_key(self, valid_cert_pem):
+        package = _make_package(cert_pem=valid_cert_pem)
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+    def test_returns_service_account_when_key_present_but_no_cert(self):
+        _, key_pem = _generate_cert()
+        package = _make_package(key_pem=key_pem)
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+    def test_returns_service_account_when_cert_is_expired(self, expired_cert_pem):
+        _, key_pem = _generate_cert()
+        package = _make_package(cert_pem=expired_cert_pem, key_pem=key_pem)
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+    def test_caches_auth_mode_after_first_call(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        with patch('metrics_utility.automation_controller_billing.package.package_crc._is_cert_valid', return_value=True) as mock_valid:
+            package.shipping_auth_mode()
+            package.shipping_auth_mode()
+        mock_valid.assert_called_once()
+
+    def test_pre_resolved_mode_is_returned_immediately(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        package._resolved_auth_mode = PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+        # Even with valid cert+key, pre-resolved mode wins
+        assert package.shipping_auth_mode() == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+
+class TestIsShippingConfigured:
+    def test_base_tar_path_check_runs_in_cert_mode(self, valid_cert_and_key):
+        """Regression: super().is_shipping_configured() must be called (not super()) so tar_path is checked."""
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        package.tar_path = None
+        assert package.is_shipping_configured() is False
+
+    def test_base_tar_path_nonexistent_file_returns_false(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        package.tar_path = '/nonexistent/path/metrics.tar.gz'
+        assert package.is_shipping_configured() is False
+
+    def test_cert_mode_returns_true_when_ingress_url_set(self, valid_cert_and_key, monkeypatch):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        monkeypatch.setenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            assert package.is_shipping_configured() is True
+
+    def test_cert_mode_returns_false_when_ingress_url_missing(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            with patch.object(PackageCRC, 'get_ingress_url', return_value=''):
+                assert package.is_shipping_configured() is False
+
+    def test_service_account_mode_returns_true_when_all_vars_set(self, monkeypatch):
+        package = _make_package()
+        monkeypatch.setenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
+        monkeypatch.setenv('METRICS_UTILITY_CRC_SSO_URL', 'https://sso.redhat.com/token')
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', 'test-client-id')
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', 'test-secret')
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            assert package.is_shipping_configured() is True
+
+    def test_service_account_mode_returns_false_when_ingress_url_missing(self, monkeypatch):
+        package = _make_package()
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', 'test-client-id')
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', 'test-secret')
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            with patch.object(PackageCRC, 'get_ingress_url', return_value=''):
+                assert package.is_shipping_configured() is False
+
+    def test_service_account_mode_returns_false_when_sso_url_missing(self, monkeypatch):
+        package = _make_package()
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', 'test-client-id')
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', 'test-secret')
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            with patch.object(PackageCRC, 'get_sso_url', return_value=''):
+                assert package.is_shipping_configured() is False
+
+    def test_service_account_mode_returns_false_when_account_id_missing(self, monkeypatch):
+        package = _make_package()
+        monkeypatch.setenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
+        monkeypatch.setenv('METRICS_UTILITY_CRC_SSO_URL', 'https://sso.redhat.com/token')
+        monkeypatch.delenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', raising=False)
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', 'test-secret')
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            assert package.is_shipping_configured() is False
+
+    def test_service_account_mode_returns_false_when_secret_missing(self, monkeypatch):
+        package = _make_package()
+        monkeypatch.setenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
+        monkeypatch.setenv('METRICS_UTILITY_CRC_SSO_URL', 'https://sso.redhat.com/token')
+        monkeypatch.setenv('METRICS_UTILITY_SERVICE_ACCOUNT_ID', 'test-client-id')
+        monkeypatch.delenv('METRICS_UTILITY_SERVICE_ACCOUNT_SECRET', raising=False)
+        with tempfile.NamedTemporaryFile() as f:
+            package.tar_path = f.name
+            assert package.is_shipping_configured() is False
+
+    def test_base_check_fails_with_error_in_tar_path(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        package.tar_path = 'Error: something went wrong'
+        assert package.is_shipping_configured() is False
+
+
+class TestShip:
+    def test_service_account_mode_delegates_directly_to_super(self):
+        package = _make_package()
+        with patch.object(base_package.Package, 'ship', return_value=True) as mock_super:
+            result = package.ship()
+        assert result is True
+        mock_super.assert_called_once()
+
+    def test_mtls_mode_invokes_super_ship(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        with patch.object(base_package.Package, 'ship', return_value=True) as mock_super:
+            result = package.ship()
+        assert result is True
+        mock_super.assert_called_once()
+
+    def test_mtls_mode_creates_temp_files_with_cert_and_key_content(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        captured = {}
+
+        def capture():
+            captured['cert_path'] = package._temp_cert_path
+            captured['key_path'] = package._temp_key_path
+            with open(package._temp_cert_path) as f:
+                captured['cert_content'] = f.read()
+            with open(package._temp_key_path) as f:
+                captured['key_content'] = f.read()
+            return True
+
+        with patch.object(base_package.Package, 'ship', side_effect=capture):
+            package.ship()
+
+        assert captured['cert_content'] == cert_pem
+        assert captured['key_content'] == key_pem
+
+    def test_mtls_mode_sets_temp_file_permissions_to_0600(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        seen_modes = {}
+        original_chmod = os.chmod
+
+        def tracking_chmod(path, mode):
+            seen_modes[path] = mode
+            original_chmod(path, mode)
+
+        with patch('os.chmod', side_effect=tracking_chmod):
+            with patch.object(base_package.Package, 'ship', return_value=True):
+                package.ship()
+
+        assert len(seen_modes) == 2
+        for mode in seen_modes.values():
+            assert mode == 0o600
+
+    def test_mtls_mode_cleans_up_temp_files_on_success(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        captured = {}
+
+        def capture():
+            captured['cert'] = package._temp_cert_path
+            captured['key'] = package._temp_key_path
+            return True
+
+        with patch.object(base_package.Package, 'ship', side_effect=capture):
+            package.ship()
+
+        assert not os.path.exists(captured['cert'])
+        assert not os.path.exists(captured['key'])
+        assert package._temp_cert_path is None
+        assert package._temp_key_path is None
+
+    def test_ssl_error_falls_back_to_service_account(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake failed'), True]):
+            result = package.ship()
+
+        assert result is True
+        assert package._resolved_auth_mode == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
+
+    def test_ssl_error_cleans_up_temp_files(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        captured = {}
+        call_count = [0]
+
+        def raise_first_then_succeed():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                captured['cert'] = package._temp_cert_path
+                captured['key'] = package._temp_key_path
+                raise requests.exceptions.SSLError('SSL error')
+            return True
+
+        with patch.object(base_package.Package, 'ship', side_effect=raise_first_then_succeed):
+            package.ship()
+
+        assert not os.path.exists(captured['cert'])
+        assert not os.path.exists(captured['key'])
+
+    def test_ssl_error_logs_error_message(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake'), True]):
+            with patch('metrics_utility.automation_controller_billing.package.package_crc.logger') as mock_logger:
+                package.ship()
+
+        mock_logger.error.assert_called_once()
+        assert 'mTLS upload failed' in mock_logger.error.call_args[0][0]
+        assert 'service account' in mock_logger.error.call_args[0][0]
+
+
+class TestGetClientCertificates:
+    def test_returns_temp_paths_when_set(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        package._temp_cert_path = '/tmp/cert.pem'
+        package._temp_key_path = '/tmp/key.pem'
+        assert package._get_client_certificates() == ('/tmp/cert.pem', '/tmp/key.pem')
+
+    def test_falls_back_to_super_when_temp_paths_not_set(self):
+        package = _make_package()
+        result = package._get_client_certificates()
+        assert result == (base_package.Package.DEFAULT_RHSM_CERT_FILE, base_package.Package.DEFAULT_RHSM_KEY_FILE)

--- a/metrics_utility/test/gather/test_package_crc.py
+++ b/metrics_utility/test/gather/test_package_crc.py
@@ -302,12 +302,47 @@ class TestShip:
         assert package._temp_cert_path is None
         assert package._temp_key_path is None
 
-    def test_ssl_error_falls_back_to_service_account(self, valid_cert_and_key):
+    def test_ssl_error_raises_when_no_service_account_credentials(self, valid_cert_and_key):
+        """If mTLS fails and no service account creds exist, raise FailedToUploadPayload instead of silently returning False."""
+        from metrics_utility.exceptions import FailedToUploadPayload
+
         cert_pem, key_pem = valid_cert_and_key
         package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
 
-        with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake failed'), True]):
-            result = package.ship()
+        with patch.object(base_package.Package, 'ship', side_effect=requests.exceptions.SSLError('handshake failed')):
+            with patch.object(PackageCRC, '_get_rh_user', return_value=None):
+                with patch.object(PackageCRC, '_get_rh_password', return_value=None):
+                    with pytest.raises(FailedToUploadPayload) as exc_info:
+                        package.ship()
+
+        assert 'mTLS upload failed' in str(exc_info.value)
+        assert 'METRICS_UTILITY_SERVICE_ACCOUNT_ID' in str(exc_info.value)
+        assert 'handshake failed' in str(exc_info.value)
+
+    def test_ssl_error_raises_preserves_original_ssl_error_as_cause(self, valid_cert_and_key):
+        """The raised FailedToUploadPayload must chain the original SSLError via __cause__."""
+        from metrics_utility.exceptions import FailedToUploadPayload
+
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+        ssl_error = requests.exceptions.SSLError('handshake failed')
+
+        with patch.object(base_package.Package, 'ship', side_effect=ssl_error):
+            with patch.object(PackageCRC, '_get_rh_user', return_value=None):
+                with patch.object(PackageCRC, '_get_rh_password', return_value=None):
+                    with pytest.raises(FailedToUploadPayload) as exc_info:
+                        package.ship()
+
+        assert exc_info.value.__cause__ is ssl_error
+
+    def test_ssl_error_falls_back_to_service_account_when_credentials_present(self, valid_cert_and_key):
+        cert_pem, key_pem = valid_cert_and_key
+        package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
+
+        with patch.object(PackageCRC, '_get_rh_user', return_value='client-id'):
+            with patch.object(PackageCRC, '_get_rh_password', return_value='secret'):
+                with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake failed'), True]):
+                    result = package.ship()
 
         assert result is True
         assert package._resolved_auth_mode == PackageCRC.SHIPPING_AUTH_SERVICE_ACCOUNT
@@ -327,8 +362,10 @@ class TestShip:
                 raise requests.exceptions.SSLError('SSL error')
             return True
 
-        with patch.object(base_package.Package, 'ship', side_effect=raise_first_then_succeed):
-            package.ship()
+        with patch.object(PackageCRC, '_get_rh_user', return_value='client-id'):
+            with patch.object(PackageCRC, '_get_rh_password', return_value='secret'):
+                with patch.object(base_package.Package, 'ship', side_effect=raise_first_then_succeed):
+                    package.ship()
 
         assert not os.path.exists(captured['cert'])
         assert not os.path.exists(captured['key'])
@@ -337,9 +374,11 @@ class TestShip:
         cert_pem, key_pem = valid_cert_and_key
         package = _make_package(cert_pem=cert_pem, key_pem=key_pem)
 
-        with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake'), True]):
-            with patch('metrics_utility.automation_controller_billing.package.package_crc.logger') as mock_logger:
-                package.ship()
+        with patch.object(PackageCRC, '_get_rh_user', return_value='client-id'):
+            with patch.object(PackageCRC, '_get_rh_password', return_value='secret'):
+                with patch.object(base_package.Package, 'ship', side_effect=[requests.exceptions.SSLError('handshake'), True]):
+                    with patch('metrics_utility.automation_controller_billing.package.package_crc.logger') as mock_logger:
+                        package.ship()
 
         mock_logger.error.assert_called_once()
         assert 'mTLS upload failed' in mock_logger.error.call_args[0][0]

--- a/metrics_utility/test/validation/test_candlepin_validation.py
+++ b/metrics_utility/test/validation/test_candlepin_validation.py
@@ -1,0 +1,202 @@
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metrics_utility.management.validation import (
+    CANDLEPIN_CERT_SETTING_KEY,
+    CANDLEPIN_KEY_SETTING_KEY,
+    _fetch_candlepin_cert_from_db,
+    handle_crc_ship_target,
+)
+
+
+SAMPLE_CERT_PEM = '-----BEGIN CERTIFICATE-----\nMIIBtest==\n-----END CERTIFICATE-----\n'
+SAMPLE_KEY_PEM = '-----BEGIN RSA PRIVATE KEY-----\nMIIEtest==\n-----END RSA PRIVATE KEY-----\n'
+
+
+def _make_cursor_with_rows(rows):
+    """Return a mock cursor context manager whose fetchall() returns rows."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = rows
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cursor
+
+
+class TestFetchCandlepinCertFromDb:
+    def test_returns_cert_and_key_when_both_present(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, json.dumps(SAMPLE_CERT_PEM)),
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert == SAMPLE_CERT_PEM
+        assert key == SAMPLE_KEY_PEM
+
+    def test_returns_none_none_when_no_rows(self):
+        mock_conn, _ = _make_cursor_with_rows([])
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert is None
+        assert key is None
+
+    def test_returns_none_for_missing_key(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, json.dumps(SAMPLE_CERT_PEM)),
+            # no key row
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert == SAMPLE_CERT_PEM
+        assert key is None
+
+    def test_returns_none_for_missing_cert(self):
+        rows = [
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+            # no cert row
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert is None
+        assert key == SAMPLE_KEY_PEM
+
+    def test_skips_rows_with_empty_value(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, ''),
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert is None
+        assert key == SAMPLE_KEY_PEM
+
+    def test_returns_none_none_on_db_exception(self):
+        with patch('django.db.connection.cursor', side_effect=Exception('DB connection refused')):
+            cert, key = _fetch_candlepin_cert_from_db()
+
+        assert cert is None
+        assert key is None
+
+    def test_logs_warning_on_db_exception(self):
+        with patch('django.db.connection.cursor', side_effect=Exception('timeout')):
+            with patch('metrics_utility.management.validation.logger') as mock_logger:
+                _fetch_candlepin_cert_from_db()
+
+        mock_logger.warning.assert_called_once()
+        assert 'Could not fetch Candlepin cert from DB' in mock_logger.warning.call_args[0][0]
+
+    def test_queries_both_setting_keys(self):
+        mock_conn, mock_cursor = _make_cursor_with_rows([])
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            _fetch_candlepin_cert_from_db()
+
+        sql_call = mock_cursor.execute.call_args[0][0]
+        args = mock_cursor.execute.call_args[0][1]
+        assert CANDLEPIN_CERT_SETTING_KEY in args
+        assert CANDLEPIN_KEY_SETTING_KEY in args
+        assert 'conf_setting' in sql_call
+
+
+class TestHandleCrcShipTargetCandlepin:
+    @pytest.fixture(autouse=True)
+    def set_required_env(self, monkeypatch):
+        monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
+        monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
+        monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
+
+    def test_injects_cert_and_key_when_both_available(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, json.dumps(SAMPLE_CERT_PEM)),
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            params = handle_crc_ship_target()
+
+        assert params['candlepin_cert_pem'] == SAMPLE_CERT_PEM
+        assert params['candlepin_key_pem'] == SAMPLE_KEY_PEM
+
+    def test_does_not_inject_when_cert_missing(self):
+        rows = [
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            params = handle_crc_ship_target()
+
+        assert 'candlepin_cert_pem' not in params
+        assert 'candlepin_key_pem' not in params
+
+    def test_does_not_inject_when_key_missing(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, json.dumps(SAMPLE_CERT_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            params = handle_crc_ship_target()
+
+        assert 'candlepin_cert_pem' not in params
+        assert 'candlepin_key_pem' not in params
+
+    def test_does_not_inject_when_db_fails(self):
+        with patch('django.db.connection.cursor', side_effect=Exception('DB error')):
+            params = handle_crc_ship_target()
+
+        assert 'candlepin_cert_pem' not in params
+        assert 'candlepin_key_pem' not in params
+
+    def test_logs_info_when_cert_loaded(self):
+        rows = [
+            (CANDLEPIN_CERT_SETTING_KEY, json.dumps(SAMPLE_CERT_PEM)),
+            (CANDLEPIN_KEY_SETTING_KEY, json.dumps(SAMPLE_KEY_PEM)),
+        ]
+        mock_conn, _ = _make_cursor_with_rows(rows)
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            with patch('metrics_utility.management.validation.logger') as mock_logger:
+                handle_crc_ship_target()
+
+        info_messages = [str(call) for call in mock_logger.info.call_args_list]
+        assert any('mTLS' in msg for msg in info_messages)
+
+    def test_logs_info_when_no_cert_found(self):
+        mock_conn, _ = _make_cursor_with_rows([])
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            with patch('metrics_utility.management.validation.logger') as mock_logger:
+                handle_crc_ship_target()
+
+        info_messages = [str(call) for call in mock_logger.info.call_args_list]
+        assert any('service account' in msg for msg in info_messages)
+
+    def test_billing_provider_params_always_includes_billing_fields(self):
+        mock_conn, _ = _make_cursor_with_rows([])
+
+        with patch('django.db.connection.cursor', return_value=mock_conn):
+            params = handle_crc_ship_target()
+
+        assert params['billing_provider'] == 'aws'
+        assert params['billing_account_id'] == '123456789012'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
     "boto3==1.35.96",
+    "cryptography>=42.0.0",
     "botocore==1.35.96",
     "distro==1.9.0",
     "django==5.2.7",

--- a/uv.lock
+++ b/uv.lock
@@ -429,6 +429,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
+    { name = "cryptography" },
     { name = "distro" },
     { name = "django" },
     { name = "kubernetes" },
@@ -454,6 +455,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = "==1.35.96" },
     { name = "botocore", specifier = "==1.35.96" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "distro", specifier = "==1.9.0" },
     { name = "django", specifier = "==5.2.7" },
     { name = "kubernetes", specifier = ">=33.1.0" },


### PR DESCRIPTION
- Added `cryptography` dependency to `pyproject.toml` and `uv.lock`.
- Enhanced `PackageCRC` class to support mTLS authentication using Candlepin certificates.
- Implemented methods to fetch certificates from the database and validate them.
- Updated shipping logic to handle both mTLS and service account authentication modes.
- Added logging for certificate loading and validation processes.

[PENDING] Feature needs to be added to AWX


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shipping/authentication paths and introduces handling of client certificate/key material (temp-file creation, cleanup, fallback logic), which could impact upload reliability and security if misconfigured.
> 
> **Overview**
> Adds optional mTLS-based payload shipping for the `crc` ship target by loading Candlepin client cert/key PEMs from the controller DB, validating certificate expiry, and using them for mutual TLS uploads (with automatic fallback to service-account auth on SSL failures when credentials exist).
> 
> Hardens data handling by stripping `candlepin_cert_pem`/`candlepin_key_pem` from `config.json` archives, and adds comprehensive unit tests plus a new `cryptography` dependency to support X.509 parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6536acbac315a30a1d9248335b18045de546dd5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->