### PR TITLE
Update anonymize_rollups function to make feature_flags_rollup an opt…

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -555,8 +555,9 @@ def anonymize_rollups(
     credentials_rollup,
     table_metadata_rollup,
     controller_version_rollup,
-    feature_flags_rollup,
     salt,
+    *,
+    feature_flags_rollup=None,
     task_executions_rollup=None,
 ):
     """
@@ -570,9 +571,9 @@ def anonymize_rollups(
         credentials_rollup: Credentials statistics
         table_metadata_rollup: Table metadata statistics
         controller_version_rollup: Controller version statistics
-        feature_flags_rollup: Enabled feature flags list
         salt: Salt string for hashing sensitive data
-        task_executions_rollup: Task execution observability statistics (optional)
+        feature_flags_rollup: Enabled feature flags list (optional, keyword-only)
+        task_executions_rollup: Task execution observability statistics (optional, keyword-only)
 
     Returns:
         Flattened and anonymized rollup data
@@ -585,7 +586,7 @@ def anonymize_rollups(
         'credentials': credentials_rollup,
         'table_metadata': table_metadata_rollup,
         'controller_version': controller_version_rollup,
-        'feature_flags': feature_flags_rollup,
+        'feature_flags': feature_flags_rollup or [],
         'task_executions': task_executions_rollup or [],
     }
 


### PR DESCRIPTION
…ional keyword-only argument. Adjusted documentation and default behavior to return an empty list if not provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Signature change can break any callers passing `feature_flags_rollup`/`salt` positionally; behavior change is otherwise limited to defaulting missing feature flags to `[]`.
> 
> **Overview**
> Updates `anonymize_rollups` to make `feature_flags_rollup` an optional, keyword-only parameter (moved after `salt` and introduced `*`).
> 
> When omitted or `None`, the generated output now defaults `feature_flags` to an empty list, and the docstring is updated to reflect the new calling convention for `feature_flags_rollup`/`task_executions_rollup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cca1bd79d90e2e661d81afaf73ff1cfe915bc210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->