### PR TITLE
[stable-0.7] Backport (#362)

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -555,8 +555,9 @@ def anonymize_rollups(
     credentials_rollup,
     table_metadata_rollup,
     controller_version_rollup,
-    feature_flags_rollup,
     salt,
+    *,
+    feature_flags_rollup=None,
     task_executions_rollup=None,
 ):
     """
@@ -570,9 +571,9 @@ def anonymize_rollups(
         credentials_rollup: Credentials statistics
         table_metadata_rollup: Table metadata statistics
         controller_version_rollup: Controller version statistics
-        feature_flags_rollup: Enabled feature flags list
         salt: Salt string for hashing sensitive data
-        task_executions_rollup: Task execution observability statistics (optional)
+        feature_flags_rollup: Enabled feature flags list (optional, keyword-only)
+        task_executions_rollup: Task execution observability statistics (optional, keyword-only)
 
     Returns:
         Flattened and anonymized rollup data
@@ -585,7 +586,7 @@ def anonymize_rollups(
         'credentials': credentials_rollup,
         'table_metadata': table_metadata_rollup,
         'controller_version': controller_version_rollup,
-        'feature_flags': feature_flags_rollup,
+        'feature_flags': feature_flags_rollup or [],
         'task_executions': task_executions_rollup or [],
     }
 


### PR DESCRIPTION
## Summary

Backport of outstanding devel commits to `stable-0.7`.

After checking all 9 commits ahead of `stable-0.7` in `devel`, the following were already present (via #368 — "Updating stable0 7"):

- #351 — Refactor JobsAnonymizedRollup numeric column handling
- #353 — collectors: unify date interpolation through `date_where`
- #354 — add `config_django` collector
- #355 — CLI: bump `config` collector version to 2.0 in manifest
- #357 — Milan new collectors (feature flags + execution times)
- #358 — library.lock docs update
- #359 — Add more `METRICS_UTILITY_DB_` env vars

The one genuinely new commit:

- **#362** — Make `feature_flags_rollup` an optional keyword-only argument in `anonymize_rollups`; defaults to `[]` if not provided

## Test plan

- [ ] Verify `anonymize_rollups` still works when called without `feature_flags_rollup`
- [ ] Verify existing callers passing `feature_flags_rollup` are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small signature change with a safe default (`[]`), limited to rollup shaping and unlikely to affect sensitive logic beyond call-site compatibility.
> 
> **Overview**
> Updates `anonymize_rollups()` to make `feature_flags_rollup` an *optional, keyword-only* parameter and defaults the emitted `feature_flags` field to an empty list when not provided.
> 
> This preserves existing behavior for callers that pass feature flags while allowing older/alternate call sites to omit them without breaking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176ac1afb08860119b0a65e3e528ad2066a28925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->