### PR TITLE
Remove use bulk from split into segment

### DIFF
--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -17,17 +17,14 @@ except ImportError:
 
 
 class StorageSegment:
-    # Size limits for Segment messages
-    # 32KB for regular messages, but leave some room for the additional metadata
+    # Max JSON size of each `data` chunk. Segment enforces ~32KB per `track` message
+    # including `properties` wrapper, event name, and segment_meta; keep this conservative.
     REGULAR_MESSAGE_LIMIT = 24 * 1024
-    # 512MB for bulk messages, but leave some room for the additional metadata
-    BULK_MESSAGE_LIMIT = 500 * 1024 * 1024
 
     def __init__(self, **settings):
         self.debug = settings.get('debug', False)
         self.user_id = settings.get('user_id', 'unknown')
         self.write_key = settings.get('write_key')
-        self.use_bulk = settings.get('use_bulk', False)
 
         if not SEGMENT_AVAILABLE:
             logger.info('StorageSegment: segment module not installed. Analytics will be disabled.')
@@ -44,15 +41,17 @@ class StorageSegment:
         Split data into chunks based on max_size.
 
         Always splits by top-level keys - each top-level key gets its own chunk(s).
-        If a top-level key's value is a list, that list may be split into multiple chunks
-        if it exceeds max_size.
+        If a top-level key's value is a list, it is split in order: the next item is
+        considered appended to the current chunk; if ``json.dumps`` of that chunk
+        would exceed max_size, the current chunk is finalized and a new one is started
+        (or a single oversize item is emitted alone).
 
         Args:
             data: Dictionary to split, dictionary contains key : value pairs
             Those key value pairs are either dicts or list
             only lists are split into chunks, dicts are not split, thus dicts can not
             be larger than max_size
-            max_size: Maximum size in bytes for each chunk
+            max_size: Maximum size in bytes for each chunk (JSON of top-level {key: ...})
 
         Returns:
             List of data chunks
@@ -72,11 +71,14 @@ class StorageSegment:
                 active_chunk = {key: []}
 
                 for item in value:
-                    active_chunk_size = self._calculate_size(active_chunk)
-                    item_size = self._calculate_size(item)
-                    if active_chunk_size + item_size > max_size:
-                        chunks.append(active_chunk)
-                        active_chunk = {key: [item]}
+                    trial = {key: active_chunk[key] + [item]}
+                    if self._calculate_size(trial) > max_size:
+                        if len(active_chunk[key]) > 0:
+                            chunks.append(active_chunk)
+                            active_chunk = {key: [item]}
+                        else:
+                            # single item does not fit max_size; emit it alone
+                            chunks.append({key: [item]})
                     else:
                         active_chunk[key].append(item)
 
@@ -98,10 +100,9 @@ class StorageSegment:
                        (defaults to 'Metrics Artifact Upload')
 
         This method supports sending anonymized analytics from
-        multiple apps. Data will be automatically split into chunks
-        based on Segment's size limits:
-        - 32KB for regular messages
-        - 512MB for bulk messages (when use_bulk=True)
+        multiple apps. Data is split so each `data` chunk is under
+        :attr:`REGULAR_MESSAGE_LIMIT` (JSON bytes), with headroom for Segment's
+        per-message size limit.
         """
         chunks = []
         if filename or fileobj or dict is None:
@@ -130,8 +131,7 @@ class StorageSegment:
         analytics.write_key = self.write_key
         analytics.debug = self.debug
 
-        # Determine size limit based on bulk mode
-        max_size = self.BULK_MESSAGE_LIMIT if self.use_bulk else self.REGULAR_MESSAGE_LIMIT
+        max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)
 
         total_chunks = len(chunks)

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -43,17 +43,6 @@ class TestStorageSegmentAvailable:
         assert len(chunks[2]['module_stats']) == 38
         assert len(chunks[3]['module_stats']) == 36
 
-    def test_correct_splitting_for_large_data_with_bulk(self):
-        storage_segment = StorageSegment(use_bulk=True)
-        chunks = storage_segment._split_into_chunks(segment_data_large, storage_segment.BULK_MESSAGE_LIMIT)
-        # Even with bulk mode, we split by top-level keys
-        assert len(chunks) == 5
-        assert 'statistics' in chunks[0]
-        assert 'module_stats' in chunks[1]
-        assert 'collection_stats' in chunks[2]
-        assert 'jobs_by_job_type' in chunks[3]
-        assert 'job_host_summary' in chunks[4]
-
     def test_simple_list_data(self):
         data = {'test_list': ['item1', 'item2']}
         storage_segment = StorageSegment()
@@ -152,39 +141,3 @@ class TestStorageSegmentAvailable:
             chunk_info = call_kwargs['properties']['chunk_info']
             assert chunk_info['chunk_number'] == i
             assert chunk_info['total_chunks'] == 7
-
-    @patch('metrics_utility.library.storage.segment.analytics')
-    @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
-    def test_put_sends_single_chunk_for_large_data_with_bulk(self, mock_analytics):
-        """Test that put method with use_bulk=True sends large data in a single chunk."""
-        # Setup
-        mock_analytics.track = Mock()
-        mock_analytics.flush = Mock()
-
-        storage_segment = StorageSegment(write_key='test_write_key', user_id='test_user', debug=True, use_bulk=True)
-
-        # Act
-        chunks = storage_segment.put(artifact_name='test_bulk_artifact', dict=segment_data_large, event_name='Test Bulk Event')
-
-        # Assert
-        # Even with bulk mode, we split by top-level keys (5 chunks)
-        assert len(chunks) == 5
-        assert mock_analytics.track.call_count == 5
-        assert mock_analytics.flush.call_count == 1
-
-        # Verify chunk numbering in the calls
-        for i, call in enumerate(mock_analytics.track.call_args_list, 1):
-            call_kwargs = call[1]
-            chunk_info = call_kwargs['properties']['chunk_info']
-            assert chunk_info['chunk_number'] == i
-            assert chunk_info['total_chunks'] == 5
-
-        # Verify the first call
-        call_args = mock_analytics.track.call_args_list[0][1]
-        assert call_args['event'] == 'Test Bulk Event'
-        assert call_args['properties']['artifact_name'] == 'test_bulk_artifact'
-
-        # Verify each chunk contains one top-level key
-        for i, call in enumerate(mock_analytics.track.call_args_list):
-            data = call[1]['properties']['data']
-            assert len(data) == 1, f'Chunk {i + 1} should contain exactly one top-level key'


### PR DESCRIPTION
# [AAP-72806] 

## Description

What it fixes - our Segment does not support use bulk mode, I removed it from the service and utility.
