### PR TITLE
[After 2.7] Fix SonarCloud issues

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -250,7 +250,7 @@ def _merge_ansible_versions(jobs_by_job_type: List[Dict[str, Any]]) -> List[str]
         ansible_versions = job.get('ansible_versions', [])
         if isinstance(ansible_versions, list):
             ansible_versions_set.update(ansible_versions)
-    return sorted(list(ansible_versions_set)) if ansible_versions_set else []
+    return sorted(ansible_versions_set) if ansible_versions_set else []
 
 
 def _calculate_execution_environments_total(execution_environments: Dict[str, Any]) -> Any:

--- a/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/base_anonymized_rollup.py
@@ -85,11 +85,11 @@ class BaseAnonymizedRollup:
         return dataframe
 
     # Base receive the full daily rollup and computes some final statistics for the day
-    def base(self, dataframe):
+    def base(self, _dataframe):
         """Compute final daily statistics from the fully-merged rollup data.
 
         Args:
-            dataframe: The accumulated rollup data produced by successive calls to
+            _dataframe: The accumulated rollup data produced by successive calls to
                 ``merge`` across all batches for the day.
 
         Returns:
@@ -157,12 +157,7 @@ class BaseAnonymizedRollup:
                 df.to_csv(csv_buffer, index=False)
                 tar_files[f'{key}.csv'] = csv_buffer.getvalue().encode('utf-8')
 
-            elif isinstance(value, list):
-                # Sanitize and store JSON data in memory for tar
-                sanitized_value = sanitize_json(value)
-                tar_files[f'{filename}.json'] = json.dumps(sanitized_value, indent=2).encode('utf-8')
-
-            elif isinstance(value, dict):
+            elif isinstance(value, (list, dict)):
                 # Sanitize and store JSON data in memory for tar
                 sanitized_value = sanitize_json(value)
                 tar_files[f'{filename}.json'] = json.dumps(sanitized_value, indent=2).encode('utf-8')

--- a/metrics_utility/anonymized_rollups/credentials_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/credentials_anonymized_rollup.py
@@ -69,7 +69,7 @@ class CredentialsAnonymizedRollup(BaseAnonymizedRollup):
         credential_types_new = set(data_new.get('credential_types', []))
 
         # Union the sets and convert back to sorted list
-        credential_types_merged = sorted(list(credential_types_all.union(credential_types_new)))
+        credential_types_merged = sorted(credential_types_all.union(credential_types_new))
 
         return {
             'credential_types': credential_types_merged,

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -17,8 +17,8 @@ from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_co
 
 # Regex pattern to match collection names (e.g., namespace.collection.role or namespace.collection.role.task)
 # Pattern is safe from reDOS: uses non-capturing groups and non-nested quantifiers
-_COLLECTION_RE = re.compile(r'^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$')
-_COLLECTION_PATTERN = r'^([A-Za-z0-9_]+\.[A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$'
+_COLLECTION_RE = re.compile(r'^(\w+)\.(\w+)\.\w+(?:\.\w+)*$')
+_COLLECTION_PATTERN = r'^(\w+\.\w+)\.\w+(?:\.\w+)*$'
 
 
 def extract_collection_name(x: str | None) -> str | None:
@@ -163,7 +163,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             list_new = item_new.get(col) if item_new.get(col) is not None else []
             set_all = set(list_all) if isinstance(list_all, list) else set()
             set_new = set(list_new) if isinstance(list_new, list) else set()
-            merged_item[col] = sorted(list(set_all.union(set_new)))
+            merged_item[col] = sorted(set_all.union(set_new))
 
     def _merge_single_item(self, item_all, item_new):
         """Merge a single item from all and new data."""
@@ -209,7 +209,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         """Merge unique_modules lists (union and sort)."""
         unique_modules_all = set(data_all.get('unique_modules', []))
         unique_modules_new = set(data_new.get('unique_modules', []))
-        return sorted(list(unique_modules_all.union(unique_modules_new)))
+        return sorted(unique_modules_all.union(unique_modules_new))
 
     def _merge_modules_per_playbook(self, data_all, data_new):
         """Merge modules_per_playbook dicts (union lists per playbook)."""
@@ -222,14 +222,14 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             list_new = modules_per_playbook_new.get(playbook, []) or []
             set_all = set(list_all) if isinstance(list_all, list) else set()
             set_new = set(list_new) if isinstance(list_new, list) else set()
-            modules_per_playbook[playbook] = sorted(list(set_all.union(set_new)))
+            modules_per_playbook[playbook] = sorted(set_all.union(set_new))
         return modules_per_playbook
 
     def _merge_unique_hosts(self, data_all, data_new):
         """Merge unique_hosts lists (union and sort)."""
         unique_hosts_all = set(data_all.get('unique_hosts', []))
         unique_hosts_new = set(data_new.get('unique_hosts', []))
-        return sorted(list(unique_hosts_all.union(unique_hosts_new)))
+        return sorted(unique_hosts_all.union(unique_hosts_new))
 
     def merge(self, data_all, data_new):
         """
@@ -540,7 +540,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
     def _convert_set_or_list_to_sorted_list(value):
         """Convert set or list to sorted list, return empty list for other types."""
         if isinstance(value, set):
-            return sorted(list(value))
+            return sorted(value)
         if isinstance(value, list):
             return value
         return []
@@ -582,15 +582,15 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
     def _compute_unique_metadata(self, task_summary):
         """Compute unique_modules, modules_per_playbook, and unique_hosts."""
-        unique_modules = sorted(list(set(task_summary['module_name'].dropna().unique())))
+        unique_modules = sorted(set(task_summary['module_name'].dropna().unique()))
 
         modules_per_playbook = {}
         for playbook in task_summary['playbook'].dropna().unique():
-            modules_in_playbook = sorted(list(set(task_summary[task_summary['playbook'] == playbook]['module_name'].dropna().unique())))
+            modules_in_playbook = sorted(set(task_summary[task_summary['playbook'] == playbook]['module_name'].dropna().unique()))
             modules_per_playbook[playbook] = modules_in_playbook
 
         host_sets = [s for s in task_summary['host_ids'].dropna() if isinstance(s, set)]
-        unique_hosts = sorted(list(set().union(*host_sets))) if host_sets else []
+        unique_hosts = sorted(set().union(*host_sets)) if host_sets else []
 
         return unique_modules, modules_per_playbook, unique_hosts
 

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -351,7 +351,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             if isinstance(parsed, list):
                 return len(parsed) > 0
             return bool(parsed)
-        except (json.JSONDecodeError, TypeError, ValueError):
+        except (TypeError, ValueError):
             return False
 
     def _parse_warnings_deprecations(self, dataframe):

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -17,8 +17,9 @@ from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_co
 
 # Regex pattern to match collection names (e.g., namespace.collection.role or namespace.collection.role.task)
 # Pattern is safe from reDOS: uses non-capturing groups and non-nested quantifiers
-_COLLECTION_RE = re.compile(r'^(\w+)\.(\w+)\.\w+(?:\.\w+)*$')
-_COLLECTION_PATTERN = r'^(\w+\.\w+)\.\w+(?:\.\w+)*$'
+# Uses explicit ASCII character class [A-Za-z0-9_] rather than \w to avoid matching Unicode word chars
+_COLLECTION_RE = re.compile(r'^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$')
+_COLLECTION_PATTERN = r'^([A-Za-z0-9_]+\.[A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$'
 
 
 def extract_collection_name(x: str | None) -> str | None:

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -176,7 +176,7 @@ class Base:
 
         Must be implemented by subclasses.
         """
-        pass
+        return None
 
     def dates(self):
         """Return the list of daily dates to iterate over for the reporting window.
@@ -246,11 +246,11 @@ class Base:
             elif operations.get(col) == 'max':
                 df[col] = df[[f'{col}_x', f'{col}_y']].max(axis=1)
             elif operations.get(col) == 'combine_set':
-                df[col] = df.apply(lambda row: combine_set(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_set(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             elif operations.get(col) == 'combine_json':
-                df[col] = df.apply(lambda row: combine_json(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_json(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             elif operations.get(col) == 'combine_json_values':
-                df[col] = df.apply(lambda row: combine_json_values(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_json_values(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             else:
                 df[col] = df[[f'{col}_x', f'{col}_y']].sum(axis=1)
             del df[f'{col}_x']
@@ -283,7 +283,7 @@ class Base:
         if rollup is None:
             return new_group
 
-        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer')
+        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='many_to_many')
         rollup = self.summarize_merged_dataframes(rollup, self.data_columns(), operations=self.operations())
         return self.cast_dataframe(rollup, self.cast_types())
 
@@ -322,16 +322,20 @@ class Base:
 
     @staticmethod
     def unique_index_columns():
-        pass
+        # Subclasses must override this to return a list of index column names.
+        return []
 
     @staticmethod
     def data_columns():
-        pass
+        # Subclasses must override this to return a list of data column names.
+        return []
 
     @staticmethod
     def cast_types():
-        pass
+        # Subclasses must override this to return a dict of column-to-dtype mappings.
+        return {}
 
     @staticmethod
     def operations():
-        pass
+        # Subclasses must override this to return a dict of column merge operations.
+        return {}

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -322,20 +322,16 @@ class Base:
 
     @staticmethod
     def unique_index_columns():
-        # Subclasses must override this to return a list of index column names.
         return []
 
     @staticmethod
     def data_columns():
-        # Subclasses must override this to return a list of data column names.
         return []
 
     @staticmethod
     def cast_types():
-        # Subclasses must override this to return a dict of column-to-dtype mappings.
         return {}
 
     @staticmethod
     def operations():
-        # Subclasses must override this to return a dict of column merge operations.
         return {}

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -8,6 +8,8 @@ import pandas as pd
 
 from dateutil.relativedelta import relativedelta
 
+from metrics_utility.dataframe_schema import DataframeSchemaMixin
+
 
 def granularity_cast(date, granularity):
     """Truncate *date* to the start of its month or year according to *granularity*.
@@ -147,7 +149,7 @@ def combine_json_values(val1, val2):
     return merged
 
 
-class Base:
+class Base(DataframeSchemaMixin):
     """Abstract base class for billing dataframe engines.
 
     Subclasses implement :meth:`build_dataframe` to extract and aggregate raw
@@ -319,19 +321,3 @@ class Base:
         # cast types to match the table
         df_grouped = self.cast_dataframe(df_grouped, self.cast_types())
         return df_grouped.reset_index()
-
-    @staticmethod
-    def unique_index_columns():
-        return []
-
-    @staticmethod
-    def data_columns():
-        return []
-
-    @staticmethod
-    def cast_types():
-        return {}
-
-    @staticmethod
-    def operations():
-        return {}

--- a/metrics_utility/automation_controller_billing/dataframe_engine/base.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/base.py
@@ -285,7 +285,7 @@ class Base(DataframeSchemaMixin):
         if rollup is None:
             return new_group
 
-        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='many_to_many')
+        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='one_to_one')
         rollup = self.summarize_merged_dataframes(rollup, self.data_columns(), operations=self.operations())
         return self.cast_dataframe(rollup, self.cast_types())
 

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -4,10 +4,7 @@ import pandas as pd
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base, merge_setdicts, merge_sets
 from metrics_utility.automation_controller_billing.helpers import merge_arrays, merge_json_sets, parse_json_array
-from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
-
-
-DATETIME64_NS = 'datetime64[ns]'
+from metrics_utility.metric_utils import DATETIME64_NS, DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
 # dataframe for job_host_summary / main_indirectmanagednodeaudit

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -7,6 +7,9 @@ from metrics_utility.automation_controller_billing.helpers import merge_arrays, 
 from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
+DATETIME64_NS = 'datetime64[ns]'
+
+
 # dataframe for job_host_summary / main_indirectmanagednodeaudit
 class DataframeJobhostSummaryUsage(Base):
     """Aggregates job-host-summary (direct) and indirect managed node audit data."""
@@ -168,9 +171,9 @@ class DataframeJobhostSummaryUsage(Base):
             'task_runs': int,
             'host_runs': int,
             'managed_node_type': int,
-            'first_automation': 'datetime64[ns]',
-            'last_automation': 'datetime64[ns]',
-            'job_created': 'datetime64[ns]',
+            'first_automation': DATETIME64_NS,
+            'last_automation': DATETIME64_NS,
+            'job_created': DATETIME64_NS,
         }
 
     @staticmethod

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -4,7 +4,15 @@ import pandas as pd
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base, merge_setdicts, merge_sets
 from metrics_utility.automation_controller_billing.helpers import merge_arrays, merge_json_sets, parse_json_array
-from metrics_utility.metric_utils import DATETIME64_NS, DIRECT, INDIRECT, MANAGED_NODE_TYPES
+from metrics_utility.metric_utils import (
+    DIRECT,
+    INDIRECT,
+    JOB_HOST_SUMMARY_CAST_TYPES,
+    JOB_HOST_SUMMARY_DATA_COLUMNS,
+    JOB_HOST_SUMMARY_INDEX_COLUMNS,
+    JOB_HOST_SUMMARY_OPERATIONS,
+    MANAGED_NODE_TYPES,
+)
 
 
 # dataframe for job_host_summary / main_indirectmanagednodeaudit
@@ -142,48 +150,19 @@ class DataframeJobhostSummaryUsage(Base):
 
     @staticmethod
     def unique_index_columns():
-        return ['organization_name', 'job_template_name', 'host_name', 'original_host_name', 'install_uuid', 'job_remote_id']
+        return JOB_HOST_SUMMARY_INDEX_COLUMNS
 
     @staticmethod
     def data_columns():
-        return [
-            'host_runs',
-            'task_runs',
-            'first_automation',
-            'last_automation',
-            'job_created',
-            'managed_node_type',
-            'managed_node_types_set',
-            'canonical_facts',
-            'facts',
-            'events',
-            'host_names_before_dedup',
-        ]
+        return JOB_HOST_SUMMARY_DATA_COLUMNS
 
     @staticmethod
     def cast_types():
-        return {
-            'task_runs': int,
-            'host_runs': int,
-            'managed_node_type': int,
-            'first_automation': DATETIME64_NS,
-            'last_automation': DATETIME64_NS,
-            'job_created': DATETIME64_NS,
-        }
+        return JOB_HOST_SUMMARY_CAST_TYPES
 
     @staticmethod
     def operations():
-        return {
-            'first_automation': 'min',
-            'last_automation': 'max',
-            'job_created': 'max',
-            'managed_node_type': 'min',
-            'managed_node_types_set': 'combine_set',
-            'events': 'combine_set',
-            'canonical_facts': 'combine_json_values',
-            'facts': 'combine_json_values',
-            'host_names_before_dedup': 'combine_set',
-        }
+        return JOB_HOST_SUMMARY_OPERATIONS
 
     def dedup(self, dataframe, hostname_mapping=None, scope_dataframe=None):
         """

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -120,8 +120,6 @@ class DataframeJobhostSummaryUsage(Base):
             job_created=('job_created', 'max'),
             managed_node_type=('managed_node_type', 'min'),
             managed_node_types_set=('managed_node_type_string', set),
-            # TODO: optimize the aggregation to keep less rows around
-            # job_ids=('inventory_name', set),
             events=('events', merge_arrays),
             canonical_facts=('canonical_facts', merge_json_sets),
             facts=('facts', merge_json_sets),

--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_jobhost_summary_usage.py
@@ -4,19 +4,12 @@ import pandas as pd
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base, merge_setdicts, merge_sets
 from metrics_utility.automation_controller_billing.helpers import merge_arrays, merge_json_sets, parse_json_array
-from metrics_utility.metric_utils import (
-    DIRECT,
-    INDIRECT,
-    JOB_HOST_SUMMARY_CAST_TYPES,
-    JOB_HOST_SUMMARY_DATA_COLUMNS,
-    JOB_HOST_SUMMARY_INDEX_COLUMNS,
-    JOB_HOST_SUMMARY_OPERATIONS,
-    MANAGED_NODE_TYPES,
-)
+from metrics_utility.dataframe_schema import JobHostSummarySchema
+from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
 # dataframe for job_host_summary / main_indirectmanagednodeaudit
-class DataframeJobhostSummaryUsage(Base):
+class DataframeJobhostSummaryUsage(JobHostSummarySchema, Base):
     """Aggregates job-host-summary (direct) and indirect managed node audit data."""
 
     def build_dataframe(self):
@@ -147,22 +140,6 @@ class DataframeJobhostSummaryUsage(Base):
             facts=('facts', merge_setdicts),
             host_names_before_dedup=('host_names_before_dedup', merge_sets),
         )
-
-    @staticmethod
-    def unique_index_columns():
-        return JOB_HOST_SUMMARY_INDEX_COLUMNS
-
-    @staticmethod
-    def data_columns():
-        return JOB_HOST_SUMMARY_DATA_COLUMNS
-
-    @staticmethod
-    def cast_types():
-        return JOB_HOST_SUMMARY_CAST_TYPES
-
-    @staticmethod
-    def operations():
-        return JOB_HOST_SUMMARY_OPERATIONS
 
     def dedup(self, dataframe, hostname_mapping=None, scope_dataframe=None):
         """

--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -314,7 +314,7 @@ class DedupRenewalExperimental(BaseDedupRenewal):
             if row['hostname_group'] not in processed_hostname_groups:
                 for serial in row['individual_serials']:
                     if serial:
-                        serial_matches = expanded_df[expanded_df['individual_serials'].apply(lambda x: serial in x if x else False)]
+                        serial_matches = expanded_df[expanded_df['individual_serials'].apply(lambda x, s=serial: s in x if x else False)]
                         hostname_groups_in_serial = serial_matches['hostname_group'].unique()
                         if len(hostname_groups_in_serial) > 1:
                             canonical_group = hostname_groups_in_serial[0]

--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -49,7 +49,7 @@ class BaseDedupRenewal:
 
     def stringify(self, value):
         """Convert a set of values to a comma-separated string, filtering out None."""
-        return ', '.join([v for v in list(value) if v is not None])
+        return ', '.join([v for v in value if v is not None])
 
     def run(self):
         """Abstract method to be implemented by subclasses."""

--- a/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
+++ b/metrics_utility/automation_controller_billing/dedup/renewal_guidance.py
@@ -78,7 +78,7 @@ class DedupRenewal(BaseDedupRenewal):
 
             # Iterative search to cover indirect relationships
             iterations = int(self.extra_params['report_renewal_guidance_dedup_iterations'])
-            for i in range(iterations):
+            for _ in range(iterations):
                 # Hostname dupe lookup
                 dupes = self.find_dupes(dupes, 'hostname', dupes['hostname'])
 

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -57,8 +57,8 @@ class PackageCRC(base.Package):
 
     def is_shipping_configured(self):
         # TODO: move to base, or children
-        ret = super()
-        if ret is False:
+        ret = super().is_shipping_configured()
+        if not ret:
             return False
 
         if self.shipping_auth_mode() == self.SHIPPING_AUTH_SERVICE_ACCOUNT:

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -170,7 +170,7 @@ class Base:
 
         return destination_dataframe
 
-    def _build_data_section_scope(self, current_row, ws, dataframe, mode=None):
+    def _build_data_section_scope(self, current_row, ws, dataframe):
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
 
@@ -540,7 +540,6 @@ class Base:
             for c_idx, value in enumerate(row, 1):
                 cell = ws.cell(row=r_idx, column=c_idx)
                 cell.value = value
-                # cell.border = dotted_border
 
                 if row_counter == 0:
                     # set header style

--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -104,14 +104,14 @@ class Base:
         """
         # If the cell is a dictionary, convert each set value to a sorted list, then dump as a JSON string.
         if isinstance(cell, dict):
-            new_cell = {k: sorted(list(v)) if isinstance(v, set) else v for k, v in cell.items()}
+            new_cell = {k: sorted(v) if isinstance(v, set) else v for k, v in cell.items()}
             return json.dumps(new_cell)
         # If the cell itself is a set, convert it to a sorted list and then to a JSON string.
         elif isinstance(cell, set):
-            return json.dumps(sorted(list(cell)))
+            return json.dumps(sorted(cell))
         # If the cell is a list, convert any set elements inside to sorted lists and dump as a JSON string.
         elif isinstance(cell, list):
-            new_cell = [sorted(list(item)) if isinstance(item, set) else item for item in cell]
+            new_cell = [sorted(item) if isinstance(item, set) else item for item in cell]
             # Sort the list itself if it contains strings
             if new_cell and all(isinstance(item, str) for item in new_cell):
                 new_cell = sorted(new_cell)

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -536,14 +536,11 @@ class ReportCCSPv2(Base):
         h1_heading_cell = ws.cell(row=current_row, column=1)
         h1_heading_cell.value = self.config['h1_heading']['value']
 
-        # h1_heading_cell.fill = PatternFill("solid", fgColor=self.BLACK_COLOR_HEX)
         h1_heading_cell.font = Font(
             name=self.FONT,
             size=12,
             bold=True,
-        )  # color=self.WHITE_COLOR_HEX)
-
-        # h1_heading_cell.alignment = Alignment(horizontal='center')
+        )
 
         current_row += 1
         return current_row

--- a/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
+++ b/metrics_utility/automation_controller_billing/report_saver/report_saver_s3.py
@@ -31,7 +31,7 @@ class ReportSaverS3:
         Returns:
             True if at least one object is found at the destination key.
         """
-        return len([file for file in self.s3_handler.list_files(self.report_spreadsheet_destination_path)]) > 0
+        return len(list(self.s3_handler.list_files(self.report_spreadsheet_destination_path))) > 0
 
     def save(self, report_spreadsheet):
         """Save the openpyxl Workbook to a temporary file and upload it to S3.

--- a/metrics_utility/base/package.py
+++ b/metrics_utility/base/package.py
@@ -57,7 +57,7 @@ class Package:
         self.total_data_size = 0
 
     @classmethod
-    def max_data_size(cls):
+    def get_max_data_size(cls):
         return cls.MAX_DATA_SIZE
 
     def add_collection(self, collection):
@@ -83,7 +83,7 @@ class Package:
         pass
 
     def has_free_space(self, requested_size):
-        return self.total_data_size + requested_size <= self.max_data_size()
+        return self.total_data_size + requested_size <= self.get_max_data_size()
 
     def is_shipping_configured(self):
         if not self.tar_path:

--- a/metrics_utility/dataframe_schema.py
+++ b/metrics_utility/dataframe_schema.py
@@ -1,0 +1,55 @@
+from metrics_utility.metric_utils import (
+    JOB_HOST_SUMMARY_CAST_TYPES,
+    JOB_HOST_SUMMARY_DATA_COLUMNS,
+    JOB_HOST_SUMMARY_INDEX_COLUMNS,
+    JOB_HOST_SUMMARY_OPERATIONS,
+)
+
+
+class DataframeSchemaMixin:
+    """Default stub implementations for dataframe schema methods.
+
+    Subclasses are expected to override these to return the actual schema
+    for their specific data type.
+    """
+
+    @staticmethod
+    def cast_types():
+        return {}
+
+    @staticmethod
+    def data_columns():
+        return []
+
+    @staticmethod
+    def operations():
+        return {}
+
+    @staticmethod
+    def unique_index_columns():
+        return []
+
+
+class JobHostSummarySchema(DataframeSchemaMixin):
+    """Shared schema for job host summary dataframes.
+
+    Used by both DataframeJobhostSummaryUsage (billing engine) and
+    DataframeJobHostSummary (traditional library) to avoid duplicating
+    the identical static schema definitions.
+    """
+
+    @staticmethod
+    def unique_index_columns():
+        return JOB_HOST_SUMMARY_INDEX_COLUMNS
+
+    @staticmethod
+    def data_columns():
+        return JOB_HOST_SUMMARY_DATA_COLUMNS
+
+    @staticmethod
+    def cast_types():
+        return JOB_HOST_SUMMARY_CAST_TYPES
+
+    @staticmethod
+    def operations():
+        return JOB_HOST_SUMMARY_OPERATIONS

--- a/metrics_utility/dataframe_schema.py
+++ b/metrics_utility/dataframe_schema.py
@@ -40,16 +40,16 @@ class JobHostSummarySchema(DataframeSchemaMixin):
 
     @staticmethod
     def unique_index_columns():
-        return JOB_HOST_SUMMARY_INDEX_COLUMNS
+        return list(JOB_HOST_SUMMARY_INDEX_COLUMNS)
 
     @staticmethod
     def data_columns():
-        return JOB_HOST_SUMMARY_DATA_COLUMNS
+        return list(JOB_HOST_SUMMARY_DATA_COLUMNS)
 
     @staticmethod
     def cast_types():
-        return JOB_HOST_SUMMARY_CAST_TYPES
+        return dict(JOB_HOST_SUMMARY_CAST_TYPES)
 
     @staticmethod
     def operations():
-        return JOB_HOST_SUMMARY_OPERATIONS
+        return dict(JOB_HOST_SUMMARY_OPERATIONS)

--- a/metrics_utility/library/collectors/controller/main_jobevent_service.py
+++ b/metrics_utility/library/collectors/controller/main_jobevent_service.py
@@ -31,7 +31,7 @@ def main_jobevent_service(*, db=None, since=None, until=None, output=DataframeOu
     # We are loading the finished jobs then we are filtering
     # for the job_created, this cannot be done by simple joins because
     # job_created is partitioned and partitions pruning dont work with joins
-    job_ids_set = set(job_id for job_id, _ in jobs)
+    job_ids_set = {job_id for job_id, _ in jobs}
 
     # Extract unique hour boundaries from job_created timestamps
     # This reduces potentially 100K timestamps down to ~100-1000 hourly ranges

--- a/metrics_utility/library/collectors/others/total_workers_vcpu.py
+++ b/metrics_utility/library/collectors/others/total_workers_vcpu.py
@@ -180,11 +180,11 @@ class PrometheusClient:
         """
         response = self.session.get(url, params=params, timeout=self.timeout)
         if response.status_code != 200:
-            raise Exception(f'HTTP error {response.status_code}: {response.text}')
+            raise RuntimeError(f'HTTP error {response.status_code}: {response.text}')
 
         data = response.json()
         if data.get('status') != 'success':
-            raise Exception(f'Prometheus API error: {data.get("error", "Unknown error")}')
+            raise RuntimeError(f'Prometheus API error: {data.get("error", "Unknown error")}')
 
         return data
 

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -46,7 +46,7 @@ class DictOutput:
             return None
 
         if type(data) is not dict:
-            raise Exception('data must be a dict, or None')
+            raise TypeError('data must be a dict, or None')
 
         return data
 
@@ -86,7 +86,7 @@ class CollectionOutput(DictOutput):
             return None
 
         if type(filenames) is not list:
-            raise Exception('filenames must be a list, or None')
+            raise TypeError('filenames must be a list, or None')
 
         return filenames
 

--- a/metrics_utility/library/dataframes/base_dataframe.py
+++ b/metrics_utility/library/dataframes/base_dataframe.py
@@ -3,7 +3,6 @@
 import pandas as pd
 
 
-# f = path or file-like
 def from_csv(f):
     """Read a CSV file (path or file-like) into a pandas DataFrame.
 
@@ -193,8 +192,6 @@ class BaseDataframe:
         """
         return df.reset_index()
 
-    # build_dataframe, where batches=iter_batches()
-    # FIXME: cli only?
     def from_tarballs(self, batches):
         """Process an iterable of raw batches and build the accumulated rollup.
 

--- a/metrics_utility/library/dataframes/base_traditional.py
+++ b/metrics_utility/library/dataframes/base_traditional.py
@@ -7,12 +7,13 @@ from itertools import chain
 
 import pandas as pd
 
+from metrics_utility.dataframe_schema import DataframeSchemaMixin
 from metrics_utility.library.dataframes.base_dataframe import BaseDataframe
 
 
 # a dataframe class with logic for merges based on lists of indexes and merge operations
 # used by DataframeMainJobevent, DataframeMainHost and DataframeJobHostSummary
-class BaseTraditional(BaseDataframe):
+class BaseTraditional(BaseDataframe, DataframeSchemaMixin):
     """Dataframe base class with outer-join merge logic and hostname deduplication.
 
     Used by :class:`DataframeJobHostSummary`, ``DataframeMainHost``, and
@@ -119,22 +120,6 @@ class BaseTraditional(BaseDataframe):
         rollup = self.summarize_merged_dataframes(rollup, self.data_columns(), operations=self.operations())
         rollup = self.cast_dataframe(rollup)
         return rollup
-
-    @staticmethod
-    def cast_types():
-        return {}
-
-    @staticmethod
-    def data_columns():
-        return []
-
-    @staticmethod
-    def operations():
-        return {}
-
-    @staticmethod
-    def unique_index_columns():
-        return []
 
 
 def combine_json(json1, json2):

--- a/metrics_utility/library/dataframes/base_traditional.py
+++ b/metrics_utility/library/dataframes/base_traditional.py
@@ -122,22 +122,18 @@ class BaseTraditional(BaseDataframe):
 
     @staticmethod
     def cast_types():
-        # Subclasses must override this to return a dict of column-to-dtype mappings.
         return {}
 
     @staticmethod
     def data_columns():
-        # Subclasses must override this to return a list of data column names.
         return []
 
     @staticmethod
     def operations():
-        # Subclasses must override this to return a dict of column merge operations.
         return {}
 
     @staticmethod
     def unique_index_columns():
-        # Subclasses must override this to return a list of index column names.
         return []
 
 

--- a/metrics_utility/library/dataframes/base_traditional.py
+++ b/metrics_utility/library/dataframes/base_traditional.py
@@ -95,11 +95,11 @@ class BaseTraditional(BaseDataframe):
             elif operations.get(col) == 'max':
                 df[col] = df[[f'{col}_x', f'{col}_y']].max(axis=1)
             elif operations.get(col) == 'combine_set':
-                df[col] = df.apply(lambda row: combine_set(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_set(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             elif operations.get(col) == 'combine_json':
-                df[col] = df.apply(lambda row: combine_json(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_json(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             elif operations.get(col) == 'combine_json_values':
-                df[col] = df.apply(lambda row: combine_json_values(row.get(f'{col}_x'), row.get(f'{col}_y')), axis=1)
+                df[col] = df.apply(lambda row, c=col: combine_json_values(row.get(f'{c}_x'), row.get(f'{c}_y')), axis=1)
             else:
                 df[col] = df[[f'{col}_x', f'{col}_y']].sum(axis=1)
             del df[f'{col}_x']
@@ -115,26 +115,30 @@ class BaseTraditional(BaseDataframe):
         if rollup is None:
             return new_group
 
-        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer')
+        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='many_to_many')
         rollup = self.summarize_merged_dataframes(rollup, self.data_columns(), operations=self.operations())
         rollup = self.cast_dataframe(rollup)
         return rollup
 
     @staticmethod
     def cast_types():
-        pass
+        # Subclasses must override this to return a dict of column-to-dtype mappings.
+        return {}
 
     @staticmethod
     def data_columns():
-        pass
+        # Subclasses must override this to return a list of data column names.
+        return []
 
     @staticmethod
     def operations():
-        pass
+        # Subclasses must override this to return a dict of column merge operations.
+        return {}
 
     @staticmethod
     def unique_index_columns():
-        pass
+        # Subclasses must override this to return a list of index column names.
+        return []
 
 
 def combine_json(json1, json2):

--- a/metrics_utility/library/dataframes/base_traditional.py
+++ b/metrics_utility/library/dataframes/base_traditional.py
@@ -116,7 +116,7 @@ class BaseTraditional(BaseDataframe, DataframeSchemaMixin):
         if rollup is None:
             return new_group
 
-        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='many_to_many')
+        rollup = pd.merge(rollup.loc[:,], new_group.loc[:,], on=self.unique_index_columns(), how='outer', validate='one_to_one')
         rollup = self.summarize_merged_dataframes(rollup, self.data_columns(), operations=self.operations())
         rollup = self.cast_dataframe(rollup)
         return rollup

--- a/metrics_utility/library/dataframes/job_host_summary.py
+++ b/metrics_utility/library/dataframes/job_host_summary.py
@@ -10,7 +10,15 @@ from metrics_utility.library.dataframes.base_traditional import (
     merge_sets,
     parse_json_array,
 )
-from metrics_utility.metric_utils import DATETIME64_NS, DIRECT, INDIRECT, MANAGED_NODE_TYPES
+from metrics_utility.metric_utils import (
+    DIRECT,
+    INDIRECT,
+    JOB_HOST_SUMMARY_CAST_TYPES,
+    JOB_HOST_SUMMARY_DATA_COLUMNS,
+    JOB_HOST_SUMMARY_INDEX_COLUMNS,
+    JOB_HOST_SUMMARY_OPERATIONS,
+    MANAGED_NODE_TYPES,
+)
 
 
 class DataframeJobHostSummary(BaseTraditional):
@@ -119,48 +127,19 @@ class DataframeJobHostSummary(BaseTraditional):
 
     @staticmethod
     def unique_index_columns():
-        return ['organization_name', 'job_template_name', 'host_name', 'original_host_name', 'install_uuid', 'job_remote_id']
+        return JOB_HOST_SUMMARY_INDEX_COLUMNS
 
     @staticmethod
     def data_columns():
-        return [
-            'host_runs',
-            'task_runs',
-            'first_automation',
-            'last_automation',
-            'job_created',
-            'managed_node_type',
-            'managed_node_types_set',
-            'canonical_facts',
-            'facts',
-            'events',
-            'host_names_before_dedup',
-        ]
+        return JOB_HOST_SUMMARY_DATA_COLUMNS
 
     @staticmethod
     def cast_types():
-        return {
-            'task_runs': int,
-            'host_runs': int,
-            'managed_node_type': int,
-            'first_automation': DATETIME64_NS,
-            'last_automation': DATETIME64_NS,
-            'job_created': DATETIME64_NS,
-        }
+        return JOB_HOST_SUMMARY_CAST_TYPES
 
     @staticmethod
     def operations():
-        return {
-            'first_automation': 'min',
-            'last_automation': 'max',
-            'job_created': 'max',
-            'managed_node_type': 'min',
-            'managed_node_types_set': 'combine_set',
-            'events': 'combine_set',
-            'canonical_facts': 'combine_json_values',
-            'facts': 'combine_json_values',
-            'host_names_before_dedup': 'combine_set',
-        }
+        return JOB_HOST_SUMMARY_OPERATIONS
 
     def dedup(self, dataframe, hostname_mapping=None, scope_dataframe=None, deduplicator=None):
         """

--- a/metrics_utility/library/dataframes/job_host_summary.py
+++ b/metrics_utility/library/dataframes/job_host_summary.py
@@ -99,8 +99,6 @@ class DataframeJobHostSummary(BaseTraditional):
             job_created=('job_created', 'max'),
             managed_node_type=('managed_node_type', 'min'),
             managed_node_types_set=('managed_node_type_string', set),
-            # TODO: optimize the aggregation to keep less rows around
-            # job_ids=('inventory_name', set),
             events=('events', merge_arrays),
             canonical_facts=('canonical_facts', merge_json_sets),
             facts=('facts', merge_json_sets),
@@ -181,7 +179,6 @@ class DataframeJobHostSummary(BaseTraditional):
             return dataframe
 
         # Enrich direct managed nodes with canonical facts and facts from scope data when experimental deduplication is enabled
-        # FIXME: dedup logic should NOT depend on deduplicator choice this way, just on is not None
         if deduplicator == 'ccsp-experimental' and scope_dataframe is not None and not scope_dataframe.empty:
             # Create a mapping from host_name to canonical_facts and facts
             if 'canonical_facts' in scope_dataframe.columns and 'facts' in scope_dataframe.columns:

--- a/metrics_utility/library/dataframes/job_host_summary.py
+++ b/metrics_utility/library/dataframes/job_host_summary.py
@@ -15,6 +15,7 @@ from metrics_utility.library.dataframes.base_traditional import (
 DIRECT = 0
 INDIRECT = 1
 MANAGED_NODE_TYPES = {DIRECT: 'DIRECT', INDIRECT: 'INDIRECT'}
+DATETIME64_NS = 'datetime64[ns]'
 
 
 class DataframeJobHostSummary(BaseTraditional):
@@ -149,9 +150,9 @@ class DataframeJobHostSummary(BaseTraditional):
             'task_runs': int,
             'host_runs': int,
             'managed_node_type': int,
-            'first_automation': 'datetime64[ns]',
-            'last_automation': 'datetime64[ns]',
-            'job_created': 'datetime64[ns]',
+            'first_automation': DATETIME64_NS,
+            'last_automation': DATETIME64_NS,
+            'job_created': DATETIME64_NS,
         }
 
     @staticmethod

--- a/metrics_utility/library/dataframes/job_host_summary.py
+++ b/metrics_utility/library/dataframes/job_host_summary.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 
+from metrics_utility.dataframe_schema import JobHostSummarySchema
 from metrics_utility.library.dataframes.base_traditional import (
     BaseTraditional,
     merge_arrays,
@@ -10,18 +11,10 @@ from metrics_utility.library.dataframes.base_traditional import (
     merge_sets,
     parse_json_array,
 )
-from metrics_utility.metric_utils import (
-    DIRECT,
-    INDIRECT,
-    JOB_HOST_SUMMARY_CAST_TYPES,
-    JOB_HOST_SUMMARY_DATA_COLUMNS,
-    JOB_HOST_SUMMARY_INDEX_COLUMNS,
-    JOB_HOST_SUMMARY_OPERATIONS,
-    MANAGED_NODE_TYPES,
-)
+from metrics_utility.metric_utils import DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
-class DataframeJobHostSummary(BaseTraditional):
+class DataframeJobHostSummary(JobHostSummarySchema, BaseTraditional):
     """Aggregated job-host-summary dataframe used by the library-layer CCSP report path.
 
     Processes both direct managed node (``job_host_summary``) and indirect
@@ -124,22 +117,6 @@ class DataframeJobHostSummary(BaseTraditional):
             facts=('facts', merge_setdicts),
             host_names_before_dedup=('host_names_before_dedup', merge_sets),
         )
-
-    @staticmethod
-    def unique_index_columns():
-        return JOB_HOST_SUMMARY_INDEX_COLUMNS
-
-    @staticmethod
-    def data_columns():
-        return JOB_HOST_SUMMARY_DATA_COLUMNS
-
-    @staticmethod
-    def cast_types():
-        return JOB_HOST_SUMMARY_CAST_TYPES
-
-    @staticmethod
-    def operations():
-        return JOB_HOST_SUMMARY_OPERATIONS
 
     def dedup(self, dataframe, hostname_mapping=None, scope_dataframe=None, deduplicator=None):
         """

--- a/metrics_utility/library/dataframes/job_host_summary.py
+++ b/metrics_utility/library/dataframes/job_host_summary.py
@@ -10,12 +10,7 @@ from metrics_utility.library.dataframes.base_traditional import (
     merge_sets,
     parse_json_array,
 )
-
-
-DIRECT = 0
-INDIRECT = 1
-MANAGED_NODE_TYPES = {DIRECT: 'DIRECT', INDIRECT: 'INDIRECT'}
-DATETIME64_NS = 'datetime64[ns]'
+from metrics_utility.metric_utils import DATETIME64_NS, DIRECT, INDIRECT, MANAGED_NODE_TYPES
 
 
 class DataframeJobHostSummary(BaseTraditional):

--- a/metrics_utility/library/extractors.py
+++ b/metrics_utility/library/extractors.py
@@ -21,11 +21,11 @@ class ExtractorTarballs:
     def __init__(self):
         log('library.extractors ExtractorTarballs.__init__')
 
-    def extract(self, local, only=None):
+    def extract(self, _local, only=None):
         """Yield fake CSV objects based on *only*.
 
         Args:
-            local: Unused local path parameter.
+            _local: Unused local path parameter.
             only: A filename string, list of filenames, or None (yields a default).
 
         Yields:

--- a/metrics_utility/library/storage/crc.py
+++ b/metrics_utility/library/storage/crc.py
@@ -74,7 +74,7 @@ class Base:
 
         # Accept 2XX status_codes
         if response.status_code >= 300:
-            raise Exception(f'{self.__class__.__name__}: Upload failed with status {response.status_code}: {response.text}')
+            raise RuntimeError(f'{self.__class__.__name__}: Upload failed with status {response.status_code}: {response.text}')
 
 
 class StorageCRC(Base):
@@ -88,10 +88,10 @@ class StorageCRC(Base):
         self.client_secret = settings.get('client_secret')
 
         if not self.client_id:
-            raise Exception('StorageCRC: client_id not set')
+            raise ValueError('StorageCRC: client_id not set')
 
         if not self.client_secret:
-            raise Exception('StorageCRC: client_secret not set')
+            raise ValueError('StorageCRC: client_secret not set')
 
     def _bearer(self):
         """Obtain an OAuth2 bearer token from the SSO endpoint.

--- a/metrics_utility/library/storage/directory.py
+++ b/metrics_utility/library/storage/directory.py
@@ -25,7 +25,7 @@ class StorageDirectory:
         self.base_path = settings.get('base_path')
 
         if not self.base_path:
-            raise Exception('StorageDirectory: base_path not set')
+            raise ValueError('StorageDirectory: base_path not set')
 
     # FIXME: used by ExtractorDirectory for now, replace with glob
     def list_files(self, relative_prefix):

--- a/metrics_utility/library/storage/s3.py
+++ b/metrics_utility/library/storage/s3.py
@@ -31,7 +31,7 @@ class StorageS3:
         self.secret_key = settings.get('secret_key')
 
         if not self.bucket:
-            raise Exception('StorageS3: bucket not set')
+            raise ValueError('StorageS3: bucket not set')
 
         self._client = None
 

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -75,7 +75,7 @@ class StorageSegment:
 
         if data is not None and not isinstance(data, dict):
             msg = f'Data is not a dictionary, got {type(data).__name__}'
-            raise Exception(msg)
+            raise TypeError(msg)
 
         for key, value in data.items():
             if isinstance(value, dict):
@@ -122,7 +122,7 @@ class StorageSegment:
         chunks = []
         if filename or fileobj or dict is None:
             msg = 'StorageSegment: filename= & fileobj= not supported, use dict='
-            raise Exception(msg)
+            raise ValueError(msg)
 
         # Check if segment is available and configured
         if not SEGMENT_AVAILABLE:

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -120,9 +120,10 @@ class StorageSegment:
         per-message size limit.
         """
         chunks = []
-        if filename or fileobj or dict is None:
-            msg = 'StorageSegment: filename= & fileobj= not supported, use dict='
-            raise ValueError(msg)
+        if filename or fileobj:
+            raise ValueError('StorageSegment: filename= & fileobj= not supported, use dict=')
+        if dict is None:
+            raise ValueError('StorageSegment: dict= argument is required')
 
         # Check if segment is available and configured
         if not SEGMENT_AVAILABLE:

--- a/metrics_utility/library/storage/util.py
+++ b/metrics_utility/library/storage/util.py
@@ -9,10 +9,6 @@ from contextlib import contextmanager
 
 
 # dict_to_json_file - create a temporary file with the input dict stringified to json
-# Example:
-
-# with dict_to_json_file({'foo': 'bar'}) as filename:
-#     storage.put('collected.json', filename=filename)
 
 
 @contextmanager

--- a/metrics_utility/library/utils.py
+++ b/metrics_utility/library/utils.py
@@ -41,26 +41,12 @@ def tempdir(prefix=None, cleanup=True):
             os.chdir(original_dir)
 
 
-def last_gather(db=None, key=None):
-    """Return the last-gather timestamp for *key* (stub — always returns None).
-
-    Args:
-        db: Unused database connection parameter.
-        key: Unused collector key parameter.
-
-    Returns:
-        None (not yet implemented).
-    """
+def last_gather(**_kwargs):
+    """Return the last-gather timestamp (stub — always returns None)."""
     log('library.utils last_gather')
     return None
 
 
-def save_last_gather(db=None, key=None, value=None):
-    """Persist the last-gather timestamp for *key* (stub — no-op).
-
-    Args:
-        db: Unused database connection parameter.
-        key: Unused collector key parameter.
-        value: Unused timestamp value parameter.
-    """
+def save_last_gather(**_kwargs):
+    """Persist the last-gather timestamp (stub — no-op)."""
     log('library.utils save_last_gather')

--- a/metrics_utility/management_utility.py
+++ b/metrics_utility/management_utility.py
@@ -111,7 +111,7 @@ class ManagementUtility(management.ManagementUtility):
         """
         commands = {}
         path = os.path.join(os.path.dirname(__file__), 'management')
-        commands.update({name: 'metrics_utility' for name in management.find_commands(path)})
+        commands.update(dict.fromkeys(management.find_commands(path), 'metrics_utility'))
         return commands
 
     def run_subcommand(self, subcommand, argv):

--- a/metrics_utility/metric_utils.py
+++ b/metrics_utility/metric_utils.py
@@ -9,3 +9,5 @@ INDIRECT = 1
 
 MANAGED_NODE_TYPES = {DIRECT: 'DIRECT', INDIRECT: 'INDIRECT'}
 """Mapping from integer node-type codes to human-readable string labels."""
+
+DATETIME64_NS = 'datetime64[ns]'

--- a/metrics_utility/metric_utils.py
+++ b/metrics_utility/metric_utils.py
@@ -11,3 +11,49 @@ MANAGED_NODE_TYPES = {DIRECT: 'DIRECT', INDIRECT: 'INDIRECT'}
 """Mapping from integer node-type codes to human-readable string labels."""
 
 DATETIME64_NS = 'datetime64[ns]'
+
+# Shared schema constants for job host summary dataframes (used by both
+# DataframeJobhostSummaryUsage and DataframeJobHostSummary)
+JOB_HOST_SUMMARY_INDEX_COLUMNS = [
+    'organization_name',
+    'job_template_name',
+    'host_name',
+    'original_host_name',
+    'install_uuid',
+    'job_remote_id',
+]
+
+JOB_HOST_SUMMARY_DATA_COLUMNS = [
+    'host_runs',
+    'task_runs',
+    'first_automation',
+    'last_automation',
+    'job_created',
+    'managed_node_type',
+    'managed_node_types_set',
+    'canonical_facts',
+    'facts',
+    'events',
+    'host_names_before_dedup',
+]
+
+JOB_HOST_SUMMARY_CAST_TYPES = {
+    'task_runs': int,
+    'host_runs': int,
+    'managed_node_type': int,
+    'first_automation': DATETIME64_NS,
+    'last_automation': DATETIME64_NS,
+    'job_created': DATETIME64_NS,
+}
+
+JOB_HOST_SUMMARY_OPERATIONS = {
+    'first_automation': 'min',
+    'last_automation': 'max',
+    'job_created': 'max',
+    'managed_node_type': 'min',
+    'managed_node_types_set': 'combine_set',
+    'events': 'combine_set',
+    'canonical_facts': 'combine_json_values',
+    'facts': 'combine_json_values',
+    'host_names_before_dedup': 'combine_set',
+}

--- a/metrics_utility/test/base/functional/helpers.py
+++ b/metrics_utility/test/base/functional/helpers.py
@@ -10,35 +10,13 @@ from metrics_utility.library import CsvFileSplitter
 TIMESTAMP_CSV_LINE_LENGTH = 40
 
 
-def trivial_slicing(key, last_gather, since, until, **kwargs):
-    """Return a single slice covering the entire [since, until) window.
-
-    Args:
-        key: Unused collector key.
-        last_gather: Unused last-gather datetime.
-        since: Start of the collection window.
-        until: End of the collection window.
-        **kwargs: Ignored extra keyword arguments.
-
-    Returns:
-        List with one ``(since, until)`` tuple.
-    """
+def trivial_slicing(_key, _last_gather, since, until, **kwargs):
+    """Return a single slice covering the entire [since, until) window."""
     return [(since, until)]
 
 
-def one_day_slicing(key, last_gather, since, until, **kwargs):
-    """Yield one-day time slices between *since* and *until*.
-
-    Args:
-        key: Unused collector key.
-        last_gather: Unused last-gather datetime.
-        since: Start of the collection window (truncated to midnight).
-        until: End of the collection window (truncated to midnight).
-        **kwargs: Ignored extra keyword arguments.
-
-    Yields:
-        ``(start, end)`` tuples spanning one calendar day each.
-    """
+def one_day_slicing(_key, _last_gather, since, until, **kwargs):
+    """Yield one-day time slices between *since* and *until*."""
     since = since.replace(hour=0, minute=0, second=0, microsecond=0)
     until = until.replace(hour=0, minute=0, second=0, microsecond=0)
     start, end = since, None

--- a/metrics_utility/test/base/functional/test_gathering.py
+++ b/metrics_utility/test/base/functional/test_gathering.py
@@ -43,8 +43,8 @@ def test_json_collections(collector):
             files[member.name] = archive.extractfile(member)
 
         assert_common_files(files)
-        assert './json_collection_1.json' in files.keys()
-        assert './json_collection_2.json' in files.keys()
+        assert './json_collection_1.json' in files
+        assert './json_collection_2.json' in files
 
         assert json.loads(files['./config.json'].read()) == {'version': '1.0'}
         assert json.loads(files['./json_collection_1.json'].read()) == {'json1': 'True'}
@@ -64,9 +64,9 @@ def test_small_csvs(collector):
             files[member.name] = archive.extractfile(member)
 
         assert_common_files(files)
-        assert './csv_collection_1.csv' in files.keys()
-        assert './csv_collection_2.csv' in files.keys()
-        assert './csv_collection_3.csv' in files.keys()
+        assert './csv_collection_1.csv' in files
+        assert './csv_collection_2.csv' in files
+        assert './csv_collection_3.csv' in files
 
         # length defined by @registered function
         assert len(files['./csv_collection_1.csv'].read()) == 100
@@ -97,13 +97,13 @@ def test_jsons_with_csvs_with_slicing(collector):
 
             assert_common_files(files)
             if i == 0:
-                assert './json_collection_1.json' in files.keys()
-                assert './json_collection_2.json' in files.keys()
-                assert './csv_slicing_1.csv' in files.keys()
+                assert './json_collection_1.json' in files
+                assert './json_collection_2.json' in files
+                assert './csv_slicing_1.csv' in files
             if i == 1:
-                assert './csv_slicing_2.csv' in files.keys()
+                assert './csv_slicing_2.csv' in files
             if i == 2:
-                assert './csv_slicing_2.csv' in files.keys()
+                assert './csv_slicing_2.csv' in files
 
 
 def test_one_csv_collection_splitted_by_size(collector):
@@ -119,7 +119,7 @@ def test_one_csv_collection_splitted_by_size(collector):
 
             assert_common_files(files)
             assert len(files.keys()) == 1 + _common_files_count()
-            assert './big_table.csv' in files.keys()
+            assert './big_table.csv' in files
             assert len(files['./big_table.csv'].read()) == 1000
 
     collector._gather_cleanup()
@@ -141,15 +141,15 @@ def test_multiple_collections_multiple_tarballs(mocker, collector):
             assert_common_files(files)
             if i == 0:
                 assert len(files.keys()) == 2 + _common_files_count()
-                assert './big_table_2.csv' in files.keys()
-                assert './csv_collection_1.csv' in files.keys()
+                assert './big_table_2.csv' in files
+                assert './csv_collection_1.csv' in files
             elif i == 1:
                 assert len(files.keys()) == 2 + _common_files_count()
-                assert './big_table_2.csv' in files.keys()
-                assert './csv_collection_2.csv' in files.keys()
+                assert './big_table_2.csv' in files
+                assert './csv_collection_2.csv' in files
             elif i == 2:
                 assert len(files.keys()) == 1 + _common_files_count()
-                assert './big_table_2.csv' in files.keys()
+                assert './big_table_2.csv' in files
 
     collector._gather_cleanup()
 
@@ -173,51 +173,51 @@ def test_multiple_collections_and_distributions(collector):
 
             assert_common_files(files)
             if i == 0:
-                assert './simple_json1.json' in files.keys()
+                assert './simple_json1.json' in files
             else:
-                assert './simple_json1.json' not in files.keys()
+                assert './simple_json1.json' not in files
 
             # CSVs with no slicing start at index 0
             if 0 <= i <= 1:
-                assert './csv_no_slicing_1-2x.csv' in files.keys()
+                assert './csv_no_slicing_1-2x.csv' in files
             else:
-                assert './csv_no_slicing_1-2x.csv' not in files.keys()
+                assert './csv_no_slicing_1-2x.csv' not in files
 
             if i == 0:
-                assert './csv_no_slicing_2-1x.csv' in files.keys()
+                assert './csv_no_slicing_2-1x.csv' in files
             else:
-                assert './csv_no_slicing_2-1x.csv' not in files.keys()
+                assert './csv_no_slicing_2-1x.csv' not in files
 
             if 0 <= i <= 9:
-                assert './csv_no_slicing_3-10x.csv' in files.keys()
+                assert './csv_no_slicing_3-10x.csv' in files
             else:
-                assert './csv_no_slicing_3-10x.csv' not in files.keys()
+                assert './csv_no_slicing_3-10x.csv' not in files
 
             if 0 <= i <= 11:
-                assert './csv_no_slicing_4-12x.csv' in files.keys()
+                assert './csv_no_slicing_4-12x.csv' in files
             else:
-                assert './csv_no_slicing_4-12x.csv' not in files.keys()
+                assert './csv_no_slicing_4-12x.csv' not in files
 
             # CSVs with slicing start after index next to previous slice
             if 0 <= i <= 4:
-                assert './csv_with_slicing_1-5x.csv' in files.keys()
+                assert './csv_with_slicing_1-5x.csv' in files
             else:
-                assert './csv_with_slicing_1-5x.csv' not in files.keys()
+                assert './csv_with_slicing_1-5x.csv' not in files
 
             if 5 <= i <= 7:
-                assert './csv_with_slicing_2-3x.csv' in files.keys()
+                assert './csv_with_slicing_2-3x.csv' in files
             else:
-                assert './csv_with_slicing_2-3x.csv' not in files.keys()
+                assert './csv_with_slicing_2-3x.csv' not in files
 
             if 8 <= i <= 9:
-                assert './csv_with_slicing_3-2x.csv' in files.keys()
+                assert './csv_with_slicing_3-2x.csv' in files
             else:
-                assert './csv_with_slicing_3-2x.csv' not in files.keys()
+                assert './csv_with_slicing_3-2x.csv' not in files
 
             if 10 <= i <= 12:
-                assert './csv_with_slicing_4-3x.csv' in files.keys()
+                assert './csv_with_slicing_4-3x.csv' in files
             else:
-                assert './csv_with_slicing_4-3x.csv' not in files.keys()
+                assert './csv_with_slicing_4-3x.csv' not in files
 
 
 def test_manifest_and_status(collector):

--- a/metrics_utility/test/base/functional/test_slicing.py
+++ b/metrics_utility/test/base/functional/test_slicing.py
@@ -47,7 +47,7 @@ def test_slices_by_date(collector):
                 files[member.name] = archive.extractfile(member)
 
             assert_common_files(files)
-            assert './csv_one_day_slicing_1.csv' in files.keys()
+            assert './csv_one_day_slicing_1.csv' in files
 
             lines = files['./csv_one_day_slicing_1.csv'].readlines()
             _header = lines.pop(0)

--- a/metrics_utility/test/base/test_package.py
+++ b/metrics_utility/test/base/test_package.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+
+from metrics_utility.base.package import Package
+
+
+def test_get_max_data_size_classmethod():
+    assert Package.get_max_data_size() == Package.MAX_DATA_SIZE
+    assert Package.get_max_data_size() == 200 * 1048576
+
+
+def test_has_free_space_within_limit():
+    pkg = MagicMock(spec=Package)
+    pkg.total_data_size = 100
+    pkg.get_max_data_size.return_value = 200
+    assert Package.has_free_space(pkg, 99) is True
+    assert Package.has_free_space(pkg, 100) is True  # exactly at limit
+
+
+def test_has_free_space_exceeds_limit():
+    pkg = MagicMock(spec=Package)
+    pkg.total_data_size = 100
+    pkg.get_max_data_size.return_value = 200
+    assert Package.has_free_space(pkg, 101) is False

--- a/metrics_utility/test/ccspv_reports/dedup/test_complex_CCSPv2_with_canonical_facts/test_complex_CCSPv2_with_canonical_facts.py
+++ b/metrics_utility/test/ccspv_reports/dedup/test_complex_CCSPv2_with_canonical_facts/test_complex_CCSPv2_with_canonical_facts.py
@@ -138,7 +138,7 @@ def transform_sheet_with_json_normalization(sheet_dict):
                     parsed = json.loads(value)
                     # Sort the parsed structure
                     sorted_row[key] = sort_json_fields(parsed)
-                except (json.JSONDecodeError, TypeError, ValueError):
+                except (TypeError, ValueError):
                     # Keep original value if not valid JSON
                     sorted_row[key] = value
             else:

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
@@ -44,7 +44,7 @@ def test_command(cleanup):
     try:
         # test workbook is openable with the lib we're creating it with
         workbook = openpyxl.load_workbook(filename=file_path)
-        assert workbook is not None
+        assert len(workbook.sheetnames) > 0
 
         sheet = pandas.read_excel(file_path, sheet_name='Managed nodes')
         assert len(transform_sheet(sheet.to_dict())) > 0

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSP_sanity_check.py
@@ -1,14 +1,8 @@
-import openpyxl
-import pandas
 import pytest
 
-from conftest import transform_sheet
-
-from metrics_utility.test.util import run_build_int
+from conftest import run_report_sanity_check
 
 
-# This test will run on all data, making sure we're backwards compatible and will generate all
-# sheets. Just checking the report generation doesn't fail
 env_vars = {
     'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
     'METRICS_UTILITY_SHIP_TARGET': 'directory',
@@ -21,33 +15,7 @@ file_path = './metrics_utility/test/test_data/reports/2025/03/CCSP-2024-02-20--2
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
-@pytest.mark.parametrize(
-    'cleanup',
-    [
-        file_path,
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize('cleanup', [file_path], indirect=True)
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
-
-    # Running a command python way, so we can work with debugger in the code
-    run_build_int(
-        env_vars,
-        {
-            'since': '2024-02-20',
-            'until': '2025-03-02',
-            'force': True,
-        },
-    )
-
-    try:
-        # test workbook is openable with the lib we're creating it with
-        workbook = openpyxl.load_workbook(filename=file_path)
-        assert len(workbook.sheetnames) > 0
-
-        sheet = pandas.read_excel(file_path, sheet_name='Managed nodes')
-        assert len(transform_sheet(sheet.to_dict())) > 0
-
-    finally:
-        workbook.close()
+    run_report_sanity_check(env_vars, file_path, since='2024-02-20', until='2025-03-02')

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
@@ -1,14 +1,8 @@
-import openpyxl
-import pandas
 import pytest
 
-from conftest import transform_sheet
-
-from metrics_utility.test.util import run_build_int
+from conftest import run_report_sanity_check
 
 
-# This test will run on all data, making sure we're backwards compatible and will generate all
-# sheets. Just checking the report generation doesn't fail
 env_vars = {
     'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
     'METRICS_UTILITY_SHIP_TARGET': 'directory',
@@ -21,33 +15,7 @@ file_path = './metrics_utility/test/test_data/reports/2025/07/CCSPv2-2025-02-25-
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
-@pytest.mark.parametrize(
-    'cleanup',
-    [
-        file_path,
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize('cleanup', [file_path], indirect=True)
 def test_command(cleanup):
     """Build xlsx report using build command and test its contents."""
-
-    # Running a command python way, so we can work with debugger in the code
-    run_build_int(
-        env_vars,
-        {
-            'since': '2025-02-25',
-            'until': '2025-07-16',
-            'force': True,
-        },
-    )
-
-    try:
-        # test workbook is openable with the lib we're creating it with
-        workbook = openpyxl.load_workbook(filename=file_path)
-        assert len(workbook.sheetnames) > 0
-
-        sheet = pandas.read_excel(file_path, sheet_name='Managed nodes')
-        assert len(transform_sheet(sheet.to_dict())) > 0
-
-    finally:
-        workbook.close()
+    run_report_sanity_check(env_vars, file_path, since='2025-02-25', until='2025-07-16')

--- a/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
+++ b/metrics_utility/test/ccspv_reports/test_complex_CCSPv2_sanity_check.py
@@ -44,7 +44,7 @@ def test_command(cleanup):
     try:
         # test workbook is openable with the lib we're creating it with
         workbook = openpyxl.load_workbook(filename=file_path)
-        assert workbook is not None
+        assert len(workbook.sheetnames) > 0
 
         sheet = pandas.read_excel(file_path, sheet_name='Managed nodes')
         assert len(transform_sheet(sheet.to_dict())) > 0

--- a/metrics_utility/test/ccspv_reports/test_empty_data_for_CCSP_and_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_empty_data_for_CCSP_and_CCSPv2.py
@@ -92,6 +92,6 @@ def test_empty_data(report, date_range, sheet, cleanup):
     if os.path.isfile(file_name):
         workbook = openpyxl.load_workbook(filename=file_name)
         try:
-            assert workbook is not None
+            assert len(workbook.sheetnames) > 0
         finally:
             workbook.close()

--- a/metrics_utility/test/ccspv_reports/test_invalid_data_for_CCSP_and_CCSPv2.py
+++ b/metrics_utility/test/ccspv_reports/test_invalid_data_for_CCSP_and_CCSPv2.py
@@ -99,7 +99,6 @@ def test_invalid_data_handling(report, date_range, sheet, cleanup):
     if os.path.isfile(file_name):
         workbook = openpyxl.load_workbook(filename=file_name)
         try:
-            assert workbook is not None
             # Verify that at least one sheet exists (even if data is invalid)
             assert len(workbook.sheetnames) > 0
         finally:

--- a/metrics_utility/test/conftest.py
+++ b/metrics_utility/test/conftest.py
@@ -204,3 +204,16 @@ def validate_cell(wb, sheet_name, address, value):
     """
     sheet = wb[sheet_name]
     assert sheet[address].value == value, f'Sheet: {sheet_name}, cell: {address}, expected value: {value}, actual value: {sheet[address].value}'
+
+
+def run_report_sanity_check(env_vars, file_path, since, until):
+    from metrics_utility.test.util import run_build_int
+
+    run_build_int(env_vars, {'since': since, 'until': until, 'force': True})
+    workbook = openpyxl.load_workbook(filename=file_path)
+    try:
+        assert len(workbook.sheetnames) > 0
+        sheet = pd.read_excel(file_path, sheet_name='Managed nodes')
+        assert len(transform_sheet(sheet.to_dict())) > 0
+    finally:
+        workbook.close()

--- a/metrics_utility/test/conftest.py
+++ b/metrics_utility/test/conftest.py
@@ -44,7 +44,7 @@ def setup_processed_dataframe(fixed_now):
     mock_batches = [{'host_metric': mock_df_for_batch_processed}]
 
     mock_extractor = MagicMock()
-    mock_extractor.iter_batches.return_value = (batch for batch in mock_batches)
+    mock_extractor.iter_batches.return_value = mock_batches
 
     db_host_metric_instance = DBDataframeHostMetric(
         extractor=mock_extractor,

--- a/metrics_utility/test/dedup/test_factory.py
+++ b/metrics_utility/test/dedup/test_factory.py
@@ -73,7 +73,6 @@ class TestDedupFactory:
         result = factory.create()
 
         assert isinstance(result, DedupRenewal)
-        # assert result.dataframes == mock_dataframes
         assert result.extra_params == base_extra_params
 
     def test_create_ccsp_deduplicator_explicit(self, mock_dataframes, base_extra_params):
@@ -96,7 +95,6 @@ class TestDedupFactory:
         result = factory.create()
 
         assert isinstance(result, DedupRenewal)
-        # assert result.dataframes == mock_dataframes
         assert result.extra_params == base_extra_params
 
     def test_create_ccsp_experimental_with_ccsp_report(self, mock_dataframes, base_extra_params):
@@ -166,7 +164,6 @@ class TestDedupFactory:
             result = factory.create()
 
             assert isinstance(result, expected_class)
-            # assert result.dataframes == mock_dataframes
             assert result.extra_params == base_extra_params
 
     def test_create_with_empty_extra_params(self, mock_dataframes):

--- a/metrics_utility/test/dedup/test_renewal_guidance.py
+++ b/metrics_utility/test/dedup/test_renewal_guidance.py
@@ -479,7 +479,7 @@ class TestDedupRenewal:
 
         dedup = DedupRenewal(mock_dataframes, base_extra_params)
 
-        test_set = {None, 'value1', 'value2', None}
+        test_set = {None, 'value1', 'value2'}
         result = ', '.join(sorted(filter(None, dedup.stringify(test_set).split(', '))))
 
         assert result == 'value1, value2'

--- a/metrics_utility/test/library/test_collectors_prometheus_client.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client.py
@@ -88,7 +88,7 @@ def test_query_with_time_param(mock_get):
 
 @patch('requests.Session.get')
 def test_query_http_error(mock_get):
-    """Test query handling of HTTP errors."""
+    """Test query handling of HTTP errors raises RuntimeError."""
     mock_response = Mock()
     mock_response.status_code = 500
     mock_response.text = 'Internal Server Error'
@@ -96,13 +96,13 @@ def test_query_http_error(mock_get):
 
     client = PrometheusClient(url='http://localhost:9090')
 
-    with pytest.raises(Exception, match='HTTP error 500'):
+    with pytest.raises(RuntimeError, match='HTTP error 500'):
         client.query('up')
 
 
 @patch('requests.Session.get')
 def test_query_prometheus_api_error(mock_get):
-    """Test query handling of Prometheus API errors."""
+    """Test query handling of Prometheus API errors raises RuntimeError."""
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {'status': 'error', 'error': 'Query timeout'}
@@ -110,7 +110,7 @@ def test_query_prometheus_api_error(mock_get):
 
     client = PrometheusClient(url='http://localhost:9090')
 
-    with pytest.raises(Exception, match='Prometheus API error'):
+    with pytest.raises(RuntimeError, match='Prometheus API error'):
         client.query('up')
 
 

--- a/metrics_utility/test/library/test_collectors_util.py
+++ b/metrics_utility/test/library/test_collectors_util.py
@@ -161,7 +161,7 @@ def test_dict_output_raises_type_error_for_non_dict():
         output.dict('not-a-dict')
 
 
-def test_collection_output_raises_type_error_for_non_list():
-    output = CollectionOutput(full_path='/tmp')
+def test_collection_output_raises_type_error_for_non_list(tmp_path):
+    output = CollectionOutput(full_path=str(tmp_path))
     with pytest.raises(TypeError, match='filenames must be a list'):
         output.files('not-a-list')

--- a/metrics_utility/test/library/test_collectors_util.py
+++ b/metrics_utility/test/library/test_collectors_util.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from metrics_utility.library.collectors.util import collector
+from metrics_utility.library.collectors.util import CollectionOutput, DictOutput, collector
 
 
 def test_collector_decorator_basic():
@@ -153,3 +153,15 @@ def test_collector_decorator_with_db_connection():
     assert result == [('row1',), ('row2',)]
     mock_db.cursor.assert_called_once()
     mock_cursor.execute.assert_called_once_with('SELECT * FROM test')
+
+
+def test_dict_output_raises_type_error_for_non_dict():
+    output = DictOutput()
+    with pytest.raises(TypeError, match='data must be a dict'):
+        output.dict('not-a-dict')
+
+
+def test_collection_output_raises_type_error_for_non_list():
+    output = CollectionOutput(full_path='/tmp')
+    with pytest.raises(TypeError, match='filenames must be a list'):
+        output.files('not-a-list')

--- a/metrics_utility/test/library/test_coverage_gaps.py
+++ b/metrics_utility/test/library/test_coverage_gaps.py
@@ -1,0 +1,85 @@
+"""Tests targeting specific uncovered lines from the Sonar-Issues PR."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
+from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import EventModulesAnonymizedRollup
+from metrics_utility.automation_controller_billing.package.package_crc import PackageCRC
+from metrics_utility.automation_controller_billing.report_saver.report_saver_s3 import ReportSaverS3
+from metrics_utility.library.storage.crc import StorageCRC
+from metrics_utility.management_utility import ManagementUtility
+
+
+# --- BaseAnonymizedRollup.base() ---
+
+
+def test_base_anonymized_rollup_base_returns_empty_dataframe():
+    rollup = BaseAnonymizedRollup(rollup_name='test')
+    result = rollup.base(pd.DataFrame({'col': [1, 2]}))
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+
+
+# --- ManagementUtility.get_commands() ---
+
+
+def test_management_utility_get_commands_returns_dict():
+    commands = ManagementUtility.get_commands()
+    assert isinstance(commands, dict)
+    assert all(v == 'metrics_utility' for v in commands.values())
+
+
+# --- ReportSaverS3.report_exist() ---
+
+
+def test_report_exist_returns_true_when_files_present():
+    saver = ReportSaverS3.__new__(ReportSaverS3)
+    saver.report_spreadsheet_destination_path = 'some/path'
+    saver.s3_handler = MagicMock()
+    saver.s3_handler.list_files.return_value = iter(['file1.xlsx'])
+    assert saver.report_exist() is True
+
+
+def test_report_exist_returns_false_when_no_files():
+    saver = ReportSaverS3.__new__(ReportSaverS3)
+    saver.report_spreadsheet_destination_path = 'some/path'
+    saver.s3_handler = MagicMock()
+    saver.s3_handler.list_files.return_value = iter([])
+    assert saver.report_exist() is False
+
+
+# --- StorageCRC (library/storage/crc.py) _put() RuntimeError ---
+
+
+def test_crc_put_raises_runtime_error_on_bad_status():
+    crc = StorageCRC(client_id='my-id', client_secret='my-secret')
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = 'Internal Server Error'
+    with patch.object(crc, '_bearer', return_value='fake-token'), patch.object(crc, '_session') as mock_session:
+        mock_session.return_value.post.return_value = mock_response
+        with pytest.raises(RuntimeError, match='Upload failed with status 500'):
+            crc._put(('artifact', b'data'))
+
+
+# --- EventModulesAnonymizedRollup._merge_single_item() host_ids branch ---
+
+
+def test_merge_single_item_sets_unique_hosts_total():
+    rollup = EventModulesAnonymizedRollup()
+    item = {'host_ids': ['host1', 'host2', 'host3'], 'total_count': 3}
+    result = rollup._merge_single_item(item, None)
+    assert result['unique_hosts_total'] == 3
+
+
+# --- PackageCRC.is_shipping_configured() super() delegation ---
+
+
+def test_package_crc_is_shipping_configured_returns_false_when_parent_returns_false():
+    pkg = MagicMock(spec=PackageCRC)
+    with patch('metrics_utility.base.Package.is_shipping_configured', return_value=False):
+        result = PackageCRC.is_shipping_configured(pkg)
+    assert result is False

--- a/metrics_utility/test/library/test_dataframe_stubs.py
+++ b/metrics_utility/test/library/test_dataframe_stubs.py
@@ -1,17 +1,38 @@
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+from metrics_utility.dataframe_schema import DataframeSchemaMixin, JobHostSummarySchema
 from metrics_utility.library.dataframes.base_traditional import BaseTraditional
+from metrics_utility.metric_utils import (
+    JOB_HOST_SUMMARY_CAST_TYPES,
+    JOB_HOST_SUMMARY_DATA_COLUMNS,
+    JOB_HOST_SUMMARY_INDEX_COLUMNS,
+    JOB_HOST_SUMMARY_OPERATIONS,
+)
 
 
-def test_base_engine_stub_methods():
+def test_dataframe_schema_mixin_stubs():
+    assert DataframeSchemaMixin.cast_types() == {}
+    assert DataframeSchemaMixin.data_columns() == []
+    assert DataframeSchemaMixin.operations() == {}
+    assert DataframeSchemaMixin.unique_index_columns() == []
+
+
+def test_job_host_summary_schema():
+    assert JobHostSummarySchema.unique_index_columns() == JOB_HOST_SUMMARY_INDEX_COLUMNS
+    assert JobHostSummarySchema.data_columns() == JOB_HOST_SUMMARY_DATA_COLUMNS
+    assert JobHostSummarySchema.cast_types() == JOB_HOST_SUMMARY_CAST_TYPES
+    assert JobHostSummarySchema.operations() == JOB_HOST_SUMMARY_OPERATIONS
+
+
+def test_base_engine_inherits_schema_mixin():
     base = Base(extractor=None, month=None, extra_params={})
     assert base.build_dataframe() is None
-    assert Base.unique_index_columns() == []
-    assert Base.data_columns() == []
     assert Base.cast_types() == {}
+    assert Base.data_columns() == []
     assert Base.operations() == {}
+    assert Base.unique_index_columns() == []
 
 
-def test_base_traditional_stub_methods():
+def test_base_traditional_inherits_schema_mixin():
     assert BaseTraditional.cast_types() == {}
     assert BaseTraditional.data_columns() == []
     assert BaseTraditional.operations() == {}

--- a/metrics_utility/test/library/test_dataframe_stubs.py
+++ b/metrics_utility/test/library/test_dataframe_stubs.py
@@ -1,0 +1,18 @@
+from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+from metrics_utility.library.dataframes.base_traditional import BaseTraditional
+
+
+def test_base_engine_stub_methods():
+    base = Base(extractor=None, month=None, extra_params={})
+    assert base.build_dataframe() is None
+    assert Base.unique_index_columns() == []
+    assert Base.data_columns() == []
+    assert Base.cast_types() == {}
+    assert Base.operations() == {}
+
+
+def test_base_traditional_stub_methods():
+    assert BaseTraditional.cast_types() == {}
+    assert BaseTraditional.data_columns() == []
+    assert BaseTraditional.operations() == {}
+    assert BaseTraditional.unique_index_columns() == []

--- a/metrics_utility/test/library/test_storage_crc.py
+++ b/metrics_utility/test/library/test_storage_crc.py
@@ -1,0 +1,13 @@
+import pytest
+
+from metrics_utility.library.storage.crc import StorageCRC
+
+
+def test_missing_client_id_raises_value_error():
+    with pytest.raises(ValueError, match='client_id not set'):
+        StorageCRC(client_secret='secret')
+
+
+def test_missing_client_secret_raises_value_error():
+    with pytest.raises(ValueError, match='client_secret not set'):
+        StorageCRC(client_id='my-id')

--- a/metrics_utility/test/library/test_storage_directory.py
+++ b/metrics_utility/test/library/test_storage_directory.py
@@ -113,3 +113,8 @@ def test_remove():
     storage = StorageDirectory(base_path=base_path)
     storage.remove(target_filename)
     assert storage.exists(target_filename) is False
+
+
+def test_missing_base_path_raises_value_error():
+    with pytest.raises(ValueError, match='base_path not set'):
+        StorageDirectory()

--- a/metrics_utility/test/library/test_storage_s3.py
+++ b/metrics_utility/test/library/test_storage_s3.py
@@ -87,3 +87,8 @@ def test_remove():
     storage = StorageS3(**s3_settings)
     storage.remove(s3_object_name)
     assert storage.exists(s3_object_name) is False
+
+
+def test_missing_bucket_raises_value_error():
+    with pytest.raises(ValueError, match='bucket not set'):
+        StorageS3()

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from metrics_utility.library.storage.segment import StorageSegment
 from metrics_utility.test.library.testing_data_for_segment import segment_data, segment_data_large
 
@@ -156,3 +158,15 @@ class TestStorageSegmentAvailable:
         assert mock_analytics.sync_mode is True
         assert mock_analytics.track.call_count == len(chunks)
         assert mock_analytics.flush.call_count == 1
+
+
+class TestStorageSegmentErrors:
+    def test_split_non_dict_raises_type_error(self):
+        storage = StorageSegment()
+        with pytest.raises(TypeError):
+            storage._split_into_chunks('not-a-dict', 100)
+
+    def test_put_without_dict_raises_value_error(self):
+        storage = StorageSegment()
+        with pytest.raises(ValueError, match='use dict='):
+            storage.put(artifact_name='test', filename='foo.json')

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -166,7 +166,12 @@ class TestStorageSegmentErrors:
         with pytest.raises(TypeError):
             storage._split_into_chunks('not-a-dict', 100)
 
+    def test_put_with_filename_raises_value_error(self):
+        storage = StorageSegment()
+        with pytest.raises(ValueError, match='not supported'):
+            storage.put(artifact_name='test', filename='foo.json')
+
     def test_put_without_dict_raises_value_error(self):
         storage = StorageSegment()
-        with pytest.raises(ValueError, match='use dict='):
-            storage.put(artifact_name='test', filename='foo.json')
+        with pytest.raises(ValueError, match='dict= argument is required'):
+            storage.put(artifact_name='test')

--- a/metrics_utility/test/library/test_summarize_merge_ops.py
+++ b/metrics_utility/test/library/test_summarize_merge_ops.py
@@ -31,7 +31,29 @@ def test_summarize_combine_json():
 def test_summarize_combine_json_values():
     df = pd.DataFrame({'col_x': [{'k': 'v1'}], 'col_y': [{'k': 'v2'}]})
     result = _bt().summarize_merged_dataframes(df, ['col'], operations={'col': 'combine_json_values'})
-    assert 'k' in result['col'].iloc[0]
+    assert result['col'].iloc[0] == {'k': {'v1', 'v2'}}
+
+
+def test_summarize_lambda_branches_bind_per_column():
+    # Exercises all three lambda operations in a single call with multiple columns.
+    # A single-column call cannot expose the closure-over-loop-variable bug (S1515)
+    # because col is only ever one value; this multi-column call would regress if
+    # the c=col default-arg capture were removed.
+    df = pd.DataFrame(
+        {
+            'a_x': [{'x': 1}],
+            'a_y': [{'y': 2}],
+            'b_x': [['p']],
+            'b_y': [['q']],
+            'c_x': [{'k': 'v1'}],
+            'c_y': [{'k': 'v2'}],
+        }
+    )
+    ops = {'a': 'combine_json', 'b': 'combine_set', 'c': 'combine_json_values'}
+    result = _bt().summarize_merged_dataframes(df, ['a', 'b', 'c'], operations=ops)
+    assert result['a'].iloc[0] == {'x': 1, 'y': 2}
+    assert result['b'].iloc[0] == {'p', 'q'}
+    assert result['c'].iloc[0] == {'k': {'v1', 'v2'}}
 
 
 # --- validate='one_to_one' in BaseTraditional.merge() ---

--- a/metrics_utility/test/library/test_summarize_merge_ops.py
+++ b/metrics_utility/test/library/test_summarize_merge_ops.py
@@ -1,8 +1,9 @@
 """Tests covering the combine_set/combine_json/combine_json_values lambda branches
-in BaseTraditional.summarize_merged_dataframes() and the validate='many_to_many'
+in BaseTraditional.summarize_merged_dataframes() and the validate='one_to_one'
 path in both Base.merge() and BaseTraditional.merge()."""
 
 import pandas as pd
+import pytest
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
 from metrics_utility.library.dataframes.base_traditional import BaseTraditional
@@ -33,7 +34,7 @@ def test_summarize_combine_json_values():
     assert 'k' in result['col'].iloc[0]
 
 
-# --- validate='many_to_many' in BaseTraditional.merge() ---
+# --- validate='one_to_one' in BaseTraditional.merge() ---
 
 
 class _ConcreteTraditional(BaseTraditional):
@@ -54,7 +55,7 @@ class _ConcreteTraditional(BaseTraditional):
         return {}
 
 
-def test_base_traditional_merge_many_to_many():
+def test_base_traditional_merge_outer():
     bt = _ConcreteTraditional()
     df1 = pd.DataFrame({'id': [1], 'val': [10]}).set_index('id')
     df2 = pd.DataFrame({'id': [2], 'val': [20]}).set_index('id')
@@ -62,7 +63,15 @@ def test_base_traditional_merge_many_to_many():
     assert len(result) == 2
 
 
-# --- validate='many_to_many' in Base.merge() ---
+def test_base_traditional_merge_raises_on_duplicate_keys():
+    bt = _ConcreteTraditional()
+    df1 = pd.DataFrame({'id': [1, 1], 'val': [10, 20]}).set_index('id')
+    df2 = pd.DataFrame({'id': [2], 'val': [30]}).set_index('id')
+    with pytest.raises(pd.errors.MergeError):
+        bt.merge(df1, df2)
+
+
+# --- validate='one_to_one' in Base.merge() ---
 
 
 class _ConcreteBase(Base):
@@ -83,9 +92,17 @@ class _ConcreteBase(Base):
         return {}
 
 
-def test_base_engine_merge_many_to_many():
+def test_base_engine_merge_outer():
     b = _ConcreteBase(extractor=None, month=None, extra_params={})
     df1 = pd.DataFrame({'id': [1], 'val': [10]}).set_index('id')
     df2 = pd.DataFrame({'id': [2], 'val': [20]}).set_index('id')
     result = b.merge(df1, df2)
     assert len(result) == 2
+
+
+def test_base_engine_merge_raises_on_duplicate_keys():
+    b = _ConcreteBase(extractor=None, month=None, extra_params={})
+    df1 = pd.DataFrame({'id': [1, 1], 'val': [10, 20]}).set_index('id')
+    df2 = pd.DataFrame({'id': [2], 'val': [30]}).set_index('id')
+    with pytest.raises(pd.errors.MergeError):
+        b.merge(df1, df2)

--- a/metrics_utility/test/library/test_summarize_merge_ops.py
+++ b/metrics_utility/test/library/test_summarize_merge_ops.py
@@ -1,0 +1,91 @@
+"""Tests covering the combine_set/combine_json/combine_json_values lambda branches
+in BaseTraditional.summarize_merged_dataframes() and the validate='many_to_many'
+path in both Base.merge() and BaseTraditional.merge()."""
+
+import pandas as pd
+
+from metrics_utility.automation_controller_billing.dataframe_engine.base import Base
+from metrics_utility.library.dataframes.base_traditional import BaseTraditional
+
+
+# --- BaseTraditional.summarize_merged_dataframes() lambda branches ---
+
+
+def _bt():
+    return BaseTraditional()
+
+
+def test_summarize_combine_set():
+    df = pd.DataFrame({'col_x': [['a', 'b']], 'col_y': [['b', 'c']]})
+    result = _bt().summarize_merged_dataframes(df, ['col'], operations={'col': 'combine_set'})
+    assert result['col'].iloc[0] == {'a', 'b', 'c'}
+
+
+def test_summarize_combine_json():
+    df = pd.DataFrame({'col_x': [{'a': 1}], 'col_y': [{'b': 2}]})
+    result = _bt().summarize_merged_dataframes(df, ['col'], operations={'col': 'combine_json'})
+    assert result['col'].iloc[0] == {'a': 1, 'b': 2}
+
+
+def test_summarize_combine_json_values():
+    df = pd.DataFrame({'col_x': [{'k': 'v1'}], 'col_y': [{'k': 'v2'}]})
+    result = _bt().summarize_merged_dataframes(df, ['col'], operations={'col': 'combine_json_values'})
+    assert 'k' in result['col'].iloc[0]
+
+
+# --- validate='many_to_many' in BaseTraditional.merge() ---
+
+
+class _ConcreteTraditional(BaseTraditional):
+    @staticmethod
+    def unique_index_columns():
+        return ['id']
+
+    @staticmethod
+    def data_columns():
+        return ['val']
+
+    @staticmethod
+    def cast_types():
+        return {}
+
+    @staticmethod
+    def operations():
+        return {}
+
+
+def test_base_traditional_merge_many_to_many():
+    bt = _ConcreteTraditional()
+    df1 = pd.DataFrame({'id': [1], 'val': [10]}).set_index('id')
+    df2 = pd.DataFrame({'id': [2], 'val': [20]}).set_index('id')
+    result = bt.merge(df1, df2)
+    assert len(result) == 2
+
+
+# --- validate='many_to_many' in Base.merge() ---
+
+
+class _ConcreteBase(Base):
+    @staticmethod
+    def unique_index_columns():
+        return ['id']
+
+    @staticmethod
+    def data_columns():
+        return ['val']
+
+    @staticmethod
+    def cast_types():
+        return {}
+
+    @staticmethod
+    def operations():
+        return {}
+
+
+def test_base_engine_merge_many_to_many():
+    b = _ConcreteBase(extractor=None, month=None, extra_params={})
+    df1 = pd.DataFrame({'id': [1], 'val': [10]}).set_index('id')
+    df2 = pd.DataFrame({'id': [2], 'val': [20]}).set_index('id')
+    result = b.merge(df1, df2)
+    assert len(result) == 2

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -1362,7 +1362,7 @@ def _extract_ansible_versions_from_jobs(jobs_by_job_type):
         ansible_versions = job.get('ansible_versions', [])
         if isinstance(ansible_versions, list):
             expected_versions_set.update(ansible_versions)
-    return sorted(list(expected_versions_set))
+    return sorted(expected_versions_set)
 
 
 def _validate_ansible_versions(result, expected_versions):

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -172,7 +172,7 @@ def _validate_ansible_versions_top_level(result):
         ansible_versions = job.get('ansible_versions', [])
         if isinstance(ansible_versions, list):
             expected_versions_set.update(ansible_versions)
-    expected_versions = sorted(list(expected_versions_set))
+    expected_versions = sorted(expected_versions_set)
     assert statistics_ansible_versions == expected_versions, (
         f'Expected ansible_versions {expected_versions} in statistics, got {statistics_ansible_versions}'
     )

--- a/metrics_utility/test/test_helpers.py
+++ b/metrics_utility/test/test_helpers.py
@@ -104,7 +104,7 @@ def test_sanitize_json_json_serializable():
 
     # This should not raise an exception
     json_string = json.dumps(result)
-    assert json_string is not None
+    assert len(json_string) > 0
 
     # Verify we can parse it back
     parsed = json.loads(json_string)


### PR DESCRIPTION
## Summary
- Fetched 182 open SonarCloud issues from `ansible/metrics-utility` project
- ~65 fixes across 4 commits grouped by severity
- BUG/BLOCKERs: fixed broken `super()` comparison (`python:S3403`), method name clash (`python:S1845`)
- CRITICAL CODE_SMELLs: empty methods (S1186), identity checks in assertions (S5727), lambda closure over loop variable (S1515), duplicate string literals (S1192), redundant Exception subclass (S5713), missing `validate` param in `pd.merge` (S6735)
- MAJOR CODE_SMELLs: generic Exception replaced (S112), dead commented-out code removed (S125), unused parameters fixed (S1172), duplicate if branches merged (S1871)
- MINOR CODE_SMELLs: redundant `list()` before `sorted()` (S7508), regex character class simplification (S6353)
- ~117 issues skipped: cognitive complexity refactors (S3776), type-narrowing issues requiring design decisions, FIXMEs

## Test plan
- [ ] SonarCloud scan on this PR branch to verify issue count reduction
- [ ] Run existing test suite to confirm no regressions
- [ ] Review skipped issues for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollup merge logic (`pd.merge` validation) and packaging/shipping configuration checks, which could surface previously-silent data issues or alter runtime failure modes. Changes are mostly mechanical/defensive with expanded test coverage, but affect critical aggregation and upload paths.
> 
> **Overview**
> Primarily refactors and hardens metrics/billing utilities to satisfy SonarCloud findings, including safer pandas merge semantics and schema reuse across dataframe implementations.
> 
> Key behavior changes include: enforcing `pd.merge(..., validate='one_to_one')` for rollup merges, fixing lambda capture-over-loop-variable in merge summarization, and centralizing job-host-summary dataframe schema via new `DataframeSchemaMixin`/`JobHostSummarySchema` (plus shared constants in `metric_utils`).
> 
> Also cleans up/standardizes error handling and APIs: replaces generic `Exception` with `TypeError`/`ValueError`/`RuntimeError` in collectors/storage, fixes `PackageCRC.is_shipping_configured()` to call `super().is_shipping_configured()`, renames `Package.max_data_size()` to `Package.get_max_data_size()`, simplifies set/list sorting unions, and tweaks report/test helpers and coverage (new targeted unit tests and consolidated report sanity checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18dffa5b1930a3e6b02346e4968c28eaf732e840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->