### PR TITLE
Dirty fix for flaky send to segment

### DIFF
--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -159,7 +159,7 @@ class StorageSegment:
                 print(msg, file=sys.stderr)
 
             analytics.track(
-                anonymous_id=f'{anonymous_id}_{i}',
+                anonymous_id=f'{anonymous_id}',
                 event=event_name,
                 properties={
                     'artifact_name': artifact_name,
@@ -173,8 +173,11 @@ class StorageSegment:
                 },
                 **segment_meta,
             )
+
             analytics.flush()
 
             # time.sleep(3) - uncomment as backup plan
+
+        analytics.flush()
 
         return chunks

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -159,7 +159,7 @@ class StorageSegment:
                 print(msg, file=sys.stderr)
 
             analytics.track(
-                anonymous_id=anonymous_id',
+                anonymous_id=anonymous_id,
                 event=event_name,
                 properties={
                     'artifact_name': artifact_name,

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import sys
 import uuid
+import time
 
 from metrics_utility.logger import logger
 
@@ -173,6 +174,9 @@ class StorageSegment:
                 },
                 **segment_meta,
             )
+
+            # sleep for 3 seconds
+            time.sleep(3)
 
         # Flush to ensure all events are sent
         analytics.flush()

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -2,8 +2,8 @@ import datetime
 import hashlib
 import json
 import sys
-import uuid
 import time
+import uuid
 
 from metrics_utility.logger import logger
 
@@ -177,6 +177,5 @@ class StorageSegment:
 
             time.sleep(3)
 
-            # time.sleep(3) - uncomment as backup plan
         analytics.flush()
         return chunks

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import sys
 import uuid
+import time
 
 from metrics_utility.logger import logger
 
@@ -174,10 +175,8 @@ class StorageSegment:
                 **segment_meta,
             )
 
-            analytics.flush()
+            time.sleep(3)
 
             # time.sleep(3) - uncomment as backup plan
-
         analytics.flush()
-
         return chunks

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -159,7 +159,7 @@ class StorageSegment:
                 print(msg, file=sys.stderr)
 
             analytics.track(
-                anonymous_id=f'{anonymous_id}',
+                anonymous_id=anonymous_id',
                 event=event_name,
                 properties={
                     'artifact_name': artifact_name,

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -2,7 +2,6 @@ import datetime
 import hashlib
 import json
 import sys
-import time
 import uuid
 
 from metrics_utility.logger import logger
@@ -160,7 +159,7 @@ class StorageSegment:
                 print(msg, file=sys.stderr)
 
             analytics.track(
-                anonymous_id=anonymous_id,
+                anonymous_id=f'{anonymous_id}_{i}',
                 event=event_name,
                 properties={
                     'artifact_name': artifact_name,
@@ -174,11 +173,8 @@ class StorageSegment:
                 },
                 **segment_meta,
             )
+            analytics.flush()
 
-            # sleep for 3 seconds
-            time.sleep(3)
-
-        # Flush to ensure all events are sent
-        analytics.flush()
+            # time.sleep(3) - uncomment as backup plan
 
         return chunks

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -2,8 +2,8 @@ import datetime
 import hashlib
 import json
 import sys
-import uuid
 import time
+import uuid
 
 from metrics_utility.logger import logger
 


### PR DESCRIPTION
[AAP-73135]

Fixes flaky sending to segment.com, before, segment did not received all the messages. Now it receives most messages (but still not completely guaranteed).

This is a temporary workaround for unreliable delivery of chunked Segment events.
Without pacing, we observe missing chunks in roughly 10–20% of uploads.
Adding a delay between chunk sends significantly reduces missing chunks before release.

