### PR TITLE
[AAP-73135] Fix Segment event loss by enabling sync_mode

### DIFF
--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -130,6 +130,7 @@ class StorageSegment:
         # Configure Segment client
         analytics.write_key = self.write_key
         analytics.debug = self.debug
+        analytics.sync_mode = True
 
         max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -135,6 +135,9 @@ class StorageSegment:
         # can silently exceed Segment's 500 KB batch limit and drop events, returning
         # HTTP 200 with no error callback fired.
         analytics.sync_mode = True
+        # gzip compresses each ~25 KB chunk to ~3 KB on the wire, reducing per-request
+        # transfer time when sync_mode sends one HTTP call per chunk.
+        analytics.gzip = True
 
         max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -21,12 +21,6 @@ class StorageSegment:
     # including `properties` wrapper, event name, and segment_meta; keep this conservative.
     REGULAR_MESSAGE_LIMIT = 24 * 1024
 
-    # Segment enforces a 500KB limit per batch POST. We flush before reaching it,
-    # leaving headroom for per-event metadata the SDK adds (anonymousId, timestamp,
-    # context, etc.). EVENT_OVERHEAD is a conservative per-event estimate.
-    BATCH_SIZE_LIMIT = 450 * 1024
-    EVENT_OVERHEAD = 512
-
     def __init__(self, **settings):
         self.debug = settings.get('debug', False)
         self.user_id = settings.get('user_id', 'unknown')
@@ -136,6 +130,11 @@ class StorageSegment:
         # Configure Segment client
         analytics.write_key = self.write_key
         analytics.debug = self.debug
+        # sync_mode makes each track() a blocking HTTP request instead of queuing to a
+        # background thread. Without it the SDK batches all chunks into one POST which
+        # can silently exceed Segment's 500 KB batch limit and drop events, returning
+        # HTTP 200 with no error callback fired.
+        analytics.sync_mode = True
 
         max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)
@@ -150,17 +149,9 @@ class StorageSegment:
             segment_meta = {}
         message_id = segment_meta.get('message_id', None)
 
-        # Send each chunk, flushing before the batch would exceed Segment's 500KB limit
-        batch_bytes = 0
+        # Send each chunk
         for i, chunk in enumerate(chunks, 1):
             chunk_size = self._calculate_size(chunk)
-            event_size = chunk_size + self.EVENT_OVERHEAD
-
-            if batch_bytes + event_size > self.BATCH_SIZE_LIMIT and batch_bytes > 0:
-                if self.debug:
-                    print(f'Flushing batch at {batch_bytes} bytes before adding chunk {i}', file=sys.stderr)
-                analytics.flush()
-                batch_bytes = 0
 
             # chunk hash = sha256(message hash + chunk index)
             if message_id:
@@ -187,9 +178,8 @@ class StorageSegment:
                 },
                 **segment_meta,
             )
-            batch_bytes += event_size
 
-        # Flush remaining queued events
+        # Flush to ensure all events are sent
         analytics.flush()
 
         return chunks

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -135,9 +135,6 @@ class StorageSegment:
         # can silently exceed Segment's 500 KB batch limit and drop events, returning
         # HTTP 200 with no error callback fired.
         analytics.sync_mode = True
-        # gzip compresses each ~25 KB chunk to ~3 KB on the wire, reducing per-request
-        # transfer time when sync_mode sends one HTTP call per chunk.
-        analytics.gzip = True
 
         max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -21,6 +21,12 @@ class StorageSegment:
     # including `properties` wrapper, event name, and segment_meta; keep this conservative.
     REGULAR_MESSAGE_LIMIT = 24 * 1024
 
+    # Segment enforces a 500KB limit per batch POST. We flush before reaching it,
+    # leaving headroom for per-event metadata the SDK adds (anonymousId, timestamp,
+    # context, etc.). EVENT_OVERHEAD is a conservative per-event estimate.
+    BATCH_SIZE_LIMIT = 450 * 1024
+    EVENT_OVERHEAD = 512
+
     def __init__(self, **settings):
         self.debug = settings.get('debug', False)
         self.user_id = settings.get('user_id', 'unknown')
@@ -130,7 +136,6 @@ class StorageSegment:
         # Configure Segment client
         analytics.write_key = self.write_key
         analytics.debug = self.debug
-        analytics.sync_mode = True
 
         max_size = self.REGULAR_MESSAGE_LIMIT
         chunks = self._split_into_chunks(dict, max_size)
@@ -145,9 +150,17 @@ class StorageSegment:
             segment_meta = {}
         message_id = segment_meta.get('message_id', None)
 
-        # Send each chunk
+        # Send each chunk, flushing before the batch would exceed Segment's 500KB limit
+        batch_bytes = 0
         for i, chunk in enumerate(chunks, 1):
             chunk_size = self._calculate_size(chunk)
+            event_size = chunk_size + self.EVENT_OVERHEAD
+
+            if batch_bytes + event_size > self.BATCH_SIZE_LIMIT and batch_bytes > 0:
+                if self.debug:
+                    print(f'Flushing batch at {batch_bytes} bytes before adding chunk {i}', file=sys.stderr)
+                analytics.flush()
+                batch_bytes = 0
 
             # chunk hash = sha256(message hash + chunk index)
             if message_id:
@@ -174,8 +187,9 @@ class StorageSegment:
                 },
                 **segment_meta,
             )
+            batch_bytes += event_size
 
-        # Flush to ensure all events are sent
+        # Flush remaining queued events
         analytics.flush()
 
         return chunks

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -149,15 +149,19 @@ class TestStorageSegmentAvailable:
 
         Without sync_mode the SDK batches all chunks into one POST which can silently
         exceed Segment's 500 KB batch limit and drop events with no error raised.
+        flush() is called once at the end only — sync_mode handles per-track delivery,
+        so no mid-loop batch flushing is needed.
         """
         mock_analytics.track = Mock()
         mock_analytics.flush = Mock()
 
         storage_segment = StorageSegment(write_key='test_write_key', debug=False)
-        storage_segment.put(
+        chunks = storage_segment.put(
             artifact_name='test_artifact',
             dict=segment_data_large,
             event_name='Test Event',
         )
 
         assert mock_analytics.sync_mode is True
+        assert mock_analytics.track.call_count == len(chunks)
+        assert mock_analytics.flush.call_count == 1

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -1,6 +1,3 @@
-# import segment data from testing_data_for_segment
-
-# import storage segment
 from unittest.mock import Mock, patch
 
 from metrics_utility.library.storage.segment import StorageSegment
@@ -88,26 +85,17 @@ class TestStorageSegmentAvailable:
     @patch('metrics_utility.library.storage.segment.analytics')
     @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
     def test_put_sends_data_to_segment(self, mock_analytics):
-        """Test that put method sends data to segment.com with proper mocking."""
-        # Setup
+        """put() tracks every chunk, flushes once, and enables sync_mode."""
         mock_analytics.track = Mock()
         mock_analytics.flush = Mock()
 
         storage_segment = StorageSegment(write_key='test_write_key', user_id='test_user', debug=True)
-
-        # Act
         chunks = storage_segment.put(artifact_name='test_artifact', dict=segment_data, event_name='Test Event')
 
-        # Assert
-        # Verify analytics.track was called
-        assert mock_analytics.track.called
+        assert mock_analytics.sync_mode is True
         assert mock_analytics.track.call_count == len(chunks)
-
-        # Verify flush was called
-        assert mock_analytics.flush.called
         assert mock_analytics.flush.call_count == 1
 
-        # Verify the call arguments
         call_args = mock_analytics.track.call_args[1]
         assert 'anonymous_id' in call_args
         assert call_args['event'] == 'Test Event'
@@ -144,13 +132,16 @@ class TestStorageSegmentAvailable:
 
     @patch('metrics_utility.library.storage.segment.analytics')
     @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
-    def test_put_sync_mode_enabled(self, mock_analytics):
-        """sync_mode is set to True so each track() is a blocking HTTP request.
+    def test_put_sync_mode_no_batch_drops(self, mock_analytics):
+        """sync_mode=True prevents Segment silently dropping chunks from oversized batches.
 
-        Without sync_mode the SDK batches all chunks into one POST which can silently
-        exceed Segment's 500 KB batch limit and drop events with no error raised.
-        flush() is called once at the end only — sync_mode handles per-track delivery,
-        so no mid-loop batch flushing is needed.
+        Without sync_mode the SDK batches all track() calls into a single POST. With
+        15 chunks at ~25 KB each the batch exceeds Segment's 500 KB limit and events
+        are dropped server-side — Segment returns HTTP 200 with no error callback.
+
+        sync_mode sends each track() as a separate blocking HTTP request so every
+        chunk is confirmed delivered before the next is sent. End-to-end validated:
+        15/15 chunks received in Segment with sync_mode=True vs 11-14 without.
         """
         mock_analytics.track = Mock()
         mock_analytics.flush = Mock()

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -93,7 +93,6 @@ class TestStorageSegmentAvailable:
         chunks = storage_segment.put(artifact_name='test_artifact', dict=segment_data, event_name='Test Event')
 
         assert mock_analytics.sync_mode is True
-        assert mock_analytics.gzip is True
         assert mock_analytics.track.call_count == len(chunks)
         assert mock_analytics.flush.call_count == 1
 
@@ -155,6 +154,5 @@ class TestStorageSegmentAvailable:
         )
 
         assert mock_analytics.sync_mode is True
-        assert mock_analytics.gzip is True
         assert mock_analytics.track.call_count == len(chunks)
         assert mock_analytics.flush.call_count == 1

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -133,7 +133,6 @@ class TestStorageSegmentAvailable:
         # Should split into 7 chunks as tested earlier
         assert len(chunks) == 7
         assert mock_analytics.track.call_count == 7
-        # 7 chunks well under 450 KB batch limit — only the final flush should fire
         assert mock_analytics.flush.call_count == 1
 
         # Verify chunk numbering in the calls
@@ -145,43 +144,20 @@ class TestStorageSegmentAvailable:
 
     @patch('metrics_utility.library.storage.segment.analytics')
     @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
-    def test_put_single_flush_when_chunks_fit_in_one_batch(self, mock_analytics):
-        """All chunks are sent in one batch when total size is below BATCH_SIZE_LIMIT."""
-        mock_analytics.track = Mock()
-        mock_analytics.flush = Mock()
+    def test_put_sync_mode_enabled(self, mock_analytics):
+        """sync_mode is set to True so each track() is a blocking HTTP request.
 
-        storage_segment = StorageSegment(write_key='test_write_key', debug=False)
-        chunks = storage_segment.put(
-            artifact_name='test_artifact',
-            dict=segment_data_large,
-            event_name='Test Event',
-        )
-
-        assert mock_analytics.track.call_count == len(chunks)
-        assert mock_analytics.flush.call_count == 1
-
-    @patch('metrics_utility.library.storage.segment.analytics')
-    @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
-    def test_put_flushes_mid_loop_when_batch_limit_reached(self, mock_analytics):
-        """flush() is called before queuing a chunk that would push the batch over BATCH_SIZE_LIMIT.
-
-        Segment silently drops events from batch POSTs that exceed 500 KB and returns
-        HTTP 200, so we flush proactively before reaching that threshold.
+        Without sync_mode the SDK batches all chunks into one POST which can silently
+        exceed Segment's 500 KB batch limit and drop events with no error raised.
         """
         mock_analytics.track = Mock()
         mock_analytics.flush = Mock()
 
         storage_segment = StorageSegment(write_key='test_write_key', debug=False)
-        # Lower the limit so each large (~24 KB) chunk forces its own batch
-        storage_segment.BATCH_SIZE_LIMIT = storage_segment.REGULAR_MESSAGE_LIMIT + storage_segment.EVENT_OVERHEAD
-
-        chunks = storage_segment.put(
+        storage_segment.put(
             artifact_name='test_artifact',
             dict=segment_data_large,
             event_name='Test Event',
         )
 
-        # Every chunk must still be tracked — none dropped
-        assert mock_analytics.track.call_count == len(chunks)
-        # Multiple flushes confirm that mid-loop splitting occurred
-        assert mock_analytics.flush.call_count > 1
+        assert mock_analytics.sync_mode is True

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -133,6 +133,7 @@ class TestStorageSegmentAvailable:
         # Should split into 7 chunks as tested earlier
         assert len(chunks) == 7
         assert mock_analytics.track.call_count == 7
+        # 7 chunks well under 450 KB batch limit — only the final flush should fire
         assert mock_analytics.flush.call_count == 1
 
         # Verify chunk numbering in the calls
@@ -141,3 +142,46 @@ class TestStorageSegmentAvailable:
             chunk_info = call_kwargs['properties']['chunk_info']
             assert chunk_info['chunk_number'] == i
             assert chunk_info['total_chunks'] == 7
+
+    @patch('metrics_utility.library.storage.segment.analytics')
+    @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
+    def test_put_single_flush_when_chunks_fit_in_one_batch(self, mock_analytics):
+        """All chunks are sent in one batch when total size is below BATCH_SIZE_LIMIT."""
+        mock_analytics.track = Mock()
+        mock_analytics.flush = Mock()
+
+        storage_segment = StorageSegment(write_key='test_write_key', debug=False)
+        chunks = storage_segment.put(
+            artifact_name='test_artifact',
+            dict=segment_data_large,
+            event_name='Test Event',
+        )
+
+        assert mock_analytics.track.call_count == len(chunks)
+        assert mock_analytics.flush.call_count == 1
+
+    @patch('metrics_utility.library.storage.segment.analytics')
+    @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
+    def test_put_flushes_mid_loop_when_batch_limit_reached(self, mock_analytics):
+        """flush() is called before queuing a chunk that would push the batch over BATCH_SIZE_LIMIT.
+
+        Segment silently drops events from batch POSTs that exceed 500 KB and returns
+        HTTP 200, so we flush proactively before reaching that threshold.
+        """
+        mock_analytics.track = Mock()
+        mock_analytics.flush = Mock()
+
+        storage_segment = StorageSegment(write_key='test_write_key', debug=False)
+        # Lower the limit so each large (~24 KB) chunk forces its own batch
+        storage_segment.BATCH_SIZE_LIMIT = storage_segment.REGULAR_MESSAGE_LIMIT + storage_segment.EVENT_OVERHEAD
+
+        chunks = storage_segment.put(
+            artifact_name='test_artifact',
+            dict=segment_data_large,
+            event_name='Test Event',
+        )
+
+        # Every chunk must still be tracked — none dropped
+        assert mock_analytics.track.call_count == len(chunks)
+        # Multiple flushes confirm that mid-loop splitting occurred
+        assert mock_analytics.flush.call_count > 1

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -93,6 +93,7 @@ class TestStorageSegmentAvailable:
         chunks = storage_segment.put(artifact_name='test_artifact', dict=segment_data, event_name='Test Event')
 
         assert mock_analytics.sync_mode is True
+        assert mock_analytics.gzip is True
         assert mock_analytics.track.call_count == len(chunks)
         assert mock_analytics.flush.call_count == 1
 
@@ -154,5 +155,6 @@ class TestStorageSegmentAvailable:
         )
 
         assert mock_analytics.sync_mode is True
+        assert mock_analytics.gzip is True
         assert mock_analytics.track.call_count == len(chunks)
         assert mock_analytics.flush.call_count == 1


### PR DESCRIPTION
## Root cause

Segment silently drops events from batch POSTs that exceed 500 KB and returns HTTP 200, making the loss invisible — no error callback fires. The SDK queues all `track()` calls and `flush()` sends them as a single batch POST. With 15 chunks at ~25 KB data each, the actual HTTP body (including ~2–3 KB of per-event SDK metadata — `anonymousId`, `timestamp`, `context`, `messageId`, `integrations`) pushes the batch well over 500 KB.

## Fix

Set `analytics.sync_mode = True` on the client before sending. This makes every `track()` call a separate blocking HTTP request (~25 KB each) rather than queuing to a background thread for batching. Each request is well within Segment's 32 KB per-request limit.

## What was tried first

A batch-size tracking approach was implemented that called `flush()` before the accumulated data size exceeded 450 KB. End-to-end testing showed it still dropped events:
- 17 chunks in one batch (~425 KB of data): only 12 arrived
- 26 chunks split into two batches: only 17 arrived

The estimated 450 KB threshold did not account for the full SDK metadata overhead (~2–3 KB per event), so actual batch bodies still exceeded 500 KB. `sync_mode=True` eliminates batching entirely and is the only approach that delivered all chunks reliably in testing.

## End-to-end validation

Tested against a live Segment source using the exact payload shape produced by `flatten_json_report` / `anonymize_rollups` (102 job-type rows, 81 installed-collection rows, ~112 KB total JSON):

| Mode | Chunks sent | Chunks received |
|---|---|---|
| `sync_mode=False` (async batch) | 15 | 11–14 (flaky) |
| `sync_mode=True` | 15 | **15 ✓** |

Large payload stress test (26 chunks, ~650 KB data):

| Mode | Chunks sent | Chunks received |
|---|---|---|
| Batch approach (450 KB limit) | 26 | 17 |
| `sync_mode=True` | 26 | **26 ✓** |

## Tests

- `test_put_sync_mode_enabled` — verifies `analytics.sync_mode` is `True`, all chunks are tracked, and `flush()` is called exactly once (final flush only — `sync_mode` handles per-track delivery)
- Existing `test_put_sends_multiple_chunks_for_large_data` — confirms all chunks are tracked and a single `flush()` fires at the end

## References

- [Segment product limits](https://segment.com/docs/connections/rate-limits/)
- [analytics-python docs — sync_mode](https://segment.com/docs/connections/sources/catalog/libraries/server/python/)
- Regression introduced in #372 which removed the previous `BULK_MESSAGE_LIMIT` constant
- Jira: AAP-73135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the delivery semantics of analytics emission from async/batched to synchronous per-event HTTP requests, which may impact performance and request timing while improving reliability.
> 
> **Overview**
> Ensures Segment analytics uploads no longer rely on the SDK’s async batching by enabling `analytics.sync_mode = True` before emitting chunked `track()` events, preventing silent drops when batched payloads exceed Segment’s 500 KB limit.
> 
> Updates `StorageSegment` tests to assert `sync_mode` is enabled, that all chunks are tracked, and that `flush()` is still called exactly once; adds a new regression test covering the large-payload batching drop scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3eac0c852805549baec6dd4270a53fb82a3301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->