### PR TITLE
_calculate_collection_interval: reuse max gather period days, and timedelta

### DIFF
--- a/metrics_utility/base/collector.py
+++ b/metrics_utility/base/collector.py
@@ -136,9 +136,12 @@ class Collector:
     #
     def _calculate_collection_interval(self, since, until):
         _now = now()
+        _max = get_max_gather_period_days()
+        _timedelta = timedelta(days=_max)
+
         original_since = since
         original_until = until
-        logger.warning(f'Original since-until: {original_since} to {original_until}')
+        logger.debug(f'Original since-until: {original_since} to {original_until}')
 
         # Make sure that the endpoints are not in the future.
         if until is not None and until > _now:
@@ -153,15 +156,15 @@ class Collector:
         # `since` parameter.
         if since is not None:
             if until is not None:
-                if until > since + timedelta(days=get_max_gather_period_days()):
-                    until = since + timedelta(days=get_max_gather_period_days())
-                    logger.warning(
-                        f'End of the collection interval is greater than {get_max_gather_period_days()} days from start, setting end to {until}.'
-                    )
+                if until > since + _timedelta:
+                    until = since + _timedelta
+                    logger.warning(f'End of the collection interval is greater than {_max} days from start, setting end to {until}.')
             else:  # until is None
-                until = min(since + timedelta(days=get_max_gather_period_days()), _now)
+                until = min(since + _timedelta, _now)
+                logger.info(f'End of the collection interval set to {until}.')
         elif until is None:
             until = _now
+            logger.info(f'End of the collection interval set to {until}.')
 
         # ensure since = until is valid and will not collect any data with timestamps
         if since and since > until:
@@ -172,23 +175,21 @@ class Collector:
         # `until`, but we want to keep `since` empty if it wasn't passed in because we use that
         # case to know whether to use the bookkeeping settings variables to decide the start of
         # the interval.
-        horizon = until - timedelta(days=get_max_gather_period_days())
+        horizon = until - _timedelta
         if since is not None and since < horizon:
             since = horizon
-            logger.warning(
-                f'Start of the collection interval is more than {get_max_gather_period_days()} days prior to {until}, setting to {horizon}.'
-            )
+            logger.warning(f'Start of the collection interval is more than {_max} days prior to {until}, setting to {horizon}.')
 
         last_gather = horizon
         if last_gather < horizon:
             last_gather = horizon
-            logger.warning(f'Last analytics run was more than {get_max_gather_period_days()} days prior to {until}, using {horizon} instead.')
+            logger.warning(f'Last analytics run was more than {_max} days prior to {until}, using {horizon} instead.')
 
         self.gather_since = since
         self.gather_until = until
         self.last_gather = last_gather
 
-        logger.warning(f'Final since-until: {since} to {until}')
+        logger.info(f'Final since-until: {since} to {until}')
 
     def _find_available_package(self, group, key, requested_size=None):
         """Checks if there is a Package available for collection.

--- a/metrics_utility/test/gather/test_gather_ranges.py
+++ b/metrics_utility/test/gather/test_gather_ranges.py
@@ -34,7 +34,7 @@ def cleanup_glob():
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_larger_range(cleanup_glob):
-    result = run_gather_ext(env_vars, ['--ship', '--since=2024-01-01', '--until=2024-01-05'])
+    result = run_gather_ext(env_vars, ['--ship', '--verbose', '--since=2024-01-01', '--until=2024-01-05'])
     validate_exists(file_glob)
 
     text = result.stderr + '\n' + result.stdout
@@ -45,7 +45,7 @@ def test_larger_range(cleanup_glob):
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_smaller_range(cleanup_glob):
-    result = run_gather_ext(env_vars, ['--ship', '--since=2024-01-01', '--until=2024-01-03'])
+    result = run_gather_ext(env_vars, ['--ship', '--verbose', '--since=2024-01-01', '--until=2024-01-03'])
     validate_exists(file_glob)
 
     text = result.stderr + '\n' + result.stdout
@@ -59,7 +59,7 @@ def test_only_host_scope(cleanup_glob):
     new_env_vars['METRICS_UTILITY_OPTIONAL_COLLECTORS'] = 'main_host'
     new_env_vars['METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS'] = '1'
 
-    result = run_gather_ext(new_env_vars, ['--ship', '--since=2024-01-01', '--until=2024-01-03'])
+    result = run_gather_ext(new_env_vars, ['--ship', '--verbose', '--since=2024-01-01', '--until=2024-01-03'])
 
     text = result.stderr + '\n' + result.stdout
 
@@ -99,3 +99,25 @@ def test_only_host_scope(cleanup_glob):
         print(tar.getnames())
         # ensure main_host.csv is present
         # assert './main_host.csv' in tar.getnames()
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_since_only(cleanup_glob):
+    result = run_gather_ext(env_vars, ['--ship', '--verbose', '--since=2024-01-01'])
+    validate_exists(file_glob)
+
+    text = result.stderr + '\n' + result.stdout
+    assert 'Original since-until: 2024-01-01 00:00:00+00:00 to None' in text
+    assert 'End of the collection interval set to ' in text
+    assert 'Final since-until: ' in text
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_no_since_no_until(cleanup_glob):
+    result = run_gather_ext(env_vars, ['--ship', '--verbose'])
+    validate_exists(file_glob)
+
+    text = result.stderr + '\n' + result.stdout
+    assert 'Original since-until: None to None' in text
+    assert 'End of the collection interval set to ' in text
+    assert 'Final since-until: None to ' in text


### PR DESCRIPTION
Cosmetic change,
compute the 2 values once, rather than for every logging,
and update logging to always report a change, but reduce the value to info/debug when logging something that's not a user error.

Thus...

|what|old|new|
|-|-|-|
| Original since-until | warning | debug |
| End in future | warning | warning |
| Since in future | warning | warning |
| Too long interval | warning | warning |
| Since set, until unset | - | info |
| Since unset, until unset | - | info |
| Since after until | warning | warning |
| Too long interval | warning | warning |
| Ignoring last run | warning | warning |
| Final since-until | warning | info |