### PR TITLE
exclude non-source dirs from sonar scanning

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,7 @@ sonar.organization=ansible
 
 # Customize what paths to scan. Default is .
 sonar.sources=metrics_utility
+sonar.exclusions=tools/**,workers/**,.github/**,mock_awx/**,docs/**,sql/**
 
 # Verbose name of project displayed in WUI. Default is set to the projectKey. This field is optional.
 sonar.projectName=metrics-utility

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.organization=ansible
 
 # Customize what paths to scan. Default is .
 sonar.sources=metrics_utility
-sonar.exclusions=tools/**,workers/**,.github/**,mock_awx/**,docs/**,sql/**
+sonar.exclusions=tools/**,workers/**,.github/**,mock_awx/**,docs/**,sql/**,run-*
 
 # Verbose name of project displayed in WUI. Default is set to the projectKey. This field is optional.
 sonar.projectName=metrics-utility


### PR DESCRIPTION
adds a `sonar.exclusions`, explicitly excluding:

* `tools/` - dev env tooling, perf test tooling, testathon data generators
* `workers` - old library examples
* `.github/` - workflow tooling
* `mock_awx` - tests mock
* `docs` - docs
* `sql` - a sql dump
* `run-*` - manual testing scripts