### PR TITLE
[AAP-54364] Write test to make sure billing information is being passed in config file

### DIFF
--- a/metrics_utility/test/validation/test_crc_billing_provider_params.py
+++ b/metrics_utility/test/validation/test_crc_billing_provider_params.py
@@ -1,0 +1,27 @@
+"""CRC ship target: billing_provider_params built from env and passed into config.json."""
+
+import pytest
+
+from metrics_utility.exceptions import MissingRequiredEnvVar
+from metrics_utility.management.validation import handle_crc_ship_target
+
+
+def test_handle_crc_ship_target_aws_billing_params(monkeypatch):
+    """CRC + AWS env produces the billing triplet that gather embeds in config.json."""
+    monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
+    monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+    monkeypatch.setenv('METRICS_UTILITY_RED_HAT_ORG_ID', '99900001')
+    result = handle_crc_ship_target()
+    assert result == {
+        'billing_provider': 'aws',
+        'billing_account_id': '123456789012',
+        'red_hat_org_id': '99900001',
+    }
+
+
+def test_handle_crc_ship_target_aws_requires_billing_account_id(monkeypatch):
+    """CRC + AWS raises MissingRequiredEnvVar when billing account ID env var is absent."""
+    monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
+    monkeypatch.delenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', raising=False)
+    with pytest.raises(MissingRequiredEnvVar, match='METRICS_UTILITY_BILLING_ACCOUNT_ID'):
+        handle_crc_ship_target()


### PR DESCRIPTION
# [[AAP-54364](https://redhat.atlassian.net/browse/AAP-54364)] Write test to make sure billing information is being passed in config file

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?
  - Adds `metrics_utility/test/validation/test_crc_billing_provider_params.py` with two pytest tests that validate `handle_crc_ship_target()`: one asserts the AWS billing env vars map to the expected `billing_provider_params` dict; one asserts `MissingRequiredEnvVar` when `METRICS_UTILITY_BILLING_ACCOUNT_ID` is missing for `METRICS_UTILITY_BILLING_PROVIDER=aws`.
- Why is this change needed?
  - Billing-related env handling should be covered next to `metrics-utility` so regressions are caught in upstream CI instead of only in downstream integration suites.
- How does this change address the issue?
  - It validates that CRC-style billing parameters are built correctly from environment variables (the logic that feeds `billing_provider_params` in `config.json`).

## Testing

<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

### Prerequisites

<!-- List any specific setup required -->
- Python 3.12+
- Repo checkout with dev/test dependencies installed
 
### Steps to Test

1. From the metrics-utility repo root, create a venv and install the package in editable mode with whatever your CI uses for pytest (see ```pyproject.toml``` / CI config for the exact extra or dependency list).
2. Run: ```pytest metrics_utility/test/validation/test_crc_billing_provider_params.py -v```

### Expected Results

<!-- Describe what should happen after following the steps -->
- `test_handle_crc_ship_target_aws_billing_params` and `test_handle_crc_ship_target_aws_requires_billing_account_id` both pass.

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds isolated unit tests only, with no production code changes. Risk is limited to potential CI failures if the current env-var validation behavior changes.
> 
> **Overview**
> Adds a new pytest module `test_crc_billing_provider_params.py` that locks in `handle_crc_ship_target()` behavior for CRC/AWS billing configuration.
> 
> The tests assert the expected `billing_provider_params` dict is built from `METRICS_UTILITY_BILLING_PROVIDER`, `METRICS_UTILITY_BILLING_ACCOUNT_ID`, and `METRICS_UTILITY_RED_HAT_ORG_ID`, and that omitting the AWS account ID raises `MissingRequiredEnvVar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979872dc245a57f8b12ebb6a260b665d5e766301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->