### PR TITLE
add hourly_slicing for main_jobevent CLI collector

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -95,6 +95,43 @@ def daily_slicing(key, last_gather, **kwargs):
         start = end
 
 
+def hourly_slicing(key, last_gather, **kwargs):
+    """Generate time slices aligned to hour boundaries.
+
+    Yields ``(start, end)`` pairs that never cross an hour boundary.
+
+    Args:
+        key: Collector key name used to look up the last-gathered entry.
+        last_gather: Fallback datetime used when no entry exists for *key*.
+        **kwargs: Accepts optional ``since`` and ``until`` datetimes.
+
+    Yields:
+        Tuple of ``(since, until)`` timezone-aware datetimes.
+    """
+    since, until = kwargs.get('since', None), kwargs.get('until', now())
+    if since is not None:
+        last_entry = since
+    else:
+        horizon = until - timedelta(days=get_max_gather_period_days())
+        last_entries = get_last_entries_from_db()
+        try:
+            last_entry = max(last_entries.get(key) or last_gather, horizon)
+        except TypeError:  # last_entries has a stale non-datetime entry for this collector
+            last_entry = max(last_gather, horizon)
+
+    start, end = last_entry, None
+    start_beginning_of_next_hour = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+
+    if until > start_beginning_of_next_hour:
+        yield (start, start_beginning_of_next_hour)
+        start = start_beginning_of_next_hour
+
+    while start < until:
+        end = min(start + timedelta(hours=1), until)
+        yield (start, end)
+        start = end
+
+
 def until_slicing(_key, _last_gather, **kwargs):
     """Generate a single snapshot slice positioned at ``until - 1 second``.
 
@@ -182,7 +219,7 @@ def cli_main_indirectmanagednodeaudit(since, until, output):
         return None
 
 
-@register('main_jobevent', '1.0', format='csv', fnc_slicing=daily_slicing)
+@register('main_jobevent', '1.0', format='csv', fnc_slicing=hourly_slicing)
 def cli_main_jobevent(since, until, output):
     if 'main_jobevent' not in get_optional_collectors():
         return None

--- a/metrics_utility/test/test_slicing.py
+++ b/metrics_utility/test/test_slicing.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from metrics_utility.automation_controller_billing.collectors import hourly_slicing
+from metrics_utility.test.util import utcdt
+
+
+class TestHourlySlicing:
+    def test_single_partial_hour(self):
+        since = utcdt('2024-01-15T10:15:00')
+        until = utcdt('2024-01-15T10:45:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=since, until=until))
+        assert slices == [(since, until)]
+
+    def test_crosses_one_hour_boundary(self):
+        since = utcdt('2024-01-15T10:15:00')
+        until = utcdt('2024-01-15T11:30:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=since, until=until))
+        assert slices == [
+            (utcdt('2024-01-15T10:15:00'), utcdt('2024-01-15T11:00:00')),
+            (utcdt('2024-01-15T11:00:00'), utcdt('2024-01-15T11:30:00')),
+        ]
+
+    def test_multiple_full_hours(self):
+        since = utcdt('2024-01-15T10:00:00')
+        until = utcdt('2024-01-15T13:00:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=since, until=until))
+        assert slices == [
+            (utcdt('2024-01-15T10:00:00'), utcdt('2024-01-15T11:00:00')),
+            (utcdt('2024-01-15T11:00:00'), utcdt('2024-01-15T12:00:00')),
+            (utcdt('2024-01-15T12:00:00'), utcdt('2024-01-15T13:00:00')),
+        ]
+
+    def test_partial_start_and_end(self):
+        since = utcdt('2024-01-15T10:30:00')
+        until = utcdt('2024-01-15T13:15:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=since, until=until))
+        assert slices == [
+            (utcdt('2024-01-15T10:30:00'), utcdt('2024-01-15T11:00:00')),
+            (utcdt('2024-01-15T11:00:00'), utcdt('2024-01-15T12:00:00')),
+            (utcdt('2024-01-15T12:00:00'), utcdt('2024-01-15T13:00:00')),
+            (utcdt('2024-01-15T13:00:00'), utcdt('2024-01-15T13:15:00')),
+        ]
+
+    def test_since_equals_until(self):
+        t = utcdt('2024-01-15T10:00:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=t, until=t))
+        assert slices == []
+
+    @patch('metrics_utility.automation_controller_billing.collectors.get_last_entries_from_db')
+    @patch('metrics_utility.automation_controller_billing.collectors.now')
+    def test_falls_back_to_db_entries(self, mock_now, mock_get_last_entries):
+        mock_now.return_value = utcdt('2024-01-15T12:00:00')
+        mock_get_last_entries.return_value = {'main_jobevent': utcdt('2024-01-15T10:00:00')}
+
+        slices = list(hourly_slicing('main_jobevent', utcdt('2024-01-01T00:00:00')))
+        assert slices[0][0] == utcdt('2024-01-15T10:00:00')
+        assert len(slices) == 2
+
+    @patch('metrics_utility.automation_controller_billing.collectors.get_last_entries_from_db')
+    @patch('metrics_utility.automation_controller_billing.collectors.now')
+    def test_horizon_clamp(self, mock_now, mock_get_last_entries):
+        mock_now.return_value = utcdt('2024-02-15T12:00:00')
+        mock_get_last_entries.return_value = {'main_jobevent': utcdt('2024-01-01T00:00:00')}
+
+        slices = list(hourly_slicing('main_jobevent', utcdt('2023-01-01T00:00:00')))
+        horizon = utcdt('2024-01-18T12:00:00')  # 28 days back from until
+        assert slices[0][0] == horizon
+
+    def test_crosses_midnight(self):
+        since = utcdt('2024-01-15T23:30:00')
+        until = utcdt('2024-01-16T01:30:00')
+        slices = list(hourly_slicing('main_jobevent', None, since=since, until=until))
+        assert slices == [
+            (utcdt('2024-01-15T23:30:00'), utcdt('2024-01-16T00:00:00')),
+            (utcdt('2024-01-16T00:00:00'), utcdt('2024-01-16T01:00:00')),
+            (utcdt('2024-01-16T01:00:00'), utcdt('2024-01-16T01:30:00')),
+        ]


### PR DESCRIPTION
Probably not meant to be merged, merely for testing perf differences when collecting events in shorter batches

---

Switch main_jobevent from daily_slicing to hourly_slicing to reduce
peak memory/disk usage per slice. The library collector is unchanged —
it just receives since/until and is agnostic to how they were sliced.

- Add `hourly_slicing` function (same structure as `daily_slicing` but
  aligned to hour boundaries instead of day boundaries)
- Switch `cli_main_jobevent` decorator to use `hourly_slicing`
- Add unit tests for `hourly_slicing`