### PR TITLE
[stable-0.7] config collector: change reported version back to 1.0

### DIFF
--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -94,7 +94,7 @@ def until_slicing(_key, _last_gather, **kwargs):
 
 
 # FIXME: move this one to caller?
-@register('config', '2.0', format='json', config=True)
+@register('config', '1.0', format='json', config=True)
 def cli_config(since, until, output):
     # runs once, used in all the tarballs
     # FIXME: , billing_provider_params={dict} rather than {} getting overwritten in collector.gather


### PR DESCRIPTION
This reverts #355 (in stable-0.7 only)
(backported as part of #368)

The other end can't accept the version change, so undoing the version change for the `config` collector.
The format still COULD have more NULL values than the original allowed, but shouldn't in practice; there are no differences other than field nullability between v1 and v2.