### PR TITLE
[stable-0.7] [AAP-76646] Updated dashboard collection (backport #392)

### DIFF
--- a/metrics_utility/library/collectors/controller/__init__.py
+++ b/metrics_utility/library/collectors/controller/__init__.py
@@ -12,6 +12,7 @@ from .main_jobevent import main_jobevent
 from .main_jobevent_service import main_jobevent_service
 from .table_metadata import table_metadata
 from .unified_jobs import unified_jobs
+from .unified_jobs_dashboard import unified_jobs_dashboard
 
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     'main_jobevent_service',
     'table_metadata',
     'unified_jobs',
+    'unified_jobs_dashboard',
 ]

--- a/metrics_utility/library/collectors/controller/unified_jobs_dashboard.py
+++ b/metrics_utility/library/collectors/controller/unified_jobs_dashboard.py
@@ -1,0 +1,87 @@
+"""Collector for unified_jobs extended with dashboard-specific fields."""
+
+from ..util import DataframeOutput, collector, date_where
+
+
+@collector
+def unified_jobs_dashboard(*, db=None, since=None, until=None, output=DataframeOutput()):
+    """Collect unified job records with additional fields required by the automation-reports dashboard.
+
+    Extends the base ``unified_jobs`` query with project name, launched-by user,
+    label IDs, and a host count — columns the dashboard needs to populate
+    ``JobData`` and ``JobLabel`` records without a separate DB round-trip.
+
+    Filters by ``finished`` timestamp (consistent with the anonymised rollup
+    pipeline). Only jobs with status ``failed`` or ``successful`` and
+    ``launch_type != 'sync'`` are useful to the dashboard, but filtering is
+    intentionally left to the caller so this collector can be reused broadly.
+
+    Args:
+        db: Django database connection.
+        since: Inclusive start datetime for the ``finished`` filter.
+        until: Exclusive end datetime for the ``finished`` filter.
+        output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
+
+    Returns:
+        pandas DataFrame or list of CSV file paths depending on *output*.
+    """
+    query = f"""
+        SELECT
+            main_unifiedjob.id,
+            main_unifiedjob.polymorphic_ctype_id,
+            django_content_type.model,
+            main_unifiedjob.organization_id,
+            main_organization.name AS organization_name,
+            main_executionenvironment.image AS execution_environment_image,
+            main_job.inventory_id,
+            main_inventory.name AS inventory_name,
+            main_unifiedjob.execution_environment_id,
+            main_unifiedjob.created,
+            main_unifiedjob.modified,
+            main_unifiedjob.name,
+            main_unifiedjob.unified_job_template_id,
+            main_unifiedjob.launch_type,
+            main_unifiedjob.schedule_id,
+            main_unifiedjob.execution_node,
+            main_unifiedjob.controller_node,
+            main_unifiedjob.cancel_flag,
+            main_unifiedjob.status,
+            main_unifiedjob.failed,
+            main_unifiedjob.started,
+            main_unifiedjob.finished,
+            main_unifiedjob.elapsed,
+            main_unifiedjob.job_explanation,
+            main_unifiedjob.instance_group_id,
+            main_unifiedjob.installed_collections,
+            main_unifiedjob.ansible_version,
+            main_job.forks,
+            mut.name AS job_template_name,
+            main_project.scm_type,
+            main_project.unifiedjobtemplate_ptr_id AS project_id,
+            ujp.name AS project_name,
+            CASE WHEN main_unifiedjob.launch_type IN ('manual', 'relaunch')
+                 THEN auth_user.id ELSE NULL END AS launched_by_id,
+            CASE WHEN main_unifiedjob.launch_type IN ('manual', 'relaunch')
+                 THEN auth_user.username ELSE NULL END AS launched_by_username,
+            (SELECT STRING_AGG(l.label_id::text, ',')
+             FROM main_unifiedjob_labels l
+             WHERE l.unifiedjob_id = main_unifiedjob.id) AS label_ids,
+            (SELECT COUNT(*)
+             FROM main_jobhostsummary
+             WHERE job_id = main_unifiedjob.id) AS num_hosts
+        FROM main_unifiedjob
+        LEFT JOIN django_content_type ON main_unifiedjob.polymorphic_ctype_id = django_content_type.id
+        LEFT JOIN main_job ON main_unifiedjob.id = main_job.unifiedjob_ptr_id
+        LEFT JOIN main_inventory ON main_job.inventory_id = main_inventory.id
+        LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
+        LEFT JOIN main_executionenvironment ON main_executionenvironment.id = main_unifiedjob.execution_environment_id
+        LEFT JOIN main_project ON main_job.project_id = main_project.unifiedjobtemplate_ptr_id
+        LEFT JOIN main_unifiedjobtemplate AS mut ON mut.id = main_unifiedjob.unified_job_template_id
+        LEFT JOIN main_unifiedjobtemplate AS ujp ON ujp.id = main_project.unifiedjobtemplate_ptr_id
+        LEFT JOIN auth_user ON auth_user.id = main_unifiedjob.created_by_id
+        WHERE
+            {date_where('main_unifiedjob.finished', since, until)}
+        ORDER BY main_unifiedjob.id ASC
+    """
+
+    return output.sql(db, query)

--- a/metrics_utility/library/collectors/dashboard/__init__.py
+++ b/metrics_utility/library/collectors/dashboard/__init__.py
@@ -1,4 +1,5 @@
 from .collectors import AWXJobHostSummaryType, AWXJobType, DashboardJobsResultType, dashboard_jobs
+from .queries import get_min_max_job_id_query
 
 
-__all__ = ['dashboard_jobs', 'DashboardJobsResultType', 'AWXJobHostSummaryType', 'AWXJobType']
+__all__ = ['dashboard_jobs', 'DashboardJobsResultType', 'AWXJobHostSummaryType', 'AWXJobType', 'get_min_max_job_id_query']

--- a/metrics_utility/library/collectors/dashboard/collectors.py
+++ b/metrics_utility/library/collectors/dashboard/collectors.py
@@ -15,7 +15,14 @@ from datetime import datetime
 from typing import List, TypedDict
 
 from ..util import collector
-from .queries import get_job_host_summaries_query, get_job_labels_query, get_jobs_query
+from .queries import (
+    get_job_host_summaries_for_ids_query,
+    get_job_host_summaries_query,
+    get_job_labels_for_ids_query,
+    get_job_labels_query,
+    get_jobs_batch_query,
+    get_jobs_query,
+)
 
 
 class AWXJobHostSummaryType(TypedDict):
@@ -49,7 +56,7 @@ class DashboardJobsResultType(TypedDict):
     results: List[AWXJobType]
 
 
-def _dashboard_job_labels(since: datetime, until: datetime, db, **kwargs) -> dict[int, list[int]]:
+def _dashboard_job_labels(since: datetime, until: datetime, db, date_field: str = 'modified', **kwargs) -> dict[int, list[int]]:
     """
     Collect job labels for the dashboard.
 
@@ -59,6 +66,7 @@ def _dashboard_job_labels(since: datetime, until: datetime, db, **kwargs) -> dic
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
         db: Database connection
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
         **kwargs: Additional parameters
 
     Returns:
@@ -73,7 +81,7 @@ def _dashboard_job_labels(since: datetime, until: datetime, db, **kwargs) -> dic
     }
     """
 
-    query, params = get_job_labels_query(since, until)
+    query, params = get_job_labels_query(since, until, date_field=date_field)
     result = {}
     with db.cursor() as cursor:
         cursor.execute(query, params)
@@ -88,7 +96,9 @@ def _dashboard_job_labels(since: datetime, until: datetime, db, **kwargs) -> dic
     return result
 
 
-def _dashboard_job_host_summaries(since: datetime, until: datetime, db, **kwargs) -> dict[int, list[AWXJobHostSummaryType]]:
+def _dashboard_job_host_summaries(
+    since: datetime, until: datetime, db, date_field: str = 'modified', **kwargs
+) -> dict[int, list[AWXJobHostSummaryType]]:
     """
     Collect job host summaries for the dashboard.
 
@@ -98,6 +108,7 @@ def _dashboard_job_host_summaries(since: datetime, until: datetime, db, **kwargs
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
         db: Database connection
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
         **kwargs: Additional parameters
 
     returns:
@@ -116,7 +127,7 @@ def _dashboard_job_host_summaries(since: datetime, until: datetime, db, **kwargs
         ...
     }
     """
-    query, params = get_job_host_summaries_query(since, until)
+    query, params = get_job_host_summaries_query(since, until, date_field=date_field)
     result = {}
     with db.cursor() as cursor:
         cursor.execute(query, params)
@@ -136,7 +147,15 @@ def _dashboard_job_host_summaries(since: datetime, until: datetime, db, **kwargs
 
 
 @collector
-def dashboard_jobs(*, db=None, since: datetime = None, until: datetime = None) -> DashboardJobsResultType:
+def dashboard_jobs(
+    *,
+    db=None,
+    since: datetime = None,
+    until: datetime = None,
+    after_id: int = None,
+    batch_size: int = None,
+    date_field: str = 'modified',
+) -> DashboardJobsResultType:
     """
     Collect job data for the dashboard.
 
@@ -146,7 +165,11 @@ def dashboard_jobs(*, db=None, since: datetime = None, until: datetime = None) -
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
         db: Database connection
-        **kwargs: Additional parameters
+        after_id: If provided alongside ``batch_size``, enables cursor-based pagination.
+        batch_size: Maximum rows per batch when paginating.
+        date_field: Column used for the date range filter — ``'modified'`` (default, used by the
+            CLI billing/CCSP pipeline) or ``'finished'`` (used by dashboard/anonymized collection
+            to exploit the existing finished index).
 
     Returns:
         dict with keys:
@@ -183,17 +206,61 @@ def dashboard_jobs(*, db=None, since: datetime = None, until: datetime = None) -
          }
     """
 
-    all_labels = _dashboard_job_labels(since, until, db)
-    all_host_summaries = _dashboard_job_host_summaries(since, until, db)
-    query, params = get_jobs_query(since, until)
+    if (after_id is None) != (batch_size is None):
+        raise ValueError('after_id and batch_size must both be provided or both omitted')
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError('batch_size must be greater than 0')
+
+    batched = after_id is not None
+
+    if batched:
+        query, params = get_jobs_batch_query(since, until, after_id, batch_size, date_field=date_field)
+    else:
+        query, params = get_jobs_query(since, until, date_field=date_field)
+
     with db.cursor() as cursor:
         cursor.execute(query, params)
         columns = [col[0] for col in cursor.description]
-        results = []
-        for row in cursor:
-            data = dict(zip(columns, row))
-            host_summaries = all_host_summaries.get(data['id'], [])
-            result = {
+        rows = [dict(zip(columns, row)) for row in cursor]
+
+    if not rows:
+        return {'count': 0, 'results': []}
+
+    if batched:
+        job_ids = [row['id'] for row in rows]
+        labels_query, labels_params = get_job_labels_for_ids_query(job_ids)
+        summaries_query, summaries_params = get_job_host_summaries_for_ids_query(job_ids)
+
+        all_labels: dict[int, list[int]] = {}
+        with db.cursor() as cursor:
+            cursor.execute(labels_query, labels_params)
+            cols = [col[0] for col in cursor.description]
+            for lrow in cursor:
+                data = dict(zip(cols, lrow))
+                all_labels.setdefault(data['unifiedjob_id'], []).append(data['label_id'])
+
+        all_host_summaries: dict[int, list] = {}
+        with db.cursor() as cursor:
+            cursor.execute(summaries_query, summaries_params)
+            cols = [col[0] for col in cursor.description]
+            for srow in cursor:
+                data = dict(zip(cols, srow))
+                all_host_summaries.setdefault(data['job_id'], []).append(
+                    {
+                        'id': data['id'],
+                        'host_id': data['host_id'],
+                        'host_name': data['host_name'],
+                    }
+                )
+    else:
+        all_labels = _dashboard_job_labels(since, until, db, date_field=date_field)
+        all_host_summaries = _dashboard_job_host_summaries(since, until, db, date_field=date_field)
+
+    results = []
+    for data in rows:
+        host_summaries = all_host_summaries.get(data['id'], [])
+        results.append(
+            {
                 'id': data['id'],
                 'name': data['name'],
                 'unified_job_template_id': data['unified_job_template_id'],
@@ -212,5 +279,5 @@ def dashboard_jobs(*, db=None, since: datetime = None, until: datetime = None) -
                 'host_summaries': host_summaries,
                 'num_hosts': len(host_summaries),
             }
-            results.append(result)
+        )
     return {'count': len(results), 'results': results}

--- a/metrics_utility/library/collectors/dashboard/queries.py
+++ b/metrics_utility/library/collectors/dashboard/queries.py
@@ -1,35 +1,75 @@
 from datetime import datetime
 
 
-def get_where_clause(since: datetime, until: datetime) -> tuple[str, list]:
+_ALLOWED_DATE_FIELDS = frozenset({'modified', 'finished'})
+
+
+def _validate_date_field(date_field: str) -> None:
+    if date_field not in _ALLOWED_DATE_FIELDS:
+        raise ValueError(f'date_field must be one of {sorted(_ALLOWED_DATE_FIELDS)}, got {date_field!r}')
+
+
+def get_min_max_job_id_query(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
     """
-    Generate SQL WHERE clause for filtering jobs by job modification date range.
+    Return the min and max job IDs for the filtered window.
+
+    Used to establish cursor bounds before a batched collection run.
+    Mirrors the ``JOIN main_job`` in ``get_jobs_batch_query`` so bounds only
+    cover actual Job-type records and not WorkflowJobs, ProjectUpdates, etc.
+
+    Args:
+        since: Start of date range (inclusive)
+        until: End of date range (exclusive)
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
+
+    Returns:
+        Tuple of (SQL query string with placeholders, [params])
+    """
+    where_clause, params = get_where_clause(since, until, date_field=date_field)
+    query = f"""
+        SELECT MIN(uj.id) AS min_id, MAX(uj.id) AS max_id
+        FROM main_unifiedjob uj
+        JOIN main_job mj ON mj.unifiedjob_ptr_id = uj.id
+        {where_clause}
+    """
+    return query, params
+
+
+def get_where_clause(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
+    """
+    Generate SQL WHERE clause for filtering jobs by a date range.
     Excludes sync jobs and includes only jobs with status 'failed' or 'successful'.
 
     Args:
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
+        date_field: Column used for the date range filter — ``'modified'`` (default, used by the
+            CLI billing/CCSP pipeline to pick up records changed since the last run) or
+            ``'finished'`` (used by dashboard/anonymized collection where job completion time
+            is the meaningful boundary and the ``finished`` index can be exploited).
 
     Returns:
         Tuple of (SQL WHERE clause string with placeholders, [params])
     """
-    where_clause = """
+    _validate_date_field(date_field)
+    where_clause = f"""
     WHERE uj.launch_type != %s
     AND (uj.status= %s OR uj.status = %s)
-    AND uj.modified >= %s
-    AND uj.modified < %s
+    AND uj.{date_field} >= %s
+    AND uj.{date_field} < %s
     """
     params = ['sync', 'failed', 'successful', since.isoformat(), until.isoformat()]
     return where_clause, params
 
 
-def get_job_labels_query(since: datetime, until: datetime) -> tuple[str, list]:
+def get_job_labels_query(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
     """
     Generate SQL query to fetch job labels for jobs executed within the specified date range.
 
     Args:
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
 
     Returns:
         Tuple of (SQL query string with placeholders, [params])
@@ -38,7 +78,7 @@ def get_job_labels_query(since: datetime, until: datetime) -> tuple[str, list]:
         - main_unifiedjob_labels
         - main_unifiedjob (for filtering by date range)
     """
-    where_clause, params = get_where_clause(since, until)
+    where_clause, params = get_where_clause(since, until, date_field=date_field)
     query = f"""
             SELECT
                 l.unifiedjob_id,
@@ -51,13 +91,14 @@ def get_job_labels_query(since: datetime, until: datetime) -> tuple[str, list]:
     return query, params
 
 
-def get_job_host_summaries_query(since: datetime, until: datetime) -> tuple[str, list]:
+def get_job_host_summaries_query(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
     """
     Generate SQL query to fetch job host summaries for jobs executed within the specified date range.
 
     Args:
         since: Start of date range (inclusive)
         until: End of date range (exclusive)
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
 
     Returns:
         Tuple of (SQL query string with placeholders, [params])
@@ -66,7 +107,7 @@ def get_job_host_summaries_query(since: datetime, until: datetime) -> tuple[str,
         - main_jobhostsummary
         - main_unifiedjob (for filtering by date range)
     """
-    where_clause, params = get_where_clause(since, until)
+    where_clause, params = get_where_clause(since, until, date_field=date_field)
     query = f"""
          SELECT
             hs.id, hs.host_name, hs.host_id, hs.job_id
@@ -77,27 +118,11 @@ def get_job_host_summaries_query(since: datetime, until: datetime) -> tuple[str,
     return query, params
 
 
-def get_jobs_query(since: datetime, until: datetime) -> tuple[str, list]:
-    """
-    Generate SQL query to fetch jobs executed within the specified date range.
-
-    Args:
-        since: Start of date range (inclusive)
-        until: End of date range (exclusive)
-
-    Returns:
-        Tuple of (SQL query string with placeholders, [params])
-
-    Database schema:
-        - main_unifiedjob
-        - main_job
-        - main_unifiedjobtemplate
-        - auth_user
-        - main_project
-        - main_unifiedjobtemplate
-    """
-    where_clause, params = get_where_clause(since, until)
-    query = f"""SELECT
+# Shared SELECT and JOIN fragment used by both get_jobs_query and get_jobs_batch_query.
+# Both functions build on this base so that adding a column or join in one place
+# automatically applies to the batched path and prevents schema drift in the shared
+# dict-building loop in dashboard_jobs.
+_JOBS_BASE_SQL = """SELECT
     uj.id,
     COALESCE(ujt.name, uj.name) as name,
     uj.unified_job_template_id,
@@ -122,5 +147,94 @@ def get_jobs_query(since: datetime, until: datetime) -> tuple[str, list]:
     JOIN main_job mj on mj.unifiedjob_ptr_id = uj.id
     LEFT JOIN main_unifiedjobtemplate ujt ON ujt.id = uj.unified_job_template_id
     LEFT JOIN auth_user u on u.id = uj.created_by_id
-    LEFT JOIN main_unifiedjobtemplate ujp on ujp.id = mj.project_id {where_clause} order by uj.modified"""
+    LEFT JOIN main_unifiedjobtemplate ujp on ujp.id = mj.project_id"""
+
+
+def get_jobs_query(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
+    """
+    Generate SQL query to fetch jobs executed within the specified date range.
+
+    Args:
+        since: Start of date range (inclusive)
+        until: End of date range (exclusive)
+        date_field: Column used for the date range filter and sort — ``'modified'`` (default) or
+            ``'finished'``. Use ``'finished'`` for dashboard/anonymized collection to exploit the
+            existing ``main_unifiedjob_finished_eccf6159`` index.
+
+    Returns:
+        Tuple of (SQL query string with placeholders, [params])
+    """
+    where_clause, params = get_where_clause(since, until, date_field=date_field)
+    query = f'{_JOBS_BASE_SQL} {where_clause} order by uj.{date_field}'
     return query, params
+
+
+def get_jobs_batch_query(since: datetime, until: datetime, after_id: int, batch_size: int, date_field: str = 'modified') -> tuple[str, list]:
+    """
+    Cursor-paginated variant of ``get_jobs_query``.
+
+    Returns up to *batch_size* rows with ``id > after_id``, ordered by ``id``
+    so successive calls advance the cursor without skipping or re-fetching rows.
+
+    Args:
+        since: Start of date range (inclusive)
+        until: End of date range (exclusive)
+        after_id: Exclusive lower bound on job ID (use 0 or min_id - 1 for first page)
+        batch_size: Maximum number of rows to return
+        date_field: Column used for the date range filter — ``'modified'`` (default) or ``'finished'``.
+
+    Returns:
+        Tuple of (SQL query string with placeholders, [params])
+    """
+    where_clause, params = get_where_clause(since, until, date_field=date_field)
+    params += [after_id, batch_size]
+    query = f"""{_JOBS_BASE_SQL}
+    {where_clause} AND uj.id > %s
+    ORDER BY uj.id
+    LIMIT %s"""
+    return query, params
+
+
+def get_job_labels_for_ids_query(job_ids: list) -> tuple[str, list]:
+    """
+    Fetch labels for a specific set of job IDs.
+
+    More efficient than ``get_job_labels_query`` when the job set is already
+    known (e.g. after a batch fetch) because it avoids re-joining against
+    the full date-range filter.
+
+    Args:
+        job_ids: List of unified job IDs to fetch labels for
+
+    Returns:
+        Tuple of (SQL query string with placeholders, [params])
+    """
+    query = """
+        SELECT l.unifiedjob_id, l.label_id
+        FROM main_unifiedjob_labels l
+        WHERE l.unifiedjob_id = ANY(%s)
+        ORDER BY l.unifiedjob_id
+    """
+    return query, [job_ids]
+
+
+def get_job_host_summaries_for_ids_query(job_ids: list) -> tuple[str, list]:
+    """
+    Fetch host summaries for a specific set of job IDs.
+
+    More efficient than ``get_job_host_summaries_query`` when the job set is
+    already known (e.g. after a batch fetch).
+
+    Args:
+        job_ids: List of unified job IDs to fetch host summaries for
+
+    Returns:
+        Tuple of (SQL query string with placeholders, [params])
+    """
+    query = """
+        SELECT hs.id, hs.host_name, hs.host_id, hs.job_id
+        FROM main_jobhostsummary hs
+        WHERE hs.job_id = ANY(%s)
+        ORDER BY hs.job_id
+    """
+    return query, [job_ids]

--- a/metrics_utility/test/library/dashboard/test_collectors_dashboard.py
+++ b/metrics_utility/test/library/dashboard/test_collectors_dashboard.py
@@ -200,3 +200,147 @@ class TestCollectorsDashboard:
         for i, job in enumerate(result['results']):
             for key, value in expected_jobs[i].items():
                 assert job[key] == value, f"Mismatch for job {i + 1} field '{key}': {job[key]} != {value}"
+
+    def test_dashboard_jobs_batch_empty(self):
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_cursor.description = [('id',), ('name',)]
+        mock_cursor.__iter__.return_value = iter([])
+        self.mock_db.cursor.return_value = mock_cursor
+
+        collector = dashboard_jobs(since=self.since, until=self.until, db=self.mock_db, after_id=100, batch_size=10000)
+        result = collector.gather()
+
+        assert result == {'count': 0, 'results': []}
+
+    @patch('metrics_utility.library.collectors.dashboard.collectors.get_jobs_batch_query')
+    @patch('metrics_utility.library.collectors.dashboard.collectors.get_job_labels_for_ids_query')
+    @patch('metrics_utility.library.collectors.dashboard.collectors.get_job_host_summaries_for_ids_query')
+    def test_dashboard_jobs_batch_uses_id_scoped_queries(self, mock_summaries_query, mock_labels_query, mock_batch_query):
+        mock_batch_query.return_value = ('SELECT 1', [])
+        mock_labels_query.return_value = ('SELECT 1', [])
+        mock_summaries_query.return_value = ('SELECT 1', [])
+
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_cursor.description = [
+            ('id',),
+            ('name',),
+            ('unified_job_template_id',),
+            ('organization_id',),
+            ('started',),
+            ('finished',),
+            ('status',),
+            ('elapsed',),
+            ('launched_by_id',),
+            ('launched_by_username',),
+            ('project_id',),
+            ('project_name',),
+            ('created',),
+            ('modified',),
+        ]
+        mock_cursor.__iter__.return_value = iter(
+            [
+                (
+                    1,
+                    'Job 1',
+                    1,
+                    1,
+                    datetime(2024, 1, 10),
+                    datetime(2024, 1, 10, 0, 5),
+                    'successful',
+                    decimal.Decimal('300.0'),
+                    1,
+                    'user',
+                    2,
+                    'proj',
+                    datetime(2024, 1, 10),
+                    datetime(2024, 1, 10),
+                ),
+            ]
+        )
+        self.mock_db.cursor.return_value = mock_cursor
+
+        collector = dashboard_jobs(since=self.since, until=self.until, db=self.mock_db, after_id=0, batch_size=5000)
+        collector.gather()
+
+        mock_batch_query.assert_called_once_with(self.since, self.until, 0, 5000, date_field='modified')
+        mock_labels_query.assert_called_once_with([1])
+        mock_summaries_query.assert_called_once_with([1])
+
+    @patch('metrics_utility.library.collectors.dashboard.collectors._dashboard_job_labels')
+    @patch('metrics_utility.library.collectors.dashboard.collectors._dashboard_job_host_summaries')
+    @patch('metrics_utility.library.collectors.dashboard.collectors.get_jobs_query')
+    def test_dashboard_jobs_non_batched_uses_helpers(self, mock_jobs_query, mock_summaries, mock_labels):
+        mock_jobs_query.return_value = ('SELECT 1', [])
+        mock_labels.return_value = {}
+        mock_summaries.return_value = {}
+
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_cursor.description = [
+            ('id',),
+            ('name',),
+            ('unified_job_template_id',),
+            ('organization_id',),
+            ('started',),
+            ('finished',),
+            ('status',),
+            ('elapsed',),
+            ('launched_by_id',),
+            ('launched_by_username',),
+            ('project_id',),
+            ('project_name',),
+            ('created',),
+            ('modified',),
+        ]
+        # Provide one row so the early-return guard doesn't fire
+        mock_cursor.__iter__.return_value = iter(
+            [
+                (
+                    1,
+                    'Job 1',
+                    1,
+                    1,
+                    datetime(2024, 1, 10),
+                    datetime(2024, 1, 10, 0, 5),
+                    'successful',
+                    decimal.Decimal('300.0'),
+                    None,
+                    None,
+                    None,
+                    None,
+                    datetime(2024, 1, 10),
+                    datetime(2024, 1, 10),
+                ),
+            ]
+        )
+        self.mock_db.cursor.return_value = mock_cursor
+
+        collector = dashboard_jobs(since=self.since, until=self.until, db=self.mock_db)
+        collector.gather()
+
+        mock_labels.assert_called_once_with(self.since, self.until, self.mock_db, date_field='modified')
+        mock_summaries.assert_called_once_with(self.since, self.until, self.mock_db, date_field='modified')
+        mock_jobs_query.assert_called_once_with(self.since, self.until, date_field='modified')
+
+    def test_dashboard_jobs_raises_on_only_after_id(self):
+        """Passing after_id without batch_size must raise rather than silently run a full-window query."""
+        import pytest
+
+        with pytest.raises(ValueError, match='after_id and batch_size'):
+            dashboard_jobs(since=self.since, until=self.until, db=self.mock_db, after_id=100).gather()
+
+    def test_dashboard_jobs_raises_on_only_batch_size(self):
+        """Passing batch_size without after_id must raise rather than silently ignore the batch intent."""
+        import pytest
+
+        with pytest.raises(ValueError, match='after_id and batch_size'):
+            dashboard_jobs(since=self.since, until=self.until, db=self.mock_db, batch_size=5000).gather()
+
+    def test_dashboard_jobs_raises_on_zero_batch_size(self):
+        """batch_size=0 must raise — a zero-row page would loop forever."""
+        import pytest
+
+        with pytest.raises(ValueError, match='batch_size must be greater than 0'):
+            dashboard_jobs(since=self.since, until=self.until, db=self.mock_db, after_id=0, batch_size=0).gather()

--- a/metrics_utility/test/library/dashboard/test_queries_dashboard.py
+++ b/metrics_utility/test/library/dashboard/test_queries_dashboard.py
@@ -1,13 +1,22 @@
 from datetime import datetime
 
-from metrics_utility.library.collectors.dashboard.queries import get_job_host_summaries_query, get_job_labels_query, get_jobs_query, get_where_clause
+from metrics_utility.library.collectors.dashboard.queries import (
+    get_job_host_summaries_for_ids_query,
+    get_job_host_summaries_query,
+    get_job_labels_for_ids_query,
+    get_job_labels_query,
+    get_jobs_batch_query,
+    get_jobs_query,
+    get_min_max_job_id_query,
+    get_where_clause,
+)
 
 
 class TestQueriesDashboard:
     since = datetime.fromisoformat('2024-01-01T00:00:00Z')
     until = datetime.fromisoformat('2024-02-01T23:59:59Z')
 
-    def test_where_clause(self):
+    def test_where_clause_defaults_to_modified(self):
         result, params = get_where_clause(self.since, self.until)
         assert 'WHERE' in result
         assert 'uj.launch_type != %s' in result
@@ -16,6 +25,18 @@ class TestQueriesDashboard:
         assert 'AND uj.modified < %s' in result
         expected_params = ['sync', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
         assert params == expected_params
+
+    def test_where_clause_finished(self):
+        result, params = get_where_clause(self.since, self.until, date_field='finished')
+        assert 'AND uj.finished >= %s' in result
+        assert 'AND uj.finished < %s' in result
+        assert 'modified' not in result
+
+    def test_where_clause_invalid_date_field(self):
+        import pytest
+
+        with pytest.raises(ValueError, match='date_field must be'):
+            get_where_clause(self.since, self.until, date_field='created')
 
     def test_get_job_labels_query(self):
         result, _ = get_job_labels_query(self.since, self.until)
@@ -61,3 +82,76 @@ class TestQueriesDashboard:
         assert 'uj.created' in result
         assert 'uj.modified' in result
         assert result.count('CASE') == 2
+
+    def test_get_jobs_query_finished(self):
+        result, _ = get_jobs_query(self.since, self.until, date_field='finished')
+        assert 'AND uj.finished >= %s' in result
+        assert 'AND uj.finished < %s' in result
+        assert 'order by uj.finished' in result
+
+    def test_get_min_max_job_id_query(self):
+        result, params = get_min_max_job_id_query(self.since, self.until)
+        assert 'MIN(uj.id) AS min_id' in result
+        assert 'MAX(uj.id) AS max_id' in result
+        assert 'FROM main_unifiedjob uj' in result
+        # Must join main_job so bounds match the INNER JOIN in get_jobs_batch_query
+        assert 'JOIN main_job mj ON mj.unifiedjob_ptr_id = uj.id' in result
+        # Same base filter as get_where_clause
+        assert 'uj.launch_type != %s' in result
+        assert 'uj.status' in result
+        assert 'uj.modified' in result
+        expected_params = ['sync', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
+        assert params == expected_params
+
+    def test_get_jobs_batch_query(self):
+        result, params = get_jobs_batch_query(self.since, self.until, after_id=500, batch_size=10000)
+        # Cursor pagination clauses
+        assert 'AND uj.id > %s' in result
+        assert 'ORDER BY uj.id' in result
+        assert 'LIMIT %s' in result
+        assert 500 in params
+        assert 10000 in params
+        # Same column selection as full query
+        assert 'COALESCE(ujt.name, uj.name) as name' in result
+        assert 'uj.unified_job_template_id' in result
+        assert 'uj.status' in result
+        assert 'mj.project_id' in result
+        # Same base filter
+        assert 'uj.launch_type != %s' in result
+
+    def test_get_jobs_batch_query_zero_after_id(self):
+        result, params = get_jobs_batch_query(self.since, self.until, after_id=0, batch_size=500)
+        assert 0 in params
+        assert 500 in params
+        assert 'AND uj.id > %s' in result
+
+    def test_get_job_labels_for_ids_query(self):
+        job_ids = [1, 2, 3]
+        result, params = get_job_labels_for_ids_query(job_ids)
+        assert 'main_unifiedjob_labels' in result
+        assert 'ANY(%s)' in result
+        assert 'unifiedjob_id' in result
+        assert 'label_id' in result
+        assert 'ORDER BY' in result
+        assert params == [job_ids]
+
+    def test_get_job_labels_for_ids_query_empty_list(self):
+        result, params = get_job_labels_for_ids_query([])
+        assert 'ANY(%s)' in result
+        assert params == [[]]
+
+    def test_get_job_host_summaries_for_ids_query(self):
+        job_ids = [10, 20, 30]
+        result, params = get_job_host_summaries_for_ids_query(job_ids)
+        assert 'main_jobhostsummary' in result
+        assert 'ANY(%s)' in result
+        assert 'host_name' in result
+        assert 'host_id' in result
+        assert 'job_id' in result
+        assert 'ORDER BY' in result
+        assert params == [job_ids]
+
+    def test_get_job_host_summaries_for_ids_query_empty_list(self):
+        result, params = get_job_host_summaries_for_ids_query([])
+        assert 'ANY(%s)' in result
+        assert params == [[]]

--- a/metrics_utility/test/library/test_collectors_unified_jobs_dashboard.py
+++ b/metrics_utility/test/library/test_collectors_unified_jobs_dashboard.py
@@ -1,0 +1,122 @@
+import datetime
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from metrics_utility.library.collectors.controller.unified_jobs_dashboard import unified_jobs_dashboard
+
+
+class TestUnifiedJobsDashboard:
+    def setup_method(self):
+        self.mock_db = None  # sql output adapter, not used directly in query tests
+        self.since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        self.until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
+
+    def _get_query(self, mock_copy_pandas):
+        return mock_copy_pandas.call_args[0][1]
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_uses_finished_filter(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'main_unifiedjob.finished >=' in query
+        assert 'main_unifiedjob.finished <' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_modified_column(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'main_unifiedjob.modified' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_project_id_and_name(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'project_id' in query
+        assert 'project_name' in query
+        assert 'ujp.name AS project_name' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_launched_by_fields(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'launched_by_id' in query
+        assert 'launched_by_username' in query
+        assert 'CASE' in query
+        assert "'manual'" in query
+        assert "'relaunch'" in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_label_ids_subquery(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'label_ids' in query
+        assert 'STRING_AGG' in query
+        assert 'main_unifiedjob_labels' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_num_hosts_subquery(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'num_hosts' in query
+        assert 'COUNT(*)' in query
+        assert 'main_jobhostsummary' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_auth_user_join(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'LEFT JOIN auth_user ON auth_user.id = main_unifiedjob.created_by_id' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_ujp_join_for_project_name(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'LEFT JOIN main_unifiedjobtemplate AS ujp' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_includes_base_unified_jobs_columns(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'main_unifiedjob' in query
+        assert 'main_unifiedjobtemplate' in query
+        assert 'django_content_type' in query
+        assert 'main_job' in query
+        assert 'main_organization' in query
+        assert 'main_executionenvironment' in query
+        assert 'main_inventory' in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_does_not_filter_by_status(self, mock_copy_pandas):
+        """Filtering to terminal states is the caller's responsibility, not the collector's."""
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert "status = 'failed'" not in query
+        assert "status = 'successful'" not in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_does_not_exclude_sync_jobs(self, mock_copy_pandas):
+        """Sync job filtering is handled by the dashboard task layer, not the collector."""
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert "launch_type != 'sync'" not in query
+        assert "launch_type <> 'sync'" not in query
+
+    @patch('metrics_utility.library.collectors.util._copy_table_pandas')
+    def test_orders_by_id(self, mock_copy_pandas):
+        mock_copy_pandas.return_value = pd.DataFrame()
+        unified_jobs_dashboard(db=self.mock_db, since=self.since, until=self.until).gather()
+        query = self._get_query(mock_copy_pandas)
+        assert 'ORDER BY main_unifiedjob.id ASC' in query


### PR DESCRIPTION
## Description

Backport of #392 to `stable-0.7`.

### New collector: `unified_jobs_dashboard`

A new collector in `metrics_utility/library/collectors/controller/unified_jobs_dashboard.py` extends the base `unified_jobs` query with the additional fields the automation-reports dashboard needs:

| New column | Source |
|---|---|
| `modified` | `main_unifiedjob.modified` |
| `project_id` | `main_project.unifiedjobtemplate_ptr_id` |
| `project_name` | `main_unifiedjobtemplate AS ujp` |
| `launched_by_id` | CASE on `launch_type IN ('manual', 'relaunch')` + `auth_user.id` |
| `launched_by_username` | same CASE + `auth_user.username` |
| `label_ids` | correlated subquery: `STRING_AGG` over `main_unifiedjob_labels` |
| `num_hosts` | correlated subquery: `COUNT(*)` over `main_jobhostsummary` |

`unified_jobs` is **unchanged** — the CLI billing and CCSP pipeline continues to use the original collector without modification.

### Batched backfill support in `dashboard_jobs`

Extends `dashboard_jobs` with optional cursor-based pagination (`after_id`, `batch_size`) so the 90-day initial backfill can commit progress incrementally. Fully backward compatible — existing CLI callers are unaffected.

## Jira

https://issues.redhat.com/browse/AAP-76646

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.