### PR TITLE
fix(AAP-75673): replace f-string SQL interpolation with parameterized queries in extractor_controller_db.py

### DIFF
--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -40,22 +40,18 @@ class ExtractorControllerDB:
             if since.tzinfo is None:
                 since = since.replace(tzinfo=datetime.UTC)
 
-            marker_cond = ''
+            marker = None
             while True:
-                cursor.execute(self.host_metric_query(since, marker_cond))
+                query, params = self.host_metric_query(since, marker)
+                cursor.execute(query, params)
                 host_metric = self.dict_fetchall(cursor)
 
                 # Marker based pagination
                 if len(host_metric) <= 0:
                     break
 
-                marker_cond = f"""
-                    AND CONCAT(main_hostmetric.hostname , '___', COALESCE(main_host.id, 0)) >
-                        '{list(host_metric)[-1]['hostname']}___{list(host_metric)[-1]['host_id']}'
-                    -- TODO wrong query, has to use several or conditions, but will it help with usage of index?
-                    -- AND main_hostmetric.hostname >= '{list(host_metric)[-1]['hostname']}'
-                    -- AND COALESCE(main_host.id, 0) > {list(host_metric)[-1]['host_id']}
-                """
+                last = list(host_metric)[-1]
+                marker = f"{last['hostname']}___{last['host_id']}"
 
                 host_metric = pd.DataFrame(host_metric)
 
@@ -111,17 +107,29 @@ class ExtractorControllerDB:
         """
         return query
 
-    def host_metric_query(self, since, marker_cond=''):
+    def host_metric_query(self, since, marker=None):
         """Build the host_metric SQL query with an optional keyset-pagination marker.
+
+        Uses parameterized queries to prevent SQL injection.
 
         Args:
             since: Inclusive lower bound timestamp (timezone-aware datetime).
-            marker_cond: Optional SQL fragment appended to the WHERE clause for
-                keyset pagination (default ``''`` returns all rows).
+            marker: Optional opaque cursor string (``'hostname___host_id'``) from the
+                last row of the previous page.  When provided, results are restricted
+                to rows whose concatenated ``hostname___host_id`` key sorts strictly
+                after this value.  Defaults to ``None``, which returns the first page.
 
         Returns:
-            SQL query string.
+            Tuple of ``(query_string, params_tuple)`` suitable for passing directly
+            to ``cursor.execute()``.
         """
+        if marker is not None:
+            marker_sql = 'AND CONCAT(main_hostmetric.hostname , \'___\', COALESCE(main_host.id, 0)) > %s'
+            params = (since, marker)
+        else:
+            marker_sql = ''
+            params = (since,)
+
         query = f"""
             SELECT main_hostmetric.hostname,
                    COALESCE(main_host.id, 0) AS host_id,
@@ -146,13 +154,13 @@ class ExtractorControllerDB:
 
             FROM main_hostmetric
             LEFT JOIN main_host ON main_host.name = main_hostmetric.hostname
-            WHERE (main_hostmetric.last_automation >= '{since.isoformat()}' {marker_cond})
+            WHERE (main_hostmetric.last_automation >= %s {marker_sql})
             ORDER BY CONCAT(main_hostmetric.hostname , '___', COALESCE(main_host.id, 0)) ASC
             -- ORDER BY main_hostmetric.hostname ASC, COALESCE(main_host.id, 0) ASC
             LIMIT {self.limit()}
         """
 
-        return query
+        return query, params
 
     @staticmethod
     def limit():


### PR DESCRIPTION
## Summary

Fixes **[AAP-75673](https://redhat.atlassian.net/browse/AAP-75673)** — SQL injection risk in `extractor_controller_db.py`.

The `host_metric_query` method was constructing SQL strings by interpolating values directly using f-strings:

- `'{since.isoformat()}'` — the datetime lower-bound was embedded as a literal string.
- The keyset-pagination marker condition embedded `hostname` and `host_id` values (read from the DB) directly into the SQL string via an f-string.

Both practices violate parameterized-query best practices and are exploitable if upstream data is ever compromised.

## Changes

- Replace `'{since.isoformat()}'` in the `WHERE` clause with a `%s` placeholder; `since` is now passed as the first element of the params tuple to `cursor.execute()`.
- Replace the f-string `marker_cond` SQL fragment with a static SQL snippet using a `%s` placeholder; the actual marker value (an opaque `hostname___host_id` string) is passed as the second parameter.
- Refactor `host_metric_query` to return `(query_string, params_tuple)` instead of a bare string — callers unpack directly into `cursor.execute(query, params)`.
- Refactor `iter_batches` to pass `marker=None` for the first page and `marker = f"{last['hostname']}___{last['host_id']}"` for subsequent pages, keeping all pagination logic intact.
- `LIMIT` remains an f-string interpolation of `self.limit()` which is a static `int` (`10000`) — not user-controlled, not a security risk.
- All existing functionality is preserved; no unrelated code is touched.

## Test plan

- [ ] Verify first-page query executes without the marker condition (`marker=None`).
- [ ] Verify subsequent pages include the `AND CONCAT(...) > %s` condition with the correct cursor string.
- [ ] Confirm `ruff check` passes on the modified file (verified locally — all checks passed).
- [ ] Run the extractor against a Controller database and confirm data is extracted correctly across multiple pages.

🤖 Generated with [Debuggernaut](https://github.com/ansible/metrics-utility) — automated bug-fix agent