### PR TITLE
fix: AAP-75681 extract hardcoded magic values to constants and env-var overrides

### DIFF
--- a/metrics_utility/__init__.py
+++ b/metrics_utility/__init__.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 
+from metrics_utility.constants import DEFAULT_AWX_PATH
 from metrics_utility.management_utility import ManagementUtility
 
 
@@ -9,7 +10,7 @@ def prepare():
     """Tries to find awx modules. Either we're already in the venv, or it can be configured through AWX_PATH, or we fall back to the mock."""
     spec = importlib.util.find_spec('awx')
     if spec is None:
-        awx_path = os.getenv('AWX_PATH', '/awx_devel')
+        awx_path = DEFAULT_AWX_PATH
         sys.path.append(awx_path)
 
         spec = importlib.util.find_spec('awx')

--- a/metrics_utility/automation_controller_billing/package/package_crc.py
+++ b/metrics_utility/automation_controller_billing/package/package_crc.py
@@ -10,6 +10,7 @@ from django.conf import settings
 
 import metrics_utility.base as base
 
+from metrics_utility.constants import CA_BUNDLE_PATH, DEFAULT_CRC_INGRESS_URL, DEFAULT_CRC_SSO_URL, HTTP_TIMEOUT
 from metrics_utility.exceptions import FailedToUploadPayload
 from metrics_utility.logger import logger
 
@@ -21,7 +22,7 @@ class PackageCRC(base.Package):
     SSO endpoint before uploading.
     """
 
-    CERT_PATH = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    CERT_PATH = CA_BUNDLE_PATH
     PAYLOAD_CONTENT_TYPE = 'application/vnd.redhat.aap-billing-controller.aap_billing_controller_payload+tgz'
 
     SHIPPING_AUTH_SERVICE_ACCOUNT = 'service-account'
@@ -31,10 +32,10 @@ class PackageCRC(base.Package):
         return f'{settings.SYSTEM_UUID}-{timestamp.strftime("%Y-%m-%d-%H%M%S%z")}'
 
     def get_sso_url(self):
-        return os.getenv('METRICS_UTILITY_CRC_SSO_URL', 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token')
+        return DEFAULT_CRC_SSO_URL
 
     def get_ingress_url(self):
-        return os.getenv('METRICS_UTILITY_CRC_INGRESS_URL', 'https://console.redhat.com/api/ingress/v1/upload')
+        return DEFAULT_CRC_INGRESS_URL
 
     def get_proxy_url(self):
         return os.getenv('METRICS_UTILITY_PROXY_URL')
@@ -87,7 +88,7 @@ class PackageCRC(base.Package):
 
             data = {'client_id': self._get_rh_user(), 'client_secret': self._get_rh_password(), 'grant_type': 'client_credentials'}
 
-            r = requests.post(sso_url, headers=headers, data=data, verify=self.CERT_PATH, timeout=(31, 31))
+            r = requests.post(sso_url, headers=headers, data=data, verify=self.CERT_PATH, timeout=HTTP_TIMEOUT)
             access_token = json.loads(r.content)['access_token']
 
             #################################
@@ -105,7 +106,7 @@ class PackageCRC(base.Package):
                 verify=self.CERT_PATH,
                 proxies=proxies,
                 headers=headers,
-                timeout=(31, 31),
+                timeout=HTTP_TIMEOUT,
             )
 
         elif self.shipping_auth_mode() == self.SHIPPING_AUTH_USERPASS:
@@ -115,11 +116,11 @@ class PackageCRC(base.Package):
                 verify=self.CERT_PATH,
                 auth=(self._get_rh_user(), self._get_rh_password()),
                 headers=session.headers,
-                timeout=(31, 31),
+                timeout=HTTP_TIMEOUT,
             )
 
         else:
-            response = session.post(url, files=files, headers=session.headers, timeout=(31, 31))
+            response = session.post(url, files=files, headers=session.headers, timeout=HTTP_TIMEOUT)
 
         # Accept 2XX status_codes
         if response.status_code >= 300:

--- a/metrics_utility/base/package.py
+++ b/metrics_utility/base/package.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 
 import requests
 
+from metrics_utility.constants import CA_BUNDLE_PATH, HTTP_TIMEOUT, MAX_DATA_SIZE
 from metrics_utility.logger import logger
 
 from .collection_data_status import CollectionDataStatus
@@ -26,7 +27,7 @@ class Package:
     See the README.md and tests/functional/test_gathering.py to see how are packages used
     """
 
-    CERT_PATH = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    CERT_PATH = CA_BUNDLE_PATH
     # i.e. "application/vnd.redhat.tower.tower_payload+tgz"
     PAYLOAD_CONTENT_TYPE = 'application/vnd.redhat.TODO+tgz'
 
@@ -43,7 +44,7 @@ class Package:
 
     Split large table dumps at dump time into a series of files.
     """
-    MAX_DATA_SIZE = 200 * 1048576
+    MAX_DATA_SIZE = MAX_DATA_SIZE
 
     def __init__(self, collector):
         self.collector = collector
@@ -230,10 +231,10 @@ class Package:
                 verify=self.CERT_PATH,
                 auth=(self._get_rh_user(), self._get_rh_password()),
                 headers=session.headers,
-                timeout=(31, 31),
+                timeout=HTTP_TIMEOUT,
             )
         else:
-            response = session.post(url, files=files, headers=session.headers, timeout=(31, 31))
+            response = session.post(url, files=files, headers=session.headers, timeout=HTTP_TIMEOUT)
 
         # Accept 2XX status_codes
         if response.status_code >= 300:

--- a/metrics_utility/constants.py
+++ b/metrics_utility/constants.py
@@ -1,0 +1,69 @@
+"""Named constants and environment-variable-tunable defaults for metrics-utility.
+
+Hardcoded "magic values" have been extracted here so they are easy to find,
+document, and override without touching business logic.  Tunable values are
+read from environment variables at import time so that operator deployments can
+adjust them without code changes.
+"""
+
+import os
+
+
+# ---------------------------------------------------------------------------
+# TLS / Certificate paths
+# ---------------------------------------------------------------------------
+
+#: System CA bundle used when verifying HTTPS connections to Red Hat services.
+#: Override via the ``METRICS_UTILITY_CA_BUNDLE_PATH`` environment variable.
+CA_BUNDLE_PATH: str = os.getenv(
+    "METRICS_UTILITY_CA_BUNDLE_PATH",
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+)
+
+# ---------------------------------------------------------------------------
+# HTTP timeouts (seconds)
+# ---------------------------------------------------------------------------
+
+#: ``(connect_timeout, read_timeout)`` tuple used for outbound HTTP requests.
+#: Override the connect timeout via ``METRICS_UTILITY_HTTP_CONNECT_TIMEOUT``
+#: and the read timeout via ``METRICS_UTILITY_HTTP_READ_TIMEOUT``.
+_http_connect_timeout: int = int(os.getenv("METRICS_UTILITY_HTTP_CONNECT_TIMEOUT", "31"))
+_http_read_timeout: int = int(os.getenv("METRICS_UTILITY_HTTP_READ_TIMEOUT", "31"))
+HTTP_TIMEOUT: tuple = (_http_connect_timeout, _http_read_timeout)
+
+# ---------------------------------------------------------------------------
+# Upload / file-size limits
+# ---------------------------------------------------------------------------
+
+#: Maximum payload size (bytes) before a collection is split into smaller
+#: chunks.  Defaults to 200 MiB (the upload limit is 100 MiB; 50 % compression
+#: is assumed).  Override via ``METRICS_UTILITY_MAX_DATA_SIZE_MB`` (in MiB).
+_max_data_size_mb: int = int(os.getenv("METRICS_UTILITY_MAX_DATA_SIZE_MB", "200"))
+MAX_DATA_SIZE: int = _max_data_size_mb * 1048576
+
+# ---------------------------------------------------------------------------
+# AWX / Automation Controller path
+# ---------------------------------------------------------------------------
+
+#: Filesystem path where the AWX Python package can be found when it is not
+#: already on ``sys.path``.  Override via the ``AWX_PATH`` environment
+#: variable.
+DEFAULT_AWX_PATH: str = os.getenv("AWX_PATH", "/awx_devel")
+
+# ---------------------------------------------------------------------------
+# Red Hat SSO and CRC Ingress URLs
+# ---------------------------------------------------------------------------
+
+#: OAuth2 token endpoint used to obtain a bearer token for CRC uploads.
+#: Override via ``METRICS_UTILITY_CRC_SSO_URL``.
+DEFAULT_CRC_SSO_URL: str = os.getenv(
+    "METRICS_UTILITY_CRC_SSO_URL",
+    "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+)
+
+#: CRC Ingress API endpoint where billing payloads are uploaded.
+#: Override via ``METRICS_UTILITY_CRC_INGRESS_URL``.
+DEFAULT_CRC_INGRESS_URL: str = os.getenv(
+    "METRICS_UTILITY_CRC_INGRESS_URL",
+    "https://console.redhat.com/api/ingress/v1/upload",
+)


### PR DESCRIPTION
## Summary

Resolves [AAP-75681] — hardcoded magic values scattered throughout the codebase.

Creates `metrics_utility/constants.py` as the single source of truth for values that were previously scattered as string and numeric literals. All tunable values are read from environment variables at import time, with the original literals as documented defaults.

### Constants introduced

| Constant | Env var override | Default |
|---|---|---|
| `CA_BUNDLE_PATH` | `METRICS_UTILITY_CA_BUNDLE_PATH` | `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` |
| `HTTP_TIMEOUT` | `METRICS_UTILITY_HTTP_CONNECT_TIMEOUT` / `METRICS_UTILITY_HTTP_READ_TIMEOUT` | `(31, 31)` |
| `MAX_DATA_SIZE` | `METRICS_UTILITY_MAX_DATA_SIZE_MB` | `200 * 1048576` (200 MiB) |
| `DEFAULT_AWX_PATH` | `AWX_PATH` | `/awx_devel` |
| `DEFAULT_CRC_SSO_URL` | `METRICS_UTILITY_CRC_SSO_URL` | `https://sso.redhat.com/...` |
| `DEFAULT_CRC_INGRESS_URL` | `METRICS_UTILITY_CRC_INGRESS_URL` | `https://console.redhat.com/...` |

### Files changed

- `metrics_utility/constants.py` — **new file**, defines all constants
- `metrics_utility/automation_controller_billing/package/package_crc.py` — imports and uses `CA_BUNDLE_PATH`, `HTTP_TIMEOUT`, `DEFAULT_CRC_SSO_URL`, `DEFAULT_CRC_INGRESS_URL`
- `metrics_utility/base/package.py` — imports and uses `CA_BUNDLE_PATH`, `HTTP_TIMEOUT`, `MAX_DATA_SIZE`
- `metrics_utility/__init__.py` — imports and uses `DEFAULT_AWX_PATH`

## Test plan

- [ ] Verify existing tests pass (`tox`)
- [ ] Confirm that setting `METRICS_UTILITY_CA_BUNDLE_PATH`, `METRICS_UTILITY_HTTP_CONNECT_TIMEOUT`, `METRICS_UTILITY_HTTP_READ_TIMEOUT`, `METRICS_UTILITY_MAX_DATA_SIZE_MB`, `METRICS_UTILITY_CRC_SSO_URL`, `METRICS_UTILITY_CRC_INGRESS_URL` overrides the respective values at runtime
- [ ] Confirm that unsetting all env vars falls back to the original defaults, preserving backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Debuggernaut