### PR TITLE
tests run_*_ext: don't create __pycache__, remove unused var, add lang & tz default

### DIFF
--- a/metrics_utility/test/snapshot_tests/snapshot_utils.py
+++ b/metrics_utility/test/snapshot_tests/snapshot_utils.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import os
 import re
@@ -15,6 +14,7 @@ import openpyxl
 import openpyxl.utils
 
 from metrics_utility.logger import logger
+from metrics_utility.test.util import _SUBPROCESS_BASE_ENV
 
 
 warnings.filterwarnings('ignore', category=ResourceWarning)
@@ -160,8 +160,7 @@ def run_snapshot_definition(data: DataShape) -> str:
     Returns:
         str: The path to the generated .xlsx file, or an empty string if it could not be determined.
     """
-    env_vars = copy.deepcopy(data['env_vars'])
-    env_vars['AWX_LOGGING_MODE'] = 'stdout'
+    env_vars = {**_SUBPROCESS_BASE_ENV, **data['env_vars']}
 
     params = [sys.executable]
     params.extend(data['params'])

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -43,7 +43,6 @@ def temporary_env(new_env):
 # Running a command as an external command, to test we can
 
 _SUBPROCESS_BASE_ENV = {
-    'AWX_LOGGING_MODE': 'stdout',
     'PYTHONDONTWRITEBYTECODE': '1',
     'TZ': 'UTC',
     'LANG': 'en_US.UTF-8',

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -42,6 +42,13 @@ def temporary_env(new_env):
 
 # Running a command as an external command, to test we can
 
+_SUBPROCESS_BASE_ENV = {
+    'AWX_LOGGING_MODE': 'stdout',
+    'PYTHONDONTWRITEBYTECODE': '1',
+    'TZ': 'UTC',
+    'LANG': 'en_US.UTF-8',
+}
+
 
 def _run_ext(env, name, args):
     """Run a management command as a subprocess and fail the test on non-zero exit.
@@ -59,7 +66,7 @@ def _run_ext(env, name, args):
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={'AWX_LOGGING_MODE': 'stdout', **env},
+        env={**_SUBPROCESS_BASE_ENV, **env},
     )
 
     status = result.returncode


### PR DESCRIPTION
During tests, `run_build_ext` and `run_gather_ext` run the full command in a new subprocess, with clean environment (except adding `AWX_LOGGING_MODE=stdout`). The same happens in snapshot tests.

Which means running tests leaves `__pycache__` dirs all over the tree, ignoring user settings like `PYTHONPYCACHEPREFIX` or `PYTHONDONTWRITEBYTECODE`.

Additionally, `AWX_LOGGING_MODE=stdout` is only relevant when running in the actual controller environment, which is not something happening during the tests - removing.

This changes the clean environment to:

```
LANG=en_US.UTF-8
PYTHONDONTWRITEBYTECODE=1
TZ=UTC
```