### PR TITLE
CI - run metrics-service tests against local metrics-utility

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -150,3 +150,75 @@ jobs:
             -Dsonar.organization=ansible
             -Dsonar.projectKey=ansible_metrics-utility
             -Dsonar.python.coverage.reportPaths=coverage.xml
+
+  pytest-service:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout metrics-utility"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v7
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: "Set up postgresql"
+        run: |
+          sudo apt install postgresql postgresql-client
+          sudo systemctl start postgresql.service
+
+      - name: "Wait for postgresql"
+        timeout-minutes: 1
+        run: |
+          until pg_isready; do
+            sleep 4
+          done
+
+      - name: "Import SQL dump"
+        run: |
+          cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags}.sql | sudo su - postgres -c psql
+
+      - name: "Clone metrics-service"
+        uses: actions/checkout@v6
+        with:
+          repository: ansible/metrics-service
+          ref: devel
+          path: metrics-service-checkout
+
+      - name: "Install metrics-service with local metrics-utility"
+        working-directory: metrics-service-checkout
+        run: |
+          uv add --editable "${GITHUB_WORKSPACE}"
+
+      - name: "Run migrations"
+        working-directory: metrics-service-checkout
+        env:
+          METRICS_SERVICE_DATABASES__default__HOST: localhost
+          METRICS_SERVICE_DATABASES__default__USER: metrics_service
+          METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
+          METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: disable
+          METRICS_SERVICE_MODE: test
+          DJANGO_SETTINGS_MODULE: metrics_service.settings
+        run: |
+          uv run python manage.py migrate --noinput
+
+      - name: "Run metrics-service pytest"
+        working-directory: metrics-service-checkout
+        env:
+          METRICS_SERVICE_DATABASES__default__HOST: localhost
+          METRICS_SERVICE_DATABASES__default__PORT: "5432"
+          METRICS_SERVICE_DATABASES__default__USER: metrics_service
+          METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
+          METRICS_SERVICE_DATABASES__default__NAME: metrics_service
+          METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: disable
+          METRICS_SERVICE_DATABASES__awx__HOST: localhost
+          METRICS_SERVICE_DATABASES__awx__PASSWORD: mypassword
+          DJANGO_SETTINGS_MODULE: metrics_service.settings
+          METRICS_SERVICE_MODE: test
+        run: |
+          uv run pytest -s -v


### PR DESCRIPTION
Issue: AAP-75297 (first step), AAP-75299

Adds a `pytest-service` CI job that:
- Sets up postgres with the same SQL dumps as the utility job (roles.sql already creates the `metrics_service` role + database)
- Clones `metrics-service@devel`
- Installs it with the current checkout of metrics-utility via `uv add --editable`
- Runs migrations and the service test suite

(Duplicates the setup for now, to be fixed in the merge pr)

This catches utility changes that break the service, without requiring any changes to metrics-service.

Future steps (separate PRs):
- Merge docker-compose environments using profiles
- Consolidate tools directories
