### PR TITLE
add mock Prometheus server for vCPU collector integration tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -91,12 +91,15 @@ jobs:
         with:
           go-version-file: tools/mock-segment-server/go.mod
 
-      - name: "Start mock Segment server"
+      - name: "Start mock servers"
         timeout-minutes: 1
         run: |
           go build -C tools/mock-segment-server -o /tmp/mock-segment-server .
+          go build -C tools/mock-prometheus-server -o /tmp/mock-prometheus-server .
           /tmp/mock-segment-server &
+          /tmp/mock-prometheus-server &
           until curl -sf http://localhost:8765/requests > /dev/null; do sleep 1; done
+          until curl -sf http://localhost:9090/requests > /dev/null; do sleep 1; done
 
       - name: "Run pytest"
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,6 +106,8 @@ jobs:
           METRICS_UTILITY_BUCKET_REGION: "us-east-1"
           METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
           METRICS_UTILITY_DB_HOST: "localhost"
+          MOCK_SEGMENT_URL: "http://localhost:8765"
+          MOCK_PROMETHEUS_URL: "http://localhost:9090"
         run: |
           uv run pytest -s -v --cov=. --cov-branch --cov-report=xml
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ compose:
 	${CONTAINER_ENGINE} compose -f tools/docker/docker-compose.yaml up
 
 clean:
-	${CONTAINER_ENGINE} compose -f tools/docker/docker-compose.yaml down -v
+	${CONTAINER_ENGINE} compose -f tools/docker/docker-compose.yaml down -v --rmi local
 
 psql:
 	${CONTAINER_ENGINE} compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx
@@ -33,7 +33,7 @@ pcompose:
 	podman-compose -f tools/docker/docker-compose.yaml up
 
 pclean:
-	podman-compose -f tools/docker/docker-compose.yaml down -v
+	podman-compose -f tools/docker/docker-compose.yaml down -v --rmi local
 
 ppsql:
 	podman-compose -f tools/docker/docker-compose.yaml exec postgres psql -U awx

--- a/metrics_utility/test/gather/test_vcpu_gather_integration.py
+++ b/metrics_utility/test/gather/test_vcpu_gather_integration.py
@@ -1,0 +1,140 @@
+"""Integration test: vCPU gather against mock Prometheus with schema validation."""
+
+import glob
+import io
+import json
+import os
+import tarfile
+import urllib.request
+
+from importlib.resources import files
+from unittest.mock import patch
+
+import jsonschema
+import pytest
+
+from metrics_utility.test.util import run_gather_int
+
+
+MOCK_PROMETHEUS_URL = os.getenv('MOCK_PROMETHEUS_URL', 'http://localhost:9090')
+
+K8S_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+K8S_CERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+
+_original_exists = os.path.exists
+_original_open = open
+
+
+def _fake_exists(path):
+    if path in (K8S_TOKEN_PATH, K8S_CERT_PATH):
+        return True
+    return _original_exists(path)
+
+
+def _fake_open(path, *args, **kwargs):
+    if str(path) == K8S_TOKEN_PATH:
+        return io.StringIO('fake-token')
+    return _original_open(path, *args, **kwargs)
+
+
+env_vars = {
+    'METRICS_UTILITY_CLUSTER_NAME': 'test-cluster',
+    'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': 'true',
+    'METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES': 'true',
+    'METRICS_UTILITY_OPTIONAL_COLLECTORS': 'total_workers_vcpu',
+    'METRICS_UTILITY_PROMETHEUS_URL': MOCK_PROMETHEUS_URL,
+    'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
+    'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
+    'METRICS_UTILITY_SHIP_TARGET': 'directory',
+    'METRICS_UTILITY_USAGE_BASED_METERING_ENABLED': 'true',
+}
+
+year = '2025'
+uuid = '00000000-0000-0000-0000-000000000000'
+file_glob = f'./metrics_utility/test/test_data/data/{year}/*/*/{uuid}-*.tar.gz'
+
+
+def _load_schema(filename):
+    return json.loads(files('metrics_utility.schemas').joinpath(filename).read_text())
+
+
+def _configure_mock(**kwargs):
+    data = json.dumps(kwargs).encode()
+    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
+    req.add_header('Content-Type', 'application/json')
+    urllib.request.urlopen(req, timeout=5)
+
+
+def _reset_mock():
+    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
+    urllib.request.urlopen(req, timeout=5)
+
+
+@pytest.fixture
+def cleanup_glob():
+    for f in glob.glob(file_glob):
+        os.remove(f)
+    yield
+    for f in glob.glob(file_glob):
+        os.remove(f)
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+@patch('metrics_utility.automation_controller_billing.collectors.open', create=True, side_effect=_fake_open)
+@patch('metrics_utility.automation_controller_billing.collectors.os.path.exists', side_effect=_fake_exists)
+def test_vcpu_gather_validates_against_schema(mock_exists, mock_open, cleanup_glob):
+    _reset_mock()
+    _configure_mock(cpu_value='16', empty_result=False)
+
+    run_gather_int(
+        env_vars,
+        {
+            'ship': True,
+            'since': '2025-06-12',
+            'until': '2025-06-14',
+        },
+    )
+
+    tarballs = glob.glob(file_glob)
+    assert len(tarballs) > 0, f'No tarballs found matching {file_glob}'
+
+    vcpu_data = None
+    manifest_data = None
+    for tarball_path in tarballs:
+        with tarfile.open(tarball_path, 'r:gz') as tar:
+            try:
+                vcpu_member = tar.extractfile('./total_workers_vcpu.json')
+            except KeyError:
+                continue
+            if vcpu_member is None:
+                continue
+            vcpu_data = json.load(vcpu_member)
+
+            manifest_member = tar.extractfile('./manifest.json')
+            if manifest_member is not None:
+                manifest_data = json.load(manifest_member)
+            break
+
+    assert vcpu_data is not None, 'total_workers_vcpu.json not found in any tarball'
+
+    # validate against JSON schema
+    schema = _load_schema('total_workers_vcpu-1.0.jsonschema')
+    jsonschema.validate(instance=vcpu_data, schema=schema)
+
+    # verify data came from mock Prometheus (not the stub value of 1)
+    assert vcpu_data['total_workers_vcpu'] == 16
+    assert vcpu_data['cluster_name'] == 'test-cluster'
+    assert 'timestamp' in vcpu_data
+
+    # validate manifest references vcpu
+    assert manifest_data is not None, 'manifest.json not found in tarball'
+    manifest_schema = _load_schema('manifest.jsonschema')
+    jsonschema.validate(instance=manifest_data, schema=manifest_schema)
+    assert 'total_workers_vcpu.json' in manifest_data
+
+    # verify Prometheus was actually called (instant + range query)
+    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests', timeout=5) as resp:
+        captured = json.loads(resp.read())
+    paths = [r['path'] for r in captured]
+    assert '/api/v1/query' in paths
+    assert '/api/v1/query_range' in paths

--- a/metrics_utility/test/gather/test_vcpu_gather_integration.py
+++ b/metrics_utility/test/gather/test_vcpu_gather_integration.py
@@ -62,12 +62,12 @@ def _configure_mock(**kwargs):
     data = json.dumps(kwargs).encode()
     req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
     req.add_header('Content-Type', 'application/json')
-    urllib.request.urlopen(req, timeout=5)
+    urllib.request.urlopen(req)
 
 
 def _reset_mock():
     req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
-    urllib.request.urlopen(req, timeout=5)
+    urllib.request.urlopen(req)
 
 
 @pytest.fixture
@@ -133,7 +133,7 @@ def test_vcpu_gather_validates_against_schema(mock_exists, mock_open, cleanup_gl
     assert 'total_workers_vcpu.json' in manifest_data
 
     # verify Prometheus was actually called (instant + range query)
-    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests', timeout=5) as resp:
+    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests') as resp:
         captured = json.loads(resp.read())
     paths = [r['path'] for r in captured]
     assert '/api/v1/query' in paths

--- a/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
@@ -156,3 +156,25 @@ class TestVcpuHelpersIntegration:
         value = client.get_current_value('sum(machine_cpu_cores)')
 
         assert value == pytest.approx(32.0)
+
+    def test_range_query_varying_values(self):
+        configure_mock(cpu_value=['8', '16', '24'])
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        start = 1700000000.0
+        end = 1700000600.0  # 10 minutes later
+        result = client.query_range('sum(machine_cpu_cores)', start_time=start, end_time=end, step='5m')
+
+        values = result['data']['result'][0]['values']
+        assert len(values) == 3
+        assert float(values[0][1]) == pytest.approx(8.0)
+        assert float(values[1][1]) == pytest.approx(16.0)
+        assert float(values[2][1]) == pytest.approx(24.0)
+
+    def test_instant_query_returns_last_value_from_list(self):
+        configure_mock(cpu_value=['8', '16', '24'])
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        value = client.get_current_value('sum(machine_cpu_cores)')
+
+        assert value == pytest.approx(24.0)

--- a/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
@@ -1,0 +1,158 @@
+"""Integration tests for PrometheusClient against the mock-prometheus-server container.
+
+These tests require the mock-prometheus service to be running (via `make compose`).
+"""
+
+import json
+import urllib.request
+
+import pytest
+
+from metrics_utility.library.collectors.others.total_workers_vcpu import (
+    PrometheusClient,
+    get_cpu_timeline,
+    get_total_workers_cpu,
+)
+
+
+MOCK_PROMETHEUS_URL = 'http://localhost:9090'
+
+
+def is_mock_prometheus_available():
+    try:
+        urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/config', timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+requires_mock_prometheus = pytest.mark.skipif(
+    not is_mock_prometheus_available(),
+    reason='mock-prometheus server not running (start with `make compose`)',
+)
+
+
+def reset_mock():
+    urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/reset', timeout=5)
+
+
+def configure_mock(**kwargs):
+    data = json.dumps(kwargs).encode()
+    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
+    req.add_header('Content-Type', 'application/json')
+    urllib.request.urlopen(req, timeout=5)
+
+
+def get_captured_requests():
+    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests', timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+@requires_mock_prometheus
+class TestPrometheusClientIntegration:
+    def setup_method(self):
+        reset_mock()
+        configure_mock(cpu_value='16', empty_result=False)
+
+    def test_instant_query(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        result = client.query('sum(machine_cpu_cores)')
+
+        assert len(result) == 1
+        assert float(result[0]['value'][1]) == pytest.approx(16.0)
+
+        captured = get_captured_requests()
+        assert len(captured) == 1
+        assert captured[0]['path'] == '/api/v1/query'
+        assert captured[0]['params']['query'] == 'sum(machine_cpu_cores)'
+
+    def test_instant_query_with_time_param(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        result = client.query('up', time_param=1700000000.0)
+
+        assert len(result) == 1
+        assert float(result[0]['value'][0]) == pytest.approx(1700000000.0)
+
+    def test_range_query(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        start = 1700000000.0
+        end = 1700003600.0  # 1 hour later
+        result = client.query_range('sum(machine_cpu_cores)', start_time=start, end_time=end, step='5m')
+
+        assert result['status'] == 'success'
+        values = result['data']['result'][0]['values']
+        # 1 hour / 5 min = 12 intervals + 1 = 13 data points
+        assert len(values) == 13
+        for ts, val in values:
+            assert float(val) == pytest.approx(16.0)
+
+        captured = get_captured_requests()
+        assert len(captured) == 1
+        assert captured[0]['path'] == '/api/v1/query_range'
+        assert captured[0]['params']['step'] == '5m'
+
+    def test_get_current_value(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        value = client.get_current_value('sum(machine_cpu_cores)')
+
+        assert value == pytest.approx(16.0)
+
+    def test_get_current_value_empty_result(self):
+        configure_mock(empty_result=True)
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        value = client.get_current_value('sum(machine_cpu_cores)')
+
+        assert value is None
+
+
+@requires_mock_prometheus
+class TestVcpuHelpersIntegration:
+    def setup_method(self):
+        reset_mock()
+        configure_mock(cpu_value='16', empty_result=False)
+
+    def test_get_total_workers_cpu(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        base_ts = 1700000000.0
+        vcpu_val, query = get_total_workers_cpu(client, base_ts)
+
+        assert vcpu_val == pytest.approx(16.0)
+        assert 'max_over_time' in query
+        assert 'sum(machine_cpu_cores)' in query
+
+    def test_get_total_workers_cpu_no_data(self):
+        configure_mock(empty_result=True)
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        vcpu_val, query = get_total_workers_cpu(client, 1700000000.0)
+
+        assert vcpu_val is None
+
+    def test_get_cpu_timeline(self):
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        start = 1700000000.0
+        end = 1700003600.0
+
+        timeline = get_cpu_timeline(client, start, end)
+
+        assert len(timeline) == 13
+        for entry in timeline:
+            assert entry['cpu_sum'] == pytest.approx(16.0)
+            assert 'timestamp' in entry
+
+    def test_get_cpu_timeline_empty(self):
+        configure_mock(empty_result=True)
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        timeline = get_cpu_timeline(client, 1700000000.0, 1700003600.0)
+
+        assert timeline == []
+
+    def test_dynamic_cpu_value(self):
+        configure_mock(cpu_value='32')
+
+        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        value = client.get_current_value('sum(machine_cpu_cores)')
+
+        assert value == pytest.approx(32.0)

--- a/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
@@ -18,18 +18,18 @@ MOCK_PROMETHEUS_URL = os.getenv('MOCK_PROMETHEUS_URL', 'http://localhost:9090')
 
 def reset_mock():
     req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
-    urllib.request.urlopen(req, timeout=5)
+    urllib.request.urlopen(req)
 
 
 def configure_mock(**kwargs):
     data = json.dumps(kwargs).encode()
     req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
     req.add_header('Content-Type', 'application/json')
-    urllib.request.urlopen(req, timeout=5)
+    urllib.request.urlopen(req)
 
 
 def get_captured_requests():
-    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests', timeout=5) as resp:
+    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests') as resp:
         return json.loads(resp.read())
 
 

--- a/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
@@ -1,9 +1,7 @@
-"""Integration tests for PrometheusClient against the mock-prometheus-server container.
-
-These tests require the mock-prometheus service to be running (via `make compose`).
-"""
+"""Integration tests for PrometheusClient against the mock-prometheus-server container."""
 
 import json
+import os
 import urllib.request
 
 import pytest
@@ -15,25 +13,12 @@ from metrics_utility.library.collectors.others.total_workers_vcpu import (
 )
 
 
-MOCK_PROMETHEUS_URL = 'http://localhost:9090'
-
-
-def is_mock_prometheus_available():
-    try:
-        urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/config', timeout=2)
-        return True
-    except Exception:
-        return False
-
-
-requires_mock_prometheus = pytest.mark.skipif(
-    not is_mock_prometheus_available(),
-    reason='mock-prometheus server not running (start with `make compose`)',
-)
+MOCK_PROMETHEUS_URL = os.getenv('MOCK_PROMETHEUS_URL', 'http://localhost:9090')
 
 
 def reset_mock():
-    urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/reset', timeout=5)
+    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
+    urllib.request.urlopen(req, timeout=5)
 
 
 def configure_mock(**kwargs):
@@ -48,7 +33,6 @@ def get_captured_requests():
         return json.loads(resp.read())
 
 
-@requires_mock_prometheus
 class TestPrometheusClientIntegration:
     def setup_method(self):
         reset_mock()
@@ -106,7 +90,6 @@ class TestPrometheusClientIntegration:
         assert value is None
 
 
-@requires_mock_prometheus
 class TestVcpuHelpersIntegration:
     def setup_method(self):
         reset_mock()

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -903,7 +903,7 @@ def _validate_all_data(json_data, statistics):
     print('✅ All data value assertions passed!')
 
 
-MOCK_SEGMENT_URL = 'http://localhost:8765'
+MOCK_SEGMENT_URL = os.getenv('MOCK_SEGMENT_URL', 'http://localhost:8765')
 
 
 def test_from_gather_to_json(cleanup_glob):
@@ -990,7 +990,8 @@ def test_from_gather_to_json(cleanup_glob):
     print(f'\nSending rollup to mock Segment server at {MOCK_SEGMENT_URL} ...')
 
     # Clear any requests captured from previous test runs.
-    urllib.request.urlopen(f'{MOCK_SEGMENT_URL}/reset', timeout=10)
+    req = urllib.request.Request(f'{MOCK_SEGMENT_URL}/reset', method='POST')
+    urllib.request.urlopen(req, timeout=10)
 
     storage = StorageSegment(write_key='test-key', host=MOCK_SEGMENT_URL)
     chunks = storage.put('anonymized_rollup', dict=json_data)

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -991,7 +991,7 @@ def test_from_gather_to_json(cleanup_glob):
 
     # Clear any requests captured from previous test runs.
     req = urllib.request.Request(f'{MOCK_SEGMENT_URL}/reset', method='POST')
-    urllib.request.urlopen(req, timeout=10)
+    urllib.request.urlopen(req)
 
     storage = StorageSegment(write_key='test-key', host=MOCK_SEGMENT_URL)
     chunks = storage.put('anonymized_rollup', dict=json_data)
@@ -999,7 +999,7 @@ def test_from_gather_to_json(cleanup_glob):
     assert chunks, 'StorageSegment.put() should return a non-empty list of chunks'
 
     # Fetch what the mock server captured.
-    with urllib.request.urlopen(f'{MOCK_SEGMENT_URL}/requests', timeout=10) as resp:
+    with urllib.request.urlopen(f'{MOCK_SEGMENT_URL}/requests') as resp:
         captured = json.loads(resp.read())
 
     assert len(captured) == len(chunks), f'Mock Segment server received {len(captured)} POST requests but expected {len(chunks)} (one per chunk)'

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -118,7 +118,6 @@ services:
       - "9090:9090"
     environment:
       MOCK_PROMETHEUS_PORT: "9090"
-      MOCK_PROMETHEUS_CPU_VALUE: "16"
 
   metrics-utility-env:
     build:

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -110,6 +110,16 @@ services:
       MOCK_SEGMENT_PORT: "8765"
       MOCK_SEGMENT_OUTPUT: "/tmp/segment/requests.jsonl"
 
+  mock-prometheus:
+    build:
+      context: ../mock-prometheus-server
+    container_name: mock-prometheus
+    ports:
+      - "9090:9090"
+    environment:
+      MOCK_PROMETHEUS_PORT: "9090"
+      MOCK_PROMETHEUS_CPU_VALUE: "16"
+
   metrics-utility-env:
     build:
       context: .

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -71,6 +71,10 @@ services:
         condition: service_completed_successfully
       postgres-wait:
         condition: service_completed_successfully
+      mock-segment:
+        condition: service_started
+      mock-prometheus:
+        condition: service_started
     volumes:
       - ../..:/app_ro
     tmpfs:
@@ -84,6 +88,8 @@ services:
       METRICS_UTILITY_BUCKET_REGION: "us-east-1"
       METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
       METRICS_UTILITY_DB_HOST: "postgres"
+      MOCK_SEGMENT_URL: "http://mock-segment:8765"
+      MOCK_PROMETHEUS_URL: "http://mock-prometheus:9090"
     entrypoint: |
       sh -c '
         set -e
@@ -104,11 +110,8 @@ services:
     container_name: mock-segment
     ports:
       - "8765:8765"
-    tmpfs:
-      - /tmp/segment:rw,mode=1777
     environment:
       MOCK_SEGMENT_PORT: "8765"
-      MOCK_SEGMENT_OUTPUT: "/tmp/segment/requests.jsonl"
 
   mock-prometheus:
     build:

--- a/tools/mock-prometheus-server/Dockerfile
+++ b/tools/mock-prometheus-server/Dockerfile
@@ -4,6 +4,8 @@ COPY go.mod main.go ./
 RUN CGO_ENABLED=0 go build -o mock-prometheus-server .
 
 FROM alpine:3
+RUN addgroup -S app && adduser -S -G app app
 COPY --from=builder /build/mock-prometheus-server /usr/local/bin/mock-prometheus-server
+USER app
 EXPOSE 9090
 ENTRYPOINT ["mock-prometheus-server"]

--- a/tools/mock-prometheus-server/Dockerfile
+++ b/tools/mock-prometheus-server/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:alpine AS builder
+WORKDIR /build
+COPY go.mod main.go ./
+RUN CGO_ENABLED=0 go build -o mock-prometheus-server .
+
+FROM alpine:3
+COPY --from=builder /build/mock-prometheus-server /usr/local/bin/mock-prometheus-server
+EXPOSE 9090
+ENTRYPOINT ["mock-prometheus-server"]

--- a/tools/mock-prometheus-server/go.mod
+++ b/tools/mock-prometheus-server/go.mod
@@ -1,0 +1,3 @@
+module mock-prometheus-server
+
+go 1.22

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -13,10 +13,12 @@
 //	GET  /config    – return current configuration
 //	POST /config    – update configuration (e.g. {"cpu_value": "24", "empty_result": true})
 //
-// Configuration (flags override env vars):
+// Configuration:
 //
-//	--port      / MOCK_PROMETHEUS_PORT       TCP port (default: 9090)
-//	--cpu-value / MOCK_PROMETHEUS_CPU_VALUE  Value returned for queries (default: 16)
+//	--port / MOCK_PROMETHEUS_PORT  TCP port (default: 9090)
+//
+// CPU values default to ["16"] and can be changed at runtime via POST /config.
+// POST /config accepts both "cpu_value": "16" and "cpu_value": ["16","32"].
 package main
 
 import (
@@ -39,10 +41,30 @@ type record struct {
 	Params    map[string]string `json:"params"`
 }
 
-type config struct {
-	CPUValue    string `json:"cpu_value"`
-	EmptyResult bool   `json:"empty_result"`
+type stringOrSlice []string
+
+func (s *stringOrSlice) UnmarshalJSON(data []byte) error {
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*s = arr
+		return nil
+	}
+
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = []string{single}
+		return nil
+	}
+
+	return fmt.Errorf("cpu_value must be a string or array of strings")
 }
+
+type config struct {
+	CPUValues   stringOrSlice `json:"cpu_value"`
+	EmptyResult bool          `json:"empty_result"`
+}
+
+var defaultConfig = config{CPUValues: []string{"16"}}
 
 var (
 	mu       sync.Mutex
@@ -134,6 +156,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	cpuVal := c.CPUValues[len(c.CPUValues)-1]
+
 	json.NewEncoder(w).Encode(map[string]any{
 		"status": "success",
 		"data": map[string]any{
@@ -141,7 +165,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			"result": []any{
 				map[string]any{
 					"metric": map[string]any{},
-					"value":  []any{ts, c.CPUValue},
+					"value":  []any{ts, cpuVal},
 				},
 			},
 		},
@@ -187,7 +211,8 @@ func handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		if ts > end {
 			break
 		}
-		values = append(values, []any{ts, c.CPUValue})
+		cpuVal := c.CPUValues[i%len(c.CPUValues)]
+		values = append(values, []any{ts, cpuVal})
 	}
 
 	json.NewEncoder(w).Encode(map[string]any{
@@ -216,6 +241,7 @@ func handleRequests(w http.ResponseWriter, _ *http.Request) {
 func handleReset(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	captured = nil
+	cfg = defaultConfig
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -242,8 +268,8 @@ func handleConfigPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mu.Lock()
-	if update.CPUValue != "" {
-		cfg.CPUValue = update.CPUValue
+	if len(update.CPUValues) > 0 {
+		cfg.CPUValues = update.CPUValues
 	}
 	cfg.EmptyResult = update.EmptyResult
 	mu.Unlock()
@@ -280,14 +306,12 @@ func envOrDefault(key, fallback string) string {
 
 func main() {
 	port := flag.String("port", envOrDefault("MOCK_PROMETHEUS_PORT", "9090"), "TCP port to listen on")
-	cpuValue := flag.String("cpu-value", envOrDefault("MOCK_PROMETHEUS_CPU_VALUE", "16"), "CPU value to return in query results")
 	flag.Parse()
 
-	cfg = config{CPUValue: *cpuValue}
+	cfg = defaultConfig
 
 	addr := ":" + *port
 	log.Printf("Mock Prometheus server listening on http://0.0.0.0%s", addr)
-	log.Printf("CPU value: %s", cfg.CPUValue)
 	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
 	log.Printf("Reset via:   GET http://localhost%s/reset", addr)
 	log.Printf("Config via:  GET/POST http://localhost%s/config", addr)

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -195,12 +195,12 @@ func handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	start, err := strconv.ParseFloat(startStr, 64)
 	if err != nil {
-		http.Error(w, "invalid start", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("invalid start: %v", err), http.StatusBadRequest)
 		return
 	}
 	end, err := strconv.ParseFloat(endStr, 64)
 	if err != nil {
-		http.Error(w, "invalid end", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("invalid end: %v", err), http.StatusBadRequest)
 		return
 	}
 	if end < start {
@@ -221,7 +221,7 @@ func handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	count := int(math.Floor((end-start)/stepSecs)) + 1
 	if count > 10000 {
-		http.Error(w, "range too large", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("range too large: %d points (max 10000)", count), http.StatusBadRequest)
 		return
 	}
 	values := make([][]any, 0, count)
@@ -282,7 +282,7 @@ func handleConfigPost(w http.ResponseWriter, r *http.Request) {
 
 	var update config
 	if err := json.Unmarshal(body, &update); err != nil {
-		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
 		return
 	}
 

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -13,9 +13,9 @@
 //	GET  /config    – return current configuration
 //	POST /config    – update configuration (e.g. {"cpu_value": "24", "empty_result": true})
 //
-// Configuration:
+// Configuration (env vars):
 //
-//	--port / MOCK_PROMETHEUS_PORT  TCP port (default: 9090)
+//	MOCK_PROMETHEUS_PORT  TCP port (default: 9090)
 //
 // CPU values default to ["16"] and can be changed at runtime via POST /config.
 // POST /config accepts both "cpu_value": "16" and "cpu_value": ["16","32"].
@@ -23,7 +23,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -286,12 +285,9 @@ func envOrDefault(key, fallback string) string {
 }
 
 func main() {
-	port := flag.String("port", envOrDefault("MOCK_PROMETHEUS_PORT", "9090"), "TCP port to listen on")
-	flag.Parse()
-
 	cfg = defaultConfig
 
-	addr := ":" + *port
+	addr := ":" + envOrDefault("MOCK_PROMETHEUS_PORT", "9090")
 	log.Printf("Mock Prometheus server listening on http://0.0.0.0%s", addr)
 	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
 	log.Printf("Reset via:   POST http://localhost%s/reset", addr)

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -193,8 +193,20 @@ func handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	endStr := r.URL.Query().Get("end")
 	stepStr := r.URL.Query().Get("step")
 
-	start, _ := strconv.ParseFloat(startStr, 64)
-	end, _ := strconv.ParseFloat(endStr, 64)
+	start, err := strconv.ParseFloat(startStr, 64)
+	if err != nil {
+		http.Error(w, "invalid start", http.StatusBadRequest)
+		return
+	}
+	end, err := strconv.ParseFloat(endStr, 64)
+	if err != nil {
+		http.Error(w, "invalid end", http.StatusBadRequest)
+		return
+	}
+	if end < start {
+		http.Error(w, "end must be >= start", http.StatusBadRequest)
+		return
+	}
 
 	stepSecs := 300.0 // default 5m
 	if stepStr != "" {
@@ -202,8 +214,16 @@ func handleQueryRange(w http.ResponseWriter, r *http.Request) {
 			stepSecs = parsed
 		}
 	}
+	if stepSecs <= 0 {
+		http.Error(w, "step must be > 0", http.StatusBadRequest)
+		return
+	}
 
 	count := int(math.Floor((end-start)/stepSecs)) + 1
+	if count > 10000 {
+		http.Error(w, "range too large", http.StatusBadRequest)
+		return
+	}
 	values := make([][]any, 0, count)
 	for i := 0; i < count; i++ {
 		ts := start + float64(i)*stepSecs

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -9,7 +9,7 @@
 // Utility endpoints:
 //
 //	GET  /requests  – return all captured requests as a JSON array
-//	GET  /reset     – clear the captured request list
+//	POST /reset     – clear the captured request list and restore default config
 //	GET  /config    – return current configuration
 //	POST /config    – update configuration (e.g. {"cpu_value": "24", "empty_result": true})
 //
@@ -278,25 +278,6 @@ func handleConfigPost(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, `{"ok":true}`)
 }
 
-func router(w http.ResponseWriter, r *http.Request) {
-	switch {
-	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/query":
-		handleQuery(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/query_range":
-		handleQueryRange(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/requests":
-		handleRequests(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/reset":
-		handleReset(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/config":
-		handleConfigGet(w, r)
-	case r.Method == http.MethodPost && r.URL.Path == "/config":
-		handleConfigPost(w, r)
-	default:
-		http.NotFound(w, r)
-	}
-}
-
 func envOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -313,11 +294,17 @@ func main() {
 	addr := ":" + *port
 	log.Printf("Mock Prometheus server listening on http://0.0.0.0%s", addr)
 	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
-	log.Printf("Reset via:   GET http://localhost%s/reset", addr)
+	log.Printf("Reset via:   POST http://localhost%s/reset", addr)
 	log.Printf("Config via:  GET/POST http://localhost%s/config", addr)
 
-	http.HandleFunc("/", router)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/query", handleQuery)
+	mux.HandleFunc("GET /api/v1/query_range", handleQueryRange)
+	mux.HandleFunc("GET /requests", handleRequests)
+	mux.HandleFunc("POST /reset", handleReset)
+	mux.HandleFunc("GET /config", handleConfigGet)
+	mux.HandleFunc("POST /config", handleConfigPost)
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -67,7 +67,7 @@ var defaultConfig = config{CPUValues: []string{"16"}}
 
 var (
 	mu       sync.Mutex
-	captured []record
+	captured = []record{}
 	cfg      config
 )
 
@@ -239,7 +239,7 @@ func handleRequests(w http.ResponseWriter, _ *http.Request) {
 
 func handleReset(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
-	captured = nil
+	captured = []record{}
 	cfg = defaultConfig
 	mu.Unlock()
 

--- a/tools/mock-prometheus-server/main.go
+++ b/tools/mock-prometheus-server/main.go
@@ -1,0 +1,299 @@
+// Mock Prometheus HTTP server for integration tests.
+//
+// Implements just enough of the Prometheus HTTP API for the vCPU collector's
+// PrometheusClient to work:
+//
+//	GET /api/v1/query        – instant query, returns a single vector result
+//	GET /api/v1/query_range  – range query, generates time-series at step intervals
+//
+// Utility endpoints:
+//
+//	GET  /requests  – return all captured requests as a JSON array
+//	GET  /reset     – clear the captured request list
+//	GET  /config    – return current configuration
+//	POST /config    – update configuration (e.g. {"cpu_value": "24", "empty_result": true})
+//
+// Configuration (flags override env vars):
+//
+//	--port      / MOCK_PROMETHEUS_PORT       TCP port (default: 9090)
+//	--cpu-value / MOCK_PROMETHEUS_CPU_VALUE  Value returned for queries (default: 16)
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type record struct {
+	Timestamp string            `json:"timestamp"`
+	Path      string            `json:"path"`
+	Params    map[string]string `json:"params"`
+}
+
+type config struct {
+	CPUValue    string `json:"cpu_value"`
+	EmptyResult bool   `json:"empty_result"`
+}
+
+var (
+	mu       sync.Mutex
+	captured []record
+	cfg      config
+)
+
+func capture(r *http.Request) {
+	params := make(map[string]string)
+	for k, v := range r.URL.Query() {
+		params[k] = v[0]
+	}
+
+	rec := record{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Path:      r.URL.Path,
+		Params:    params,
+	}
+
+	mu.Lock()
+	captured = append(captured, rec)
+	mu.Unlock()
+}
+
+func getConfig() config {
+	mu.Lock()
+	c := cfg
+	mu.Unlock()
+	return c
+}
+
+// parseDuration handles simple Prometheus duration strings: a number followed
+// by one of s, m, h (e.g. "5m", "300s", "1h"). A bare number is treated as
+// seconds.
+func parseDuration(s string) (float64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+
+	multiplier := 1.0
+	numStr := s
+
+	last := s[len(s)-1]
+	switch last {
+	case 's':
+		numStr = s[:len(s)-1]
+	case 'm':
+		numStr = s[:len(s)-1]
+		multiplier = 60
+	case 'h':
+		numStr = s[:len(s)-1]
+		multiplier = 3600
+	default:
+		if last < '0' || last > '9' {
+			return 0, fmt.Errorf("unsupported duration suffix: %c", last)
+		}
+	}
+
+	n, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration number: %s", numStr)
+	}
+
+	return n * multiplier, nil
+}
+
+func handleQuery(w http.ResponseWriter, r *http.Request) {
+	capture(r)
+
+	c := getConfig()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if c.EmptyResult {
+		json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "vector",
+				"result":     []any{},
+			},
+		})
+		return
+	}
+
+	ts := float64(time.Now().Unix())
+	if timeStr := r.URL.Query().Get("time"); timeStr != "" {
+		if parsed, err := strconv.ParseFloat(timeStr, 64); err == nil {
+			ts = parsed
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "vector",
+			"result": []any{
+				map[string]any{
+					"metric": map[string]any{},
+					"value":  []any{ts, c.CPUValue},
+				},
+			},
+		},
+	})
+}
+
+func handleQueryRange(w http.ResponseWriter, r *http.Request) {
+	capture(r)
+
+	c := getConfig()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if c.EmptyResult {
+		json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "matrix",
+				"result":     []any{},
+			},
+		})
+		return
+	}
+
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+	stepStr := r.URL.Query().Get("step")
+
+	start, _ := strconv.ParseFloat(startStr, 64)
+	end, _ := strconv.ParseFloat(endStr, 64)
+
+	stepSecs := 300.0 // default 5m
+	if stepStr != "" {
+		if parsed, err := parseDuration(stepStr); err == nil {
+			stepSecs = parsed
+		}
+	}
+
+	count := int(math.Floor((end-start)/stepSecs)) + 1
+	values := make([][]any, 0, count)
+	for i := 0; i < count; i++ {
+		ts := start + float64(i)*stepSecs
+		if ts > end {
+			break
+		}
+		values = append(values, []any{ts, c.CPUValue})
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "matrix",
+			"result": []any{
+				map[string]any{
+					"metric": map[string]any{},
+					"values": values,
+				},
+			},
+		},
+	})
+}
+
+func handleRequests(w http.ResponseWriter, _ *http.Request) {
+	mu.Lock()
+	data, _ := json.Marshal(captured)
+	mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func handleReset(w http.ResponseWriter, _ *http.Request) {
+	mu.Lock()
+	captured = nil
+	mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintln(w, `{"reset":true}`)
+}
+
+func handleConfigGet(w http.ResponseWriter, _ *http.Request) {
+	c := getConfig()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(c)
+}
+
+func handleConfigPost(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	var update config
+	if err := json.Unmarshal(body, &update); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	mu.Lock()
+	if update.CPUValue != "" {
+		cfg.CPUValue = update.CPUValue
+	}
+	cfg.EmptyResult = update.EmptyResult
+	mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintln(w, `{"ok":true}`)
+}
+
+func router(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/query":
+		handleQuery(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/query_range":
+		handleQueryRange(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/requests":
+		handleRequests(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/reset":
+		handleReset(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/config":
+		handleConfigGet(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/config":
+		handleConfigPost(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	port := flag.String("port", envOrDefault("MOCK_PROMETHEUS_PORT", "9090"), "TCP port to listen on")
+	cpuValue := flag.String("cpu-value", envOrDefault("MOCK_PROMETHEUS_CPU_VALUE", "16"), "CPU value to return in query results")
+	flag.Parse()
+
+	cfg = config{CPUValue: *cpuValue}
+
+	addr := ":" + *port
+	log.Printf("Mock Prometheus server listening on http://0.0.0.0%s", addr)
+	log.Printf("CPU value: %s", cfg.CPUValue)
+	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
+	log.Printf("Reset via:   GET http://localhost%s/reset", addr)
+	log.Printf("Config via:  GET/POST http://localhost%s/config", addr)
+
+	http.HandleFunc("/", router)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tools/mock-segment-server/Dockerfile
+++ b/tools/mock-segment-server/Dockerfile
@@ -4,6 +4,8 @@ COPY go.mod main.go ./
 RUN CGO_ENABLED=0 go build -o mock-segment-server .
 
 FROM alpine:3
+RUN addgroup -S app && adduser -S -G app app
 COPY --from=builder /build/mock-segment-server /usr/local/bin/mock-segment-server
+USER app
 EXPOSE 8765
 ENTRYPOINT ["mock-segment-server"]

--- a/tools/mock-segment-server/main.go
+++ b/tools/mock-segment-server/main.go
@@ -1,17 +1,16 @@
 // Mock Segment HTTP server for integration tests.
 //
-// Accepts any POST request, returns {"success":true} with HTTP 200, and appends
-// each request body as a JSONL line (with a UTC timestamp) to an output file.
+// Accepts any POST request, returns {"success":true} with HTTP 200, and
+// captures each request body in memory.
 //
 // Utility endpoints:
 //
-//	GET /requests  – return all captured requests as a JSON array
-//	GET /reset     – clear the in-memory list and truncate the output file
+//	GET  /requests – return all captured requests as a JSON array
+//	POST /reset    – clear the captured request list
 //
-// Configuration (flags override env vars):
+// Configuration:
 //
-//	--port   / MOCK_SEGMENT_PORT    TCP port (default: 8765)
-//	--output / MOCK_SEGMENT_OUTPUT  JSONL output file path (default: /tmp/mock_segment.jsonl)
+//	--port / MOCK_SEGMENT_PORT  TCP port (default: 8765)
 package main
 
 import (
@@ -33,9 +32,8 @@ type record struct {
 }
 
 var (
-	mu         sync.Mutex
-	captured   []record
-	outputFile string
+	mu       sync.Mutex
+	captured []record
 )
 
 func handlePost(w http.ResponseWriter, r *http.Request) {
@@ -53,12 +51,6 @@ func handlePost(w http.ResponseWriter, r *http.Request) {
 
 	mu.Lock()
 	captured = append(captured, rec)
-	if f, ferr := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); ferr == nil {
-		line, _ := json.Marshal(rec)
-		f.Write(line)
-		f.Write([]byte("\n"))
-		f.Close()
-	}
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -77,24 +69,10 @@ func handleRequests(w http.ResponseWriter, _ *http.Request) {
 func handleReset(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	captured = nil
-	os.WriteFile(outputFile, []byte{}, 0o644)
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintln(w, `{"reset":true}`)
-}
-
-func router(w http.ResponseWriter, r *http.Request) {
-	switch {
-	case r.Method == http.MethodPost:
-		handlePost(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/requests":
-		handleRequests(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/reset":
-		handleReset(w, r)
-	default:
-		http.NotFound(w, r)
-	}
 }
 
 func envOrDefault(key, fallback string) string {
@@ -106,19 +84,18 @@ func envOrDefault(key, fallback string) string {
 
 func main() {
 	port := flag.String("port", envOrDefault("MOCK_SEGMENT_PORT", "8765"), "TCP port to listen on")
-	output := flag.String("output", envOrDefault("MOCK_SEGMENT_OUTPUT", "/tmp/mock_segment.jsonl"), "JSONL output file")
 	flag.Parse()
-
-	outputFile = *output
 
 	addr := ":" + *port
 	log.Printf("Mock Segment server listening on http://0.0.0.0%s", addr)
-	log.Printf("Captured requests written to: %s", outputFile)
 	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
-	log.Printf("Reset via:   GET http://localhost%s/reset", addr)
+	log.Printf("Reset via:   POST http://localhost%s/reset", addr)
 
-	http.HandleFunc("/", router)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /reset", handleReset)
+	mux.HandleFunc("GET /requests", handleRequests)
+	mux.HandleFunc("POST /", handlePost)
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/tools/mock-segment-server/main.go
+++ b/tools/mock-segment-server/main.go
@@ -32,7 +32,7 @@ type record struct {
 
 var (
 	mu       sync.Mutex
-	captured []record
+	captured = []record{}
 )
 
 func handlePost(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +67,7 @@ func handleRequests(w http.ResponseWriter, _ *http.Request) {
 
 func handleReset(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
-	captured = nil
+	captured = []record{}
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/tools/mock-segment-server/main.go
+++ b/tools/mock-segment-server/main.go
@@ -8,14 +8,13 @@
 //	GET  /requests – return all captured requests as a JSON array
 //	POST /reset    – clear the captured request list
 //
-// Configuration:
+// Configuration (env vars):
 //
-//	--port / MOCK_SEGMENT_PORT  TCP port (default: 8765)
+//	MOCK_SEGMENT_PORT  TCP port (default: 8765)
 package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -83,10 +82,7 @@ func envOrDefault(key, fallback string) string {
 }
 
 func main() {
-	port := flag.String("port", envOrDefault("MOCK_SEGMENT_PORT", "8765"), "TCP port to listen on")
-	flag.Parse()
-
-	addr := ":" + *port
+	addr := ":" + envOrDefault("MOCK_SEGMENT_PORT", "8765")
 	log.Printf("Mock Segment server listening on http://0.0.0.0%s", addr)
 	log.Printf("Inspect via: GET http://localhost%s/requests", addr)
 	log.Printf("Reset via:   POST http://localhost%s/reset", addr)


### PR DESCRIPTION
Issue: [AAP-78452](https://redhat.atlassian.net/browse/AAP-78452)

Lightweight Go HTTP server (following the mock-segment-server pattern) that
implements `/api/v1/query` and `/api/v1/query_range` with a configurable CPU
value. Includes `/requests`, `/reset`, and `/config` utility endpoints for
test inspection.

Also adds integration tests that exercise `PrometheusClient` and the
`get_total_workers_cpu`/`get_cpu_timeline` helpers against the real HTTP
server (auto-skipped when the mock isn't running).

Adds a full gather pipeline integration test (`test_vcpu_gather_integration`)
that runs `run_gather_int` with the vCPU collector against mock Prometheus
(metering enabled, JHS disabled), then validates the output tarball against
the `total_workers_vcpu-1.0` JSON schema.

---

Also updates the segment mock to follow the same patterns, most of those come from comments in #409 