### PR TITLE
modify schema review action to run on PR edits

### DIFF
--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -13,24 +13,24 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    steps:
-      - name: Request schema review
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
-            const author = context.payload.pull_request.user.login;
-            const reviewers = allReviewers.filter(reviewer => reviewer !== author);
-            
-            await github.rest.pulls.requestReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              reviewers: reviewers
-            });
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: "⚠️ This PR modifies files in `schemas/`. One person from Emerging Services (@hunterkepley / @himdel / @MilanPospisil / @cshiels-ie), and one person from Analytics HCC (@dmzoneill / @AparnaKarve) must approve. DO NOT merge until both teams have approved the changes. [Contract here](https://handbook.eng.ansible.com/pr-preview/pr-1463/Teams/Emerging-Services-Team/Metrics-Utility/Contracts/billing-analytics-contract)"
-            });
+      steps:
+        - name: Request schema review
+          uses: actions/github-script@v7
+          with:
+            script: |
+              const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
+              const author = context.payload.pull_request.user.login;
+              const reviewers = allReviewers.filter(reviewer => reviewer !== author);
+              
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                reviewers: reviewers
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: "⚠️ This PR modifies files in `schemas/`. One person from Emerging Services (@hunterkepley / @himdel / @MilanPospisil / @cshiels-ie), and one person from Analytics HCC (@dmzoneill / @AparnaKarve) must approve. DO NOT merge until both teams have approved the changes. [Contract here](https://handbook.eng.ansible.com/pr-preview/pr-1463/Teams/Emerging-Services-Team/Metrics-Utility/Contracts/billing-analytics-contract)"
+              });

--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -13,24 +13,24 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-      steps:
-        - name: Request schema review
-          uses: actions/github-script@v7
-          with:
-            script: |
-              const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
-              const author = context.payload.pull_request.user.login;
-              const reviewers = allReviewers.filter(reviewer => reviewer !== author);
-              
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                reviewers: reviewers
-              });
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: "⚠️ This PR modifies files in `schemas/`. One person from Emerging Services (@hunterkepley / @himdel / @MilanPospisil / @cshiels-ie), and one person from Analytics HCC (@dmzoneill / @AparnaKarve) must approve. DO NOT merge until both teams have approved the changes. [Contract here](https://handbook.eng.ansible.com/pr-preview/pr-1463/Teams/Emerging-Services-Team/Metrics-Utility/Contracts/billing-analytics-contract)"
-              });
+    steps:
+      - name: Request schema review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
+            const author = context.payload.pull_request.user.login;
+            const reviewers = allReviewers.filter(reviewer => reviewer !== author);
+            
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: reviewers
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "⚠️ This PR modifies files in `schemas/`. One person from Emerging Services (@hunterkepley / @himdel / @MilanPospisil / @cshiels-ie), and one person from Analytics HCC (@dmzoneill / @AparnaKarve) must approve. DO NOT merge until both teams have approved the changes. [Contract here](https://handbook.eng.ansible.com/pr-preview/pr-1463/Teams/Emerging-Services-Team/Metrics-Utility/Contracts/billing-analytics-contract)"
+            });

--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -2,7 +2,7 @@ name: Schema Change Review
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, edited]
+    types: [opened, ready_for_review, edited, synchronize]
     paths:
       - 'schemas/**'
 

--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -1,7 +1,7 @@
 name: Schema Change Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, edited]
     paths:
       - 'schemas/**'

--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -1,8 +1,8 @@
 name: Schema Change Review
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
+  pull_request:
+    types: [opened, ready_for_review, edited]
     paths:
       - 'schemas/**'
 
@@ -18,11 +18,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
+            const author = context.payload.pull_request.user.login;
+            const reviewers = allReviewers.filter(reviewer => reviewer !== author);
+            
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve']
+              reviewers: reviewers
             });
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/schemas/config-1.0.jsonschema
+++ b/schemas/config-1.0.jsonschema
@@ -61,6 +61,9 @@
       "type": "string",
       "format": "uuid"
     },
+    "test_value": {
+      "type": "string"
+    },
     "instance_uuid": {
       "type": "string",
       "format": "uuid"


### PR DESCRIPTION
When a PR touches schemas/, automatically request reviews from Emerging Services and Analytics HCC and comment with approval requirements.

[AAP-78360]
https://redhat.atlassian.net/browse/AAP-78360
Dont forget to link back issue to PR.

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?
Introduces a basic github action to ping the appropriate parties when a file in `schemas/` is touched
- Why is this change needed?
To automatically request review from the Analytics HCC + members of the ES team who have worked on the schemas when changes are detected. This way we can commit to our contract of notifying them of changes to schemas before a release
- How does this change address the issue?
A message + request for reviewers come up when the `schemas` dir is modified. It does not block merge directly, **If we want it to do so, we'll need to modify the repo some, and I'll need to add a script to this action which passes the check when not editing the schemas dir, and fails when editing the schemas dir and not having review from at least 1 person from both teams** - _let me know if we want this, it's much more complicated overall, i thought this simpler version is enough_

## Testing

<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

### Prerequisites

<!-- List any specific setup required -->

### Steps to Test

1. Modify a schemas/ file
2. Watch it act