### PR TITLE
fix: consolidate schema-review workflow to pull_request_target with path filter

### DIFF
--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -1,0 +1,32 @@
+name: Schema Change Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+    paths:
+      - 'schemas/**'
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    steps:
+      - name: Request schema review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve']
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "⚠️ This PR modifies files in `schemas/`. One person from Emerging Services (@hunterkepley / @himdel / @MilanPospisil / @cshiels-ie), and one person from Analytics HCC (@dmzoneill / @AparnaKarve) must approve. DO NOT merge until both teams have approved the changes. [Contract here](https://handbook.eng.ansible.com/pr-preview/pr-1463/Teams/Emerging-Services-Team/Metrics-Utility/Contracts/billing-analytics-contract)"
+            });


### PR DESCRIPTION
## Summary

Fixes the schema-review GitHub Actions workflow introduced in #435 so that reviewer requests and comments work correctly for PRs from forks.

### Problem

The original workflow had two mismatched triggers:

- `pull_request_target` with `types` but **no `paths` filter** — fired on every PR opened, regardless of whether it touched `schemas/**`
- `pull_request` with `paths: ['schemas/**']` — has the right filter but **receives a read-only token for fork-originated PRs**, so the `pulls.requestReviewers` and `issues.createComment` API calls fail

### Fix

Consolidate into a single `pull_request_target` trigger with **both** `types` and `paths` set:

```yaml
on:
  pull_request_target:
    types: [opened, ready_for_review]
    paths:
      - 'schemas/**'
```

`pull_request_target` always runs in the context of the base repository, so it retains `pull-requests: write` and `issues: write` permissions even when the PR originates from a fork. The `paths` filter ensures it only fires when `schemas/**` files are modified.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.