### PR TITLE
improve schema review workflow stability

### DIFF
--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -2,7 +2,7 @@ name: Schema Change Review
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
     paths:
       - 'schemas/**'
 
@@ -18,11 +18,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
+            const author = context.payload.pull_request.user.login;
+            const filtered_reviewers = allReviewers.filter(reviewer => reviewer !== author);
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve']
+              reviewers: filtered_reviewers
             });
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -2,7 +2,7 @@ name: Schema Change Review
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize, edited]
     paths:
       - 'schemas/**'
 

--- a/schemas/config-1.0.jsonschema
+++ b/schemas/config-1.0.jsonschema
@@ -51,9 +51,6 @@
     "controller_url_base": {
       "type": "string"
     },
-    "test_value": {
-      "type": "string"
-    },
     "external_logger_enabled": {
       "type": "boolean"
     },

--- a/schemas/config-1.0.jsonschema
+++ b/schemas/config-1.0.jsonschema
@@ -51,6 +51,9 @@
     "controller_url_base": {
       "type": "string"
     },
+    "test_value": {
+      "type": "string"
+    },
     "external_logger_enabled": {
       "type": "boolean"
     },


### PR DESCRIPTION
[AAP-7630]
https://redhat.atlassian.net/browse/AAP-78360

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?

Adds `synchronize` type to activities, to run when a schema change is made late
Adds filter to reviewers list to filter out the author (caused failure in action)

- Why is this change needed?

Stability and coverage

- How does this change address the issue?

Self explanatory / explained above..

## Testing

<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

Testing through this MR by making a fake schema change after posting