### PR TITLE
remove HCC analytics reviewer assignments, keep comment pinging them

### DIFF
--- a/.github/workflows/schema-review.yml
+++ b/.github/workflows/schema-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie', 'dmzoneill', 'AparnaKarve'];
+            const allReviewers = ['hunterkepley', 'himdel', 'MilanPospisil', 'cshiels-ie'];
             const author = context.payload.pull_request.user.login;
             const filtered_reviewers = allReviewers.filter(reviewer => reviewer !== author);
             await github.rest.pulls.requestReviewers({

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-this test file should not start the workflow

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+this test file should not start the workflow


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-78360

[AAP-76360]

Removed HCC Analytics team from reviewer assignments, but keeps the comment pinging them, to get the action to pass