### PR TITLE
validator - fix schema path after move to metrics_utility package

### DIFF
--- a/tools/validator/validate.py
+++ b/tools/validator/validate.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import jsonschema
 
 
-SCHEMAS_DIR = Path(__file__).resolve().parent.parent.parent / 'schemas'
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent.parent / 'metrics_utility' / 'schemas'
 
 REQUIRED_FILES = {'config.json', 'manifest.json'}
 DCS_FILE = 'data_collection_status.csv'


### PR DESCRIPTION
PR #444 moved schemas from `schemas/` to `metrics_utility/schemas/` but didn't update the path in `tools/validator/validate.py`, so the validator can't find any schemas - updating too.