### PR TITLE
cleanup_glob - fix uncleaned files, remove empty dirs, extract helper to util

### DIFF
--- a/metrics_utility/test/gather/test_directory_gather.py
+++ b/metrics_utility/test/gather/test_directory_gather.py
@@ -1,10 +1,10 @@
 import glob
-import os
 
 from datetime import datetime
 
 import pytest
 
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_ext, run_gather_int
 
 
@@ -27,8 +27,7 @@ def validate_exists(file_glob):
 @pytest.fixture
 def cleanup_glob():
     yield
-    for file in glob.glob(file_glob):
-        os.remove(file)
+    _cleanup_glob(file_glob)
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')

--- a/metrics_utility/test/gather/test_gather_ranges.py
+++ b/metrics_utility/test/gather/test_gather_ranges.py
@@ -1,11 +1,11 @@
 import glob
-import os
 import tarfile
 
 from datetime import datetime
 
 import pytest
 
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_ext
 
 
@@ -28,8 +28,7 @@ def validate_exists(file_glob):
 @pytest.fixture
 def cleanup_glob():
     yield
-    for file in glob.glob(file_glob):
-        os.remove(file)
+    _cleanup_glob(file_glob)
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')

--- a/metrics_utility/test/gather/test_jobhostsummary_gather.py
+++ b/metrics_utility/test/gather/test_jobhostsummary_gather.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from metrics_utility.base.collection import Collection
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_ext, run_gather_int
 
 
@@ -165,8 +166,7 @@ skip_columns = {
 @pytest.fixture
 def cleanup_glob():
     yield
-    for file in glob.glob(file_glob):
-        os.remove(file)
+    _cleanup_glob(file_glob)
 
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')

--- a/metrics_utility/test/util.py
+++ b/metrics_utility/test/util.py
@@ -1,5 +1,6 @@
 """Test utilities: command runners, environment helpers, and fixture generators."""
 
+import glob
 import os
 import random
 import subprocess
@@ -19,6 +20,19 @@ def utcdt(s):
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+def cleanup_glob(file_glob):
+    """Remove files matching a glob pattern and their empty parent directories."""
+    dirs = set()
+    for file in glob.glob(file_glob):
+        os.remove(file)
+        dirs.add(os.path.dirname(file))
+    for d in dirs:
+        try:
+            os.removedirs(d)
+        except OSError:
+            pass
 
 
 @contextmanager

--- a/metrics_utility/test/validation/test_json_schema.py
+++ b/metrics_utility/test/validation/test_json_schema.py
@@ -2,7 +2,6 @@ import csv
 import glob
 import io
 import json
-import os
 import tarfile
 
 from datetime import datetime
@@ -11,6 +10,7 @@ from importlib.resources import files
 import jsonschema
 import pytest
 
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_int
 
 
@@ -48,8 +48,8 @@ def _generate_and_extract(member_path, extra_env=None):
 
 @pytest.fixture
 def cleanup_glob():
-    for file in glob.glob(file_glob):
-        os.remove(file)
+    yield
+    _cleanup_glob(file_glob)
 
 
 @pytest.fixture


### PR DESCRIPTION
The `cleanup_glob` fixtures in gather/validation tests only removed tar.gz files but left empty parent directories behind (e.g. `test_data/data/2025/06/`).
Additionally, `test_json_schema.py` (added in #428) was missing `yield` in its fixture, so it only cleaned before tests, never after, leaving around actual tarballs after tests.

- extract shared `cleanup_glob()` into `test/util.py` — removes files and (newly) empty parent dirs via `os.removedirs`
- add missing `yield` to `test_json_schema.py` fixture, cc @hunterkepley 
- update all four test files to use the shared helper