### PR TITLE
cleanup_glob - fix outlier test fixtures, missing cleanup

### DIFF
--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -1,6 +1,5 @@
 import csv
 import glob
-import os
 
 import pytest
 
@@ -11,6 +10,7 @@ from metrics_utility.library.collectors.controller.job_host_summary_service impo
 from metrics_utility.library.collectors.controller.main_jobevent_service import main_jobevent_service
 from metrics_utility.library.collectors.controller.unified_jobs import unified_jobs
 from metrics_utility.test.gather.test_jobhostsummary_gather import SafeTarFile
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_ext, utcdt
 
 
@@ -194,11 +194,8 @@ def validate_dataframe(df, expected_lines, skip_columns_names):
 
 @pytest.fixture
 def cleanup_glob():
-    for file in glob.glob(file_glob):
-        os.remove(file)
     yield
-    for file in glob.glob(file_glob):
-        os.remove(file)
+    _cleanup_glob(file_glob)
 
 
 jobs_lines = [

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
@@ -58,18 +58,10 @@ from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymi
 
 @pytest.fixture(scope='module')
 def cleanup_test_data():
-    """Clean up test directories before and after all tests in this module."""
+    yield
     out_dir = './out'
-
-    # Cleanup before tests
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
-
-    yield  # Run all tests
-
-    # Cleanup after all tests (commented out for debugging)
-    # if os.path.exists(out_dir):
-    #     shutil.rmtree(out_dir)
 
 
 def create_csv_file(data_list, csv_path):

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
@@ -59,9 +59,9 @@ from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymi
 @pytest.fixture(scope='module')
 def cleanup_test_data():
     yield
-    out_dir = './out'
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
+    for d in ['./out/data/2024/01/15', './out/rollups/2024/01/15']:
+        if os.path.exists(d):
+            shutil.rmtree(d)
 
 
 def create_csv_file(data_list, csv_path):

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
@@ -52,18 +52,10 @@ from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymi
 
 @pytest.fixture(scope='module')
 def cleanup_test_data():
-    """Clean up test directories before and after all tests in this module."""
+    yield
     out_dir = './out'
-
-    # Cleanup before tests
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
-
-    yield  # Run all tests
-
-    # Cleanup after all tests (commented out for debugging)
-    # if os.path.exists(out_dir):
-    #     shutil.rmtree(out_dir)
 
 
 def create_csv_file(data_list, csv_path):

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
@@ -53,9 +53,9 @@ from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymi
 @pytest.fixture(scope='module')
 def cleanup_test_data():
     yield
-    out_dir = './out'
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
+    for d in ['./out/data/2024/01/15', './out/rollups/2024/01/15']:
+        if os.path.exists(d):
+            shutil.rmtree(d)
 
 
 def create_csv_file(data_list, csv_path):

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import shutil
 import urllib.request
 
 import pandas as pd
@@ -21,6 +20,7 @@ from metrics_utility.library.collectors.controller import (
 )
 from metrics_utility.library.storage.segment import StorageSegment
 from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymized_rollup_from_raw_data
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import utcdt
 
 
@@ -836,19 +836,13 @@ def _validate_controller_versions(json_data):
     )
 
 
+file_glob = './out/rollups/2025/06/13/anonymized_*.json'
+
+
 @pytest.fixture
 def cleanup_glob():
-    out_dir = './out'
-
-    # --- Cleanup before test ---
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
-
-    yield  # Run your test
-
-    # --- Cleanup after test ---
-    # if os.path.exists(out_dir):
-    #    shutil.rmtree(out_dir)
+    yield
+    _cleanup_glob(file_glob)
 
 
 def _collect_time_series_data(collector_func, collector_name, time_intervals, db):
@@ -913,7 +907,8 @@ def _prepare_input_data(results, collector_to_input_key):
 
 def _save_json_output(json_data, since, until):
     """Save JSON data to the expected output path."""
-    json_path = f'./out/rollups/{since.year}/{since.month}/{since.day}/anonymized_{since.strftime("%Y-%m-%d")}_{until.strftime("%Y-%m-%d")}.json'
+    since_s, until_s = since.strftime('%Y-%m-%d'), until.strftime('%Y-%m-%d')
+    json_path = f'./out/rollups/{since.year}/{since.month:02d}/{since.day:02d}/anonymized_{since_s}_{until_s}.json'
 
     # create the dir
     os.makedirs(os.path.dirname(json_path), exist_ok=True)

--- a/metrics_utility/test/test_anonymized_rollups/test_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_json.py
@@ -1,7 +1,6 @@
 import json
 
 import pandas as pd
-import pytest
 
 from django.db import connection
 
@@ -85,7 +84,7 @@ def _deep_compare(obj1, obj2, path=''):
     return True, None
 
 
-def test_json_serialization_roundtrip(cleanup_glob):
+def test_json_serialization_roundtrip():
     """
     Test that calling all collectors, then calling rollup prepare,
     serializing to JSON and parsing back results in matching data.
@@ -170,9 +169,3 @@ def test_json_serialization_roundtrip(cleanup_glob):
         except Exception as e:
             print(f'  ❌ {collector_name}: Error during test - {e}')
             raise
-
-
-@pytest.fixture
-def cleanup_glob():
-    """Fixture placeholder for consistency with other tests."""
-    yield

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -38,18 +38,10 @@ from metrics_utility.test.test_anonymized_rollups.test_jobs_anonymized_rollups i
 
 @pytest.fixture(scope='module')
 def cleanup_test_data():
-    """Clean up test directories before and after all tests in this module."""
+    yield
     out_dir = './out'
-
-    # Cleanup before tests
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
-
-    yield  # Run all tests
-
-    # Cleanup after all tests (commented out for debugging)
-    # if os.path.exists(out_dir):
-    #     shutil.rmtree(out_dir)
 
 
 def _create_csv_files_from_split_data(data_dir, jobs, events, execution_environments, jobhostsummary, credentials):

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -39,9 +39,9 @@ from metrics_utility.test.test_anonymized_rollups.test_jobs_anonymized_rollups i
 @pytest.fixture(scope='module')
 def cleanup_test_data():
     yield
-    out_dir = './out'
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
+    for d in ['./out/data/2025/06/13', './out/rollups/2025/06/13']:
+        if os.path.exists(d):
+            shutil.rmtree(d)
 
 
 def _create_csv_files_from_split_data(data_dir, jobs, events, execution_environments, jobhostsummary, credentials):

--- a/metrics_utility/test/test_anonymized_rollups/test_report_splitting.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_report_splitting.py
@@ -12,6 +12,7 @@ This test:
 
 import json
 import os
+import shutil
 
 import pytest
 
@@ -20,12 +21,10 @@ from metrics_utility.library.storage.segment import StorageSegment
 
 @pytest.fixture(scope='function')
 def cleanup_test_data():
-    """Clean up test directories before and after test.
-
-    Note: Cleanup is disabled to allow data persistence for validation.
-    Uncomment the cleanup code below if you want to clean up test data.
-    """
-    yield  # Run test
+    yield
+    out_dir = './out/test_report_splitting'
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
 
 
 def _create_statistics_dict(num_modules, num_jobs):

--- a/metrics_utility/test/test_anonymized_rollups/test_report_splitting.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_report_splitting.py
@@ -12,19 +12,20 @@ This test:
 
 import json
 import os
-import shutil
 
 import pytest
 
 from metrics_utility.library.storage.segment import StorageSegment
+from metrics_utility.test.util import cleanup_glob as _cleanup_glob
+
+
+file_glob = './out/test_report_splitting/*.json'
 
 
 @pytest.fixture(scope='function')
 def cleanup_test_data():
     yield
-    out_dir = './out/test_report_splitting'
-    if os.path.exists(out_dir):
-        shutil.rmtree(out_dir)
+    _cleanup_glob(file_glob)
 
 
 def _create_statistics_dict(num_modules, num_jobs):


### PR DESCRIPTION
Follows #448.

Makes more test file cleanup follow the `cleanup_glob` pattern, and fixes broken `cleanup_test_data` fixtures where after-cleanup was commented out.

cleanup_glob:
* `test_from_gather_to_json` - replace before-cleanup with after-cleanup (previously commented out), switch to shared `cleanup_glob` helper; zero-pad month/day in output path for consistency
* `test_gather_jobs_events_summaries_service` - replace before+after cleanup with after-only, using the shared helper
* `test_json` - remove no-op placeholder `cleanup_glob` fixture (test doesn't produce files)
* `test_report_splitting` - switch from `shutil.rmtree` to `cleanup_glob`

cleanup_test_data:
* `test_multiple_files` - narrow `rmtree` scope from `./out` to specific date directories (`./out/data/2025/06/13`, `./out/rollups/2025/06/13`)
* `big_test1/test_all`, `big_test1/test_all_no_events` - narrow `rmtree` scope from `./out` to specific date directories (`./out/data/2024/01/15`, `./out/rollups/2024/01/15`)