### PR TITLE
feat(AAP-79243): add filter option collectors for AWX orgs/templates/projects/labels

### DIFF
--- a/metrics_utility/library/collectors/dashboard/__init__.py
+++ b/metrics_utility/library/collectors/dashboard/__init__.py
@@ -1,5 +1,29 @@
 from .collectors import AWXJobHostSummaryType, AWXJobType, DashboardJobsResultType, dashboard_jobs
+from .filter_options import (
+    fetch_job_templates,
+    fetch_labels,
+    fetch_organizations,
+    fetch_projects,
+    get_job_templates_query,
+    get_labels_query,
+    get_organizations_query,
+    get_projects_query,
+)
 from .queries import get_min_max_job_id_query
 
 
-__all__ = ['dashboard_jobs', 'DashboardJobsResultType', 'AWXJobHostSummaryType', 'AWXJobType', 'get_min_max_job_id_query']
+__all__ = [
+    'AWXJobHostSummaryType',
+    'AWXJobType',
+    'DashboardJobsResultType',
+    'dashboard_jobs',
+    'fetch_job_templates',
+    'fetch_labels',
+    'fetch_organizations',
+    'fetch_projects',
+    'get_job_templates_query',
+    'get_labels_query',
+    'get_min_max_job_id_query',
+    'get_organizations_query',
+    'get_projects_query',
+]

--- a/metrics_utility/library/collectors/dashboard/filter_options.py
+++ b/metrics_utility/library/collectors/dashboard/filter_options.py
@@ -1,0 +1,66 @@
+"""
+Collector functions for AWX filter option entities.
+
+Provides full-table snapshots of organizations, job templates, projects, and labels
+from the Controller DB. Used by the metrics-service task system to populate local
+cache tables so that filter dropdown endpoints have no runtime dependency on Controller.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_organizations_query() -> tuple[str, list]:
+    """Return (sql, params) to fetch all AWX organizations."""
+    return 'SELECT id, name FROM main_organization ORDER BY name', []
+
+
+def get_job_templates_query() -> tuple[str, list]:
+    """Return (sql, params) to fetch all AWX job templates."""
+    return (
+        'SELECT ujt.id, ujt.name FROM main_unifiedjobtemplate ujt JOIN main_jobtemplate jt ON jt.unifiedjobtemplate_ptr_id = ujt.id ORDER BY ujt.name'
+    ), []
+
+
+def get_projects_query() -> tuple[str, list]:
+    """Return (sql, params) to fetch all AWX projects."""
+    return (
+        'SELECT ujt.id, ujt.name FROM main_unifiedjobtemplate ujt JOIN main_project pj ON pj.unifiedjobtemplate_ptr_id = ujt.id ORDER BY ujt.name'
+    ), []
+
+
+def get_labels_query() -> tuple[str, list]:
+    """Return (sql, params) to fetch all AWX labels."""
+    return 'SELECT id, name FROM main_label ORDER BY name', []
+
+
+def _fetch_id_name(db: Any, query: str, params: list) -> list[dict]:
+    """Execute a SELECT id, name query and return [{id, name}, ...] dicts."""
+    with db.cursor() as cursor:
+        cursor.execute(query, params)
+        return [{'id': row[0], 'name': row[1]} for row in cursor.fetchall()]
+
+
+def fetch_organizations(db: Any) -> list[dict]:
+    """Fetch all AWX organizations as [{id, name}, ...] from the Controller DB."""
+    query, params = get_organizations_query()
+    return _fetch_id_name(db, query, params)
+
+
+def fetch_job_templates(db: Any) -> list[dict]:
+    """Fetch all AWX job templates as [{id, name}, ...] from the Controller DB."""
+    query, params = get_job_templates_query()
+    return _fetch_id_name(db, query, params)
+
+
+def fetch_projects(db: Any) -> list[dict]:
+    """Fetch all AWX projects as [{id, name}, ...] from the Controller DB."""
+    query, params = get_projects_query()
+    return _fetch_id_name(db, query, params)
+
+
+def fetch_labels(db: Any) -> list[dict]:
+    """Fetch all AWX labels as [{id, name}, ...] from the Controller DB."""
+    query, params = get_labels_query()
+    return _fetch_id_name(db, query, params)

--- a/metrics_utility/test/library/dashboard/test_filter_options.py
+++ b/metrics_utility/test/library/dashboard/test_filter_options.py
@@ -1,0 +1,152 @@
+from unittest.mock import MagicMock
+
+from metrics_utility.library.collectors.dashboard.filter_options import (
+    fetch_job_templates,
+    fetch_labels,
+    fetch_organizations,
+    fetch_projects,
+    get_job_templates_query,
+    get_labels_query,
+    get_organizations_query,
+    get_projects_query,
+)
+
+
+def _make_mock_db(rows):
+    """Return a mock db whose cursor().fetchall() returns *rows*."""
+    mock_cursor = MagicMock()
+    mock_cursor.__enter__.return_value = mock_cursor
+    mock_cursor.fetchall.return_value = rows
+    mock_db = MagicMock()
+    mock_db.cursor.return_value = mock_cursor
+    return mock_db, mock_cursor
+
+
+class TestGetOrganizationsQuery:
+    def test_queries_main_organization(self):
+        sql, params = get_organizations_query()
+        assert 'main_organization' in sql
+        assert params == []
+
+    def test_selects_id_and_name(self):
+        sql, _ = get_organizations_query()
+        assert 'id' in sql and 'name' in sql
+
+    def test_ordered_by_name(self):
+        sql, _ = get_organizations_query()
+        assert 'ORDER BY name' in sql
+
+
+class TestGetJobTemplatesQuery:
+    def test_queries_main_unifiedjobtemplate(self):
+        sql, params = get_job_templates_query()
+        assert 'main_unifiedjobtemplate' in sql
+        assert params == []
+
+    def test_joins_main_jobtemplate(self):
+        sql, _ = get_job_templates_query()
+        assert 'main_jobtemplate' in sql
+        assert 'JOIN' in sql
+
+    def test_ordered_by_name(self):
+        sql, _ = get_job_templates_query()
+        assert 'ORDER BY' in sql and 'name' in sql
+
+
+class TestGetProjectsQuery:
+    def test_queries_main_unifiedjobtemplate(self):
+        sql, params = get_projects_query()
+        assert 'main_unifiedjobtemplate' in sql
+        assert params == []
+
+    def test_joins_main_project(self):
+        sql, _ = get_projects_query()
+        assert 'main_project' in sql
+        assert 'JOIN' in sql
+
+    def test_ordered_by_name(self):
+        sql, _ = get_projects_query()
+        assert 'ORDER BY' in sql and 'name' in sql
+
+
+class TestGetLabelsQuery:
+    def test_queries_main_label(self):
+        sql, params = get_labels_query()
+        assert 'main_label' in sql
+        assert params == []
+
+    def test_selects_id_and_name(self):
+        sql, _ = get_labels_query()
+        assert 'id' in sql and 'name' in sql
+
+    def test_ordered_by_name(self):
+        sql, _ = get_labels_query()
+        assert 'ORDER BY name' in sql
+
+
+class TestFetchOrganizations:
+    def test_returns_id_name_dicts(self):
+        mock_db, _ = _make_mock_db([(1, 'Default'), (2, 'Operations')])
+        result = fetch_organizations(mock_db)
+        assert result == [{'id': 1, 'name': 'Default'}, {'id': 2, 'name': 'Operations'}]
+
+    def test_empty_result(self):
+        mock_db, _ = _make_mock_db([])
+        assert fetch_organizations(mock_db) == []
+
+    def test_executes_expected_sql(self):
+        mock_db, mock_cursor = _make_mock_db([])
+        fetch_organizations(mock_db)
+        called_sql = mock_cursor.execute.call_args[0][0]
+        assert 'main_organization' in called_sql
+
+
+class TestFetchJobTemplates:
+    def test_returns_id_name_dicts(self):
+        mock_db, _ = _make_mock_db([(10, 'Deploy'), (11, 'Smoke Test')])
+        result = fetch_job_templates(mock_db)
+        assert result == [{'id': 10, 'name': 'Deploy'}, {'id': 11, 'name': 'Smoke Test'}]
+
+    def test_empty_result(self):
+        mock_db, _ = _make_mock_db([])
+        assert fetch_job_templates(mock_db) == []
+
+    def test_executes_expected_sql(self):
+        mock_db, mock_cursor = _make_mock_db([])
+        fetch_job_templates(mock_db)
+        called_sql = mock_cursor.execute.call_args[0][0]
+        assert 'main_jobtemplate' in called_sql
+
+
+class TestFetchProjects:
+    def test_returns_id_name_dicts(self):
+        mock_db, _ = _make_mock_db([(5, 'ansible-playbooks')])
+        result = fetch_projects(mock_db)
+        assert result == [{'id': 5, 'name': 'ansible-playbooks'}]
+
+    def test_empty_result(self):
+        mock_db, _ = _make_mock_db([])
+        assert fetch_projects(mock_db) == []
+
+    def test_executes_expected_sql(self):
+        mock_db, mock_cursor = _make_mock_db([])
+        fetch_projects(mock_db)
+        called_sql = mock_cursor.execute.call_args[0][0]
+        assert 'main_project' in called_sql
+
+
+class TestFetchLabels:
+    def test_returns_id_name_dicts(self):
+        mock_db, _ = _make_mock_db([(42, 'production'), (43, 'staging')])
+        result = fetch_labels(mock_db)
+        assert result == [{'id': 42, 'name': 'production'}, {'id': 43, 'name': 'staging'}]
+
+    def test_empty_result(self):
+        mock_db, _ = _make_mock_db([])
+        assert fetch_labels(mock_db) == []
+
+    def test_executes_expected_sql(self):
+        mock_db, mock_cursor = _make_mock_db([])
+        fetch_labels(mock_db)
+        called_sql = mock_cursor.execute.call_args[0][0]
+        assert 'main_label' in called_sql


### PR DESCRIPTION
## Summary

- Adds `metrics_utility/library/collectors/dashboard/filter_options.py` with four query functions and four fetch functions covering AWX organizations, job templates, projects, and labels
- Exports all eight symbols from `metrics_utility/library/collectors/dashboard/__init__.py`
- 24 new tests in `metrics_utility/test/library/dashboard/test_filter_options.py`

**Used by**: metrics-service `sync_dashboard_filter_caches` task (companion PR ansible/metrics-service#299) to populate local cache tables so that filter dropdown endpoints have no runtime dependency on the Controller DB.

## Design

These are **not** `@collector`-decorated time-windowed DataFrame collectors. They are plain SQL full-table snapshots:

- `get_*_query()` — return `(sql, params)` tuples, same convention as `dashboard/queries.py`
- `fetch_*(db)` — execute the query and return `[{"id": ..., "name": ...}]` dicts directly

SQL mirrors what was previously in `metrics-service/apps/dashboard_reports/awx_queries.py` (which is deleted in the companion PR).

| Function | AWX table |
|---|---|
| `fetch_organizations` | `main_organization` |
| `fetch_job_templates` | `main_unifiedjobtemplate ⨝ main_jobtemplate` |
| `fetch_projects` | `main_unifiedjobtemplate ⨝ main_project` |
| `fetch_labels` | `main_label` |

## Test plan

- [ ] `uv run pytest metrics_utility/test/library/dashboard/test_filter_options.py -v` — 24 tests pass

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.