### PR TITLE
Feature/indirect managed nodes anonymization

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Import SQL dump"
         run: |
-          cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags}.sql | sudo su - postgres -c psql
+          cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags,main_indirectmanagednodeaudit}.sql | sudo su - postgres -c psql
 
       - name: "Pull minio"
         run: |
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Import SQL dump"
         run: |
-          cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags}.sql | sudo su - postgres -c psql
+          cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags,main_indirectmanagednodeaudit}.sql | sudo su - postgres -c psql
 
       - name: "Clone metrics-service"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -537,7 +537,6 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'controller_versions': controller_versions,
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
-        'indirect_managed_nodes': indirect_managed_nodes_root.get('indirect_node_ids', []) if indirect_managed_nodes_root else [],
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -315,7 +315,7 @@ def _build_statistics(
         'rollup_period_failed_hosts_total': host_summary_totals['failed_hosts_total'],
         'rollup_period_unreachable_hosts_total': host_summary_totals['unreachable_hosts_total'],
         # from indirect_managed_nodes
-        'rollup_period_indirect_managed_nodes_total': indirect_nodes_total,
+        'rollup_period_indirect_managed_nodes_all_total': indirect_nodes_total,
     }
 
     # Only include event-related fields if there are events

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -49,8 +49,8 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             Dict with 'json' key containing the final rollup data.
         """
         if data is None:
-            return {'json': {'indirect_node_ids': [], 'indirect_nodes_total': 0}}
-        return {'json': data}
+            return {'json': {'indirect_nodes_total': 0}}
+        return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
 
     def merge(self, data_all, data_new):
         """Merge two indirect node rollups by deduplicating host IDs.

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -39,6 +39,19 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             }
         )
 
+    def base(self, data):
+        """Return final rollup payload with count only (no host IDs for privacy).
+
+        Args:
+            data: Accumulated dict from merge() calls, or None if no data.
+
+        Returns:
+            Dict with 'json' key containing the final rollup data.
+        """
+        if data is None:
+            return {'json': {'indirect_node_ids': [], 'indirect_nodes_total': 0}}
+        return {'json': data}
+
     def merge(self, data_all, data_new):
         """Merge two indirect node rollups by deduplicating host IDs.
 

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -32,6 +32,7 @@ from metrics_utility.library.collectors.controller import (
     execution_environments,
     feature_flags_service,
     job_host_summary_service,
+    main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
     unified_jobs,
@@ -204,6 +205,12 @@ def compute_anonymized_rollup(db, since, until, service_db=None):
         except Exception as e:
             logger.error(f'Failed to gather task_executions data: {e}')
 
+    indirect_managed_nodes_data = []
+    try:
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
+    except Exception as e:
+        logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
+
     input_data = {
         'execution_environments': execution_environments_data,
         'unified_jobs': unified_jobs_data,
@@ -214,6 +221,7 @@ def compute_anonymized_rollup(db, since, until, service_db=None):
         'controller_version': controller_version_data,
         'feature_flags': feature_flags_data,
         'task_executions': task_executions_data,
+        'indirect_managed_nodes': indirect_managed_nodes_data,
     }
 
     # load data for each collector

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -21,6 +21,7 @@ from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import 
 from metrics_utility.anonymized_rollups.execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
 from metrics_utility.anonymized_rollups.feature_flags_anonymized_rollup import FeatureFlagsAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import IndirectManagedNodesAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 from metrics_utility.anonymized_rollups.table_metadata_anonymized_rollup import TableMetadataAnonymizedRollup
@@ -120,6 +121,9 @@ def compute_anonymized_rollup_from_raw_data(input_data):
     task_executions = load_anonymized_rollup_data(TaskExecutionsAnonymizedRollup(), input_data.get('task_executions', []))
     task_executions_result = TaskExecutionsAnonymizedRollup().base(task_executions)
 
+    indirect_managed_nodes = load_anonymized_rollup_data(IndirectManagedNodesAnonymizedRollup(), input_data.get('indirect_managed_nodes', []))
+    indirect_managed_nodes_result = IndirectManagedNodesAnonymizedRollup().base(indirect_managed_nodes)
+
     anonymized_rollup = anonymize_rollups(
         events_modules_rollup=events_modules_result['json'],
         execution_environments_rollup=execution_environments_result['json'],
@@ -130,6 +134,7 @@ def compute_anonymized_rollup_from_raw_data(input_data):
         controller_version_rollup=controller_version_result['json'],
         feature_flags_rollup=feature_flags_result['json'],
         task_executions_rollup=task_executions_result['json'],
+        indirect_managed_nodes_rollup=indirect_managed_nodes_result['json'],
     )
     # Sanitize the result to replace NaN and infinity values with None (valid JSON)
     anonymized_rollup = sanitize_json(anonymized_rollup)

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -14,6 +14,7 @@ from metrics_utility.library.collectors.controller import (
     execution_environments,
     feature_flags_service,
     job_host_summary_service,
+    main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
     unified_jobs,
@@ -56,6 +57,9 @@ def _validate_top_level_structure(json_data):
     assert 'controller_versions' in json_data, "Missing 'controller_versions' at top level"
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
+    assert 'indirect_managed_nodes' not in json_data, (
+        'indirect_managed_nodes IDs must not appear at the top level — only the count goes in statistics'
+    )
 
 
 def _validate_statistics_structure(statistics):
@@ -88,6 +92,7 @@ def _validate_statistics_structure(statistics):
         'rollup_period_task_skipped_total',
         'rollup_period_task_unreachable_total',
         'rollup_period_task_ignored_total',
+        'rollup_period_indirect_managed_nodes_total',
     ]
     for field in required_fields:
         assert field in statistics, f"Missing '{field}' in statistics"
@@ -841,6 +846,22 @@ def _save_json_output(json_data, since, until):
         json.dump(json_data, f, indent=4)
 
 
+def _validate_indirect_managed_nodes(json_data, statistics):
+    """Validate indirect managed node count and confirm IDs are not in the output."""
+    print('--- Validating indirect_managed_nodes data values ---')
+    assert isinstance(statistics['rollup_period_indirect_managed_nodes_total'], int), (
+        'rollup_period_indirect_managed_nodes_total should be an integer'
+    )
+    # 10:00h window: host_ids 1, 2 (2 unique)
+    # 11:00h window: host_ids 2, 3 (2 is a duplicate, 3 is new)
+    # Unique across both windows: 1, 2, 3 = 3
+    assert statistics['rollup_period_indirect_managed_nodes_total'] == 3, (
+        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated across windows), '
+        f'got {statistics["rollup_period_indirect_managed_nodes_total"]}'
+    )
+    assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
+
+
 def _validate_all_data(json_data, statistics):
     """Run all validation checks on the json_data."""
     # Validate structure
@@ -894,6 +915,7 @@ def _validate_all_data(json_data, statistics):
     _validate_controller_versions(json_data)
     _validate_jobs_by_controller_version(json_data, statistics)
     _validate_feature_flags(json_data)
+    _validate_indirect_managed_nodes(json_data, statistics)
 
     print('✅ All data value assertions passed!')
 
@@ -941,6 +963,10 @@ def test_from_gather_to_json(cleanup_glob):
             'func': feature_flags_service,
             'needs_since_until': False,  # snapshot collector
         },
+        'main_indirectmanagednodeaudit': {
+            'func': main_indirectmanagednodeaudit,
+            'needs_since_until': True,
+        },
     }
 
     # Define two hourly intervals: 10:00-11:00 and 11:00-12:00
@@ -959,6 +985,7 @@ def test_from_gather_to_json(cleanup_glob):
         'table_metadata': 'table_metadata',
         'controller_version_service': 'controller_version',
         'feature_flags_service': 'feature_flags',
+        'main_indirectmanagednodeaudit': 'indirect_managed_nodes',
     }
 
     # Collect data from all collectors

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -92,7 +92,7 @@ def _validate_statistics_structure(statistics):
         'rollup_period_task_skipped_total',
         'rollup_period_task_unreachable_total',
         'rollup_period_task_ignored_total',
-        'rollup_period_indirect_managed_nodes_total',
+        'rollup_period_indirect_managed_nodes_all_total',
     ]
     for field in required_fields:
         assert field in statistics, f"Missing '{field}' in statistics"
@@ -849,15 +849,15 @@ def _save_json_output(json_data, since, until):
 def _validate_indirect_managed_nodes(json_data, statistics):
     """Validate indirect managed node count and confirm IDs are not in the output."""
     print('--- Validating indirect_managed_nodes data values ---')
-    assert isinstance(statistics['rollup_period_indirect_managed_nodes_total'], int), (
-        'rollup_period_indirect_managed_nodes_total should be an integer'
+    assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
+        'rollup_period_indirect_managed_nodes_all_total should be an integer'
     )
     # 10:00h window: host_ids 1, 2 (2 unique)
     # 11:00h window: host_ids 2, 3 (2 is a duplicate, 3 is new)
     # Unique across both windows: 1, 2, 3 = 3
-    assert statistics['rollup_period_indirect_managed_nodes_total'] == 3, (
+    assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
         f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated across windows), '
-        f'got {statistics["rollup_period_indirect_managed_nodes_total"]}'
+        f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
     )
     assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -104,6 +104,31 @@ def test_merge_handles_none():
     assert result == data_new
 
 
+def test_base_returns_count_only_no_ids():
+    """Test that base() returns only the count, never host IDs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'indirect_node_ids': ['remote1', 'remote2', 'remote3'],
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    assert result == {'json': {'indirect_nodes_total': 3}}
+    assert 'indirect_node_ids' not in result['json']
+
+
+def test_base_handles_none():
+    """Test that base() returns zero count when no data."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    result = rollup.base(None)
+
+    assert result == {'json': {'indirect_nodes_total': 0}}
+    assert 'indirect_node_ids' not in result['json']
+
+
 def test_rollup_name():
     """Test that rollup has correct name."""
     rollup = IndirectManagedNodesAnonymizedRollup()

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - ./main_instance.sql:/docker-entrypoint-initdb.d/init-5-main_instance.sql
       - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-6-main_jobhostsummary.sql
       - ./dab_feature_flags.sql:/docker-entrypoint-initdb.d/init-7-dab_feature_flags.sql
+      - ./main_indirectmanagednodeaudit.sql:/docker-entrypoint-initdb.d/init-8-main_indirectmanagednodeaudit.sql
 
   postgres-wait:
     image: "mirror.gcr.io/postgres"

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,0 +1,79 @@
+-- 10:00-11:00 window: host_ids 1 and 2 (2 distinct indirect hosts).
+-- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 10:30:00+00',
+    'cisco-switch-01',
+    '{"fqdn": "cisco-switch-01.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    3,
+    1,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 10:30:00+00',
+    'cisco-switch-02',
+    '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    5,
+    2,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+-- 11:00-12:00 window: host_id 2 again (dedup test) and host_id 3 (new).
+-- Expected unique count across both windows: 3 (host_ids 1, 2, 3).
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 11:30:00+00',
+    'cisco-switch-02',
+    '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    2,
+    2,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_11_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 11:30:00+00',
+    'cisco-switch-03',
+    '{"fqdn": "cisco-switch-03.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    1,
+    3,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_11_2025-06-13'
+ORDER BY j.id
+LIMIT 1;


### PR DESCRIPTION
## Description

- Adds `IndirectManagedNodesAnonymizedRollup` to `hourly_rollup_processors` in `daily_metrics_rollup.py` so the 24 hourly indirect node collections are merged into the `DailyMetricsSummary` each day.
- Passes `indirect_managed_nodes_rollup` to `anonymize_rollups()` in `daily_anonymize_and_prepare.py` so the merged rollup is included in the anonymized Segment payload.
- Adds an `indirect_managed_nodes` example entry to `collect_hourly_metrics` in `TASK_METADATA`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- metrics-utility `feature/indirect-managed-nodes-anonymization` must be merged and released to PyPI before this PR's CI will pass (the import of `IndirectManagedNodesAnonymizedRollup` fails against the current published version).

### Steps to Test

1. After metrics-utility is updated on PyPI: `uv run pytest tests/ -v`
2. Verify no new failures beyond the pre-existing baseline.

### Expected Results

Test suite passes. If `indirect_managed_nodes` hourly collections exist in the database, the daily rollup will include a deduplicated count of unique indirect managed nodes and the Segment payload will contain `indirect_managed_nodes` and `rollup_period_indirect_managed_nodes_total`.