### PR TITLE
add PR target repo/branch check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,20 @@ jobs:
   pr-checks:
     runs-on: ubuntu-latest
     steps:
+      - name: "Check PR target"
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [[ "$BASE_REPO" == "ansible/metrics-utility" && "$BASE_BRANCH" == "devel" ]]; then
+            echo "✓ PR targets devel on upstream"
+          elif [[ "$BASE_BRANCH" == stable-* ]]; then
+            echo "✓ PR targets $BASE_BRANCH"
+          else
+            echo "::error::PRs should target devel on ansible/metrics-utility or a stable-* branch"
+            exit 1
+          fi
+
       - name: "Checkout metrics-utility (${{ github.ref }})"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 


### PR DESCRIPTION
Same idea as the check in metrics-service (ansible/metrics-service#249),
ensures PRs target the right repo/branch combo:

- `ansible/metrics-utility` + `devel` — ok
- any `stable-*` branch — ok
- anything else — fail

Uses `stable-*` instead of `stable-2.*` to match this repo's branch
naming (`stable-0.6`, `stable-0.7`, etc).

---

Downstream devel branches are upstream mirrors, so any changes merged there directly have to be fixed manually :)