### PR TITLE
Disable Candlepin functionality by default

### DIFF
--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -468,6 +468,12 @@ def handle_crc_ship_target():
         allowed = '", "'.join(['controller_db', 'directory', 's3'])
         logger.warning(f'Ignoring METRICS_UTILITY_SHIP_PATH used without METRICS_UTILITY_SHIP_TARGET="{allowed}"')
 
+    # Master flag to disable all Candlepin functionality (cert loading, registration, lifecycle).
+    # When disabled, metrics-utility will use service account auth only.
+    if not bool_from_env('METRICS_UTILITY_CANDLEPIN_ENABLED', default=False):
+        logger.info('Candlepin disabled; using service account auth only.')
+        return billing_provider_params
+
     # Prefer the cert already managed by the AWX Controller (AWX PR #16388).
     # The Controller owns registration, check-in, and renewal; when its cert is
     # present and valid, use it directly and skip the metrics-utility lifecycle to

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -401,7 +401,7 @@ def _load_candlepin_cert(store):
             cert_pem, key_pem, consumer_uuid = awx_cert, awx_key, awx_uuid
 
     # If no cert exists yet, attempt initial registration when enabled.
-    if not (cert_pem and key_pem) and bool_from_env('METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED', default=True):
+    if not (cert_pem and key_pem) and bool_from_env('METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED', default=False):
         cert_pem, key_pem, consumer_uuid = _register_candlepin_consumer(store)
 
     return cert_pem, key_pem, consumer_uuid
@@ -494,7 +494,7 @@ def handle_crc_ship_target():
 
     if cert_pem and key_pem:
         _warn_if_cert_expiring(cert_pem)
-        if bool_from_env('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', default=True):
+        if bool_from_env('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', default=False):
             cert_pem, key_pem = _run_candlepin_lifecycle(cert_pem, key_pem, consumer_uuid, store)
         billing_provider_params['candlepin_cert_pem'] = cert_pem
         billing_provider_params['candlepin_key_pem'] = key_pem

--- a/metrics_utility/test/library/test_candlepin_lifecycle.py
+++ b/metrics_utility/test/library/test_candlepin_lifecycle.py
@@ -328,36 +328,40 @@ class TestHandleCrcShipTargetLifecycleWiring:
     def required_env(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
         monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_ENABLED', 'true')
         monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
 
     def test_lifecycle_not_called_when_flag_disabled(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', 'false')
         mock_store = _make_mock_store(cert_pem=SAMPLE_CERT_PEM, key_pem=SAMPLE_KEY_PEM, uuid=CONSUMER_UUID)
-        with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
-            with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
-                with patch('metrics_utility.management.validation._run_candlepin_lifecycle') as mock_lc:
-                    handle_crc_ship_target()
+        with patch('metrics_utility.management.validation._load_cert_from_controller_db', return_value=(None, None, None)):
+            with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
+                with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
+                    with patch('metrics_utility.management.validation._run_candlepin_lifecycle') as mock_lc:
+                        handle_crc_ship_target()
         mock_lc.assert_not_called()
 
     def test_lifecycle_called_when_flag_enabled(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', 'true')
         mock_store = _make_mock_store(cert_pem=SAMPLE_CERT_PEM, key_pem=SAMPLE_KEY_PEM, uuid=CONSUMER_UUID)
-        with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
-            with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
-                with patch(
-                    'metrics_utility.management.validation._run_candlepin_lifecycle', return_value=(SAMPLE_CERT_PEM, SAMPLE_KEY_PEM)
-                ) as mock_lc:
-                    handle_crc_ship_target()
+        with patch('metrics_utility.management.validation._load_cert_from_controller_db', return_value=(None, None, None)):
+            with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
+                with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
+                    with patch(
+                        'metrics_utility.management.validation._run_candlepin_lifecycle', return_value=(SAMPLE_CERT_PEM, SAMPLE_KEY_PEM)
+                    ) as mock_lc:
+                        handle_crc_ship_target()
         mock_lc.assert_called_once_with(SAMPLE_CERT_PEM, SAMPLE_KEY_PEM, CONSUMER_UUID, mock_store)
 
     def test_renewed_cert_injected_into_billing_params(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', 'true')
         mock_store = _make_mock_store(cert_pem=SAMPLE_CERT_PEM, key_pem=SAMPLE_KEY_PEM, uuid=CONSUMER_UUID)
-        with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
-            with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
-                with patch('metrics_utility.management.validation._run_candlepin_lifecycle', return_value=(SAMPLE_NEW_CERT, SAMPLE_NEW_KEY)):
-                    params = handle_crc_ship_target()
+        with patch('metrics_utility.management.validation._load_cert_from_controller_db', return_value=(None, None, None)):
+            with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):
+                with patch('metrics_utility.management.validation.parse_cert', return_value={'days_remaining': 90}):
+                    with patch('metrics_utility.management.validation._run_candlepin_lifecycle', return_value=(SAMPLE_NEW_CERT, SAMPLE_NEW_KEY)):
+                        params = handle_crc_ship_target()
         assert params['candlepin_cert_pem'] == SAMPLE_NEW_CERT
         assert params['candlepin_key_pem'] == SAMPLE_NEW_KEY
 

--- a/metrics_utility/test/validation/test_candlepin_validation.py
+++ b/metrics_utility/test/validation/test_candlepin_validation.py
@@ -383,6 +383,7 @@ class TestHandleCrcShipTargetAwxSeeding:
     def set_required_env(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
         monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_ENABLED', 'true')
         monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', raising=False)
@@ -448,6 +449,7 @@ class TestHandleCrcShipTargetCandlepin:
     def set_required_env(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
         monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_ENABLED', 'true')
         monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', raising=False)
@@ -634,6 +636,7 @@ class TestHandleCrcShipTargetDbFirst:
     def set_required_env(self, monkeypatch):
         monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
         monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_ENABLED', 'true')
         monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
         monkeypatch.delenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', raising=False)

--- a/metrics_utility/test/validation/test_candlepin_validation.py
+++ b/metrics_utility/test/validation/test_candlepin_validation.py
@@ -371,6 +371,46 @@ class TestRunCandlepinLifecyclePlaceholderUUID:
 # ---------------------------------------------------------------------------
 
 
+class TestHandleCrcShipTargetDisabled:
+    """When METRICS_UTILITY_CANDLEPIN_ENABLED is False (default), all Candlepin
+    functionality is disabled and handle_crc_ship_target returns early."""
+
+    @pytest.fixture(autouse=True)
+    def set_required_env(self, monkeypatch):
+        monkeypatch.setenv('METRICS_UTILITY_BILLING_PROVIDER', 'aws')
+        monkeypatch.setenv('METRICS_UTILITY_BILLING_ACCOUNT_ID', '123456789012')
+        monkeypatch.delenv('METRICS_UTILITY_CANDLEPIN_ENABLED', raising=False)
+        monkeypatch.delenv('METRICS_UTILITY_RED_HAT_ORG_ID', raising=False)
+        monkeypatch.delenv('METRICS_UTILITY_SHIP_PATH', raising=False)
+
+    def test_returns_billing_params_only_when_disabled(self):
+        """When Candlepin is disabled, only billing params are returned (no certs)."""
+        params = handle_crc_ship_target()
+        assert params['billing_provider'] == 'aws'
+        assert params['billing_account_id'] == '123456789012'
+        assert 'candlepin_cert_pem' not in params
+        assert 'candlepin_key_pem' not in params
+
+    def test_does_not_load_from_db_when_disabled(self):
+        """When Candlepin is disabled, DB cert loading is skipped."""
+        with patch('metrics_utility.management.validation._load_cert_from_controller_db') as mock_db:
+            handle_crc_ship_target()
+        mock_db.assert_not_called()
+
+    def test_does_not_load_from_local_store_when_disabled(self):
+        """When Candlepin is disabled, local store loading is skipped."""
+        with patch('metrics_utility.management.validation.get_candlepin_store') as mock_store:
+            handle_crc_ship_target()
+        mock_store.assert_not_called()
+
+    def test_logs_disabled_message(self):
+        """When Candlepin is disabled, an info message is logged."""
+        with patch('metrics_utility.management.validation.logger') as mock_logger:
+            handle_crc_ship_target()
+        info_msgs = [str(c) for c in mock_logger.info.call_args_list]
+        assert any('Candlepin disabled' in m and 'service account' in m for m in info_msgs)
+
+
 class TestHandleCrcShipTargetAwxSeeding:
     """When local store is empty, cert should be seeded from AWX conf_setting.
 

--- a/metrics_utility/test/validation/test_candlepin_validation.py
+++ b/metrics_utility/test/validation/test_candlepin_validation.py
@@ -689,7 +689,8 @@ class TestHandleCrcShipTargetDbFirst:
         assert params['candlepin_cert_pem'] == SAMPLE_CERT_PEM
         mock_store.load.assert_called_once()
 
-    def test_lifecycle_runs_in_fallback_path(self):
+    def test_lifecycle_runs_in_fallback_path(self, monkeypatch):
+        monkeypatch.setenv('METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED', 'true')
         mock_store = _make_mock_store(cert_pem=SAMPLE_CERT_PEM, key_pem=SAMPLE_KEY_PEM, uuid=CONSUMER_UUID)
         with patch('metrics_utility.management.validation._load_cert_from_controller_db', return_value=(None, None, None)):
             with patch('metrics_utility.management.validation.get_candlepin_store', return_value=mock_store):


### PR DESCRIPTION
## Summary

This PR adds a master flag `METRICS_UTILITY_CANDLEPIN_ENABLED` (default=False) to disable all Candlepin functionality by default, and updates the other Candlepin-related flags to also default to False for consistency.

## Changes

1. **Added master flag**: `METRICS_UTILITY_CANDLEPIN_ENABLED` (default=False)
   - Checked early in `handle_crc_ship_target()` to short-circuit all Candlepin operations
   - When disabled, metrics-utility uses service account auth only

2. **Updated existing flag defaults** for consistency:
   - `METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED`: default=True → False
   - `METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED`: default=True → False

## Behavior

**Default (all flags False):**
- No Candlepin cert loading from AWX Controller DB
- No Candlepin cert loading from local filesystem
- No Candlepin consumer registration
- No Candlepin lifecycle management (check-in/renewal)
- Falls back to service account authentication

**To enable Candlepin with full functionality:**
```bash
METRICS_UTILITY_CANDLEPIN_ENABLED=true
METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED=true
METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED=true
```

**Minimal Candlepin (cert loading only, no auto-registration/renewal):**
```bash
METRICS_UTILITY_CANDLEPIN_ENABLED=true
```

## Rationale

- Provides a clean opt-in model for Candlepin functionality
- Avoids confusing mixed defaults (master=False, sub-flags=True)
- Single flag to completely disable all Candlepin operations
- Maintains backward compatibility (users can enable with env vars)

Assisted-By: Claude Sonnet 4.5