### PR TITLE
[AAP-81123] Switch indirect node collector from hourly to daily snapshot

### DIFF
--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -53,27 +53,16 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
 
     def merge(self, data_all, data_new):
-        """Merge two indirect node rollups by deduplicating host IDs.
+        """Pass through the snapshot batch unchanged.
 
-        Combines indirect_node_ids from multiple hourly collections,
-        maintaining uniqueness for accurate daily billing counts.
+        With a daily snapshot collector there is only one batch per day,
+        so cross-batch merging is not needed.
 
         Args:
-            data_all: Accumulated data from previous merges (or None for first merge)
-            data_new: New data to merge in
+            data_all: Unused (always None for snapshot collectors)
+            data_new: Prepared data from the single snapshot batch
 
         Returns:
-            Merged dictionary with deduplicated indirect_node_ids and updated total
+            data_new unchanged
         """
-        if data_all is None:
-            return data_new
-
-        # Merge and deduplicate indirect_node_ids
-        ids_all = set(data_all.get('indirect_node_ids', []))
-        ids_new = set(data_new.get('indirect_node_ids', []))
-        indirect_node_ids = sorted(ids_all.union(ids_new))
-
-        return {
-            'indirect_node_ids': indirect_node_ids,
-            'indirect_nodes_total': len(indirect_node_ids),
-        }
+        return data_new

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -164,14 +164,14 @@ def cli_main_host_daily(since, until, output):
     return output.as_files(collector)
 
 
-@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=daily_slicing)
+@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=until_slicing)
 def cli_main_indirectmanagednodeaudit(since, until, output):
     if 'main_indirectmanagednodeaudit' not in get_optional_collectors():
         return None
 
     # the table does not exist in 2.4, may be 2.6+
     try:
-        collector = main_indirectmanagednodeaudit(db=connection, since=since, until=until)
+        collector = main_indirectmanagednodeaudit(db=connection)
         return output.as_files(collector)
     except (ProgrammingError, UndefinedTable) as e:
         logger.warning(

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,22 +1,20 @@
 """Collector for indirect managed node audit records from the Controller database."""
 
-from ..util import DataframeOutput, collector, date_where
+from ..util import DataframeOutput, collector
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
-    """Collect indirect managed node audit records within the given time window.
+def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
+    """Collect all indirect managed node audit records (full-table snapshot).
 
     Args:
         db: Django database connection.
-        since: Inclusive start datetime for the ``created`` filter.
-        until: Exclusive end datetime for the ``created`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:
         pandas DataFrame with indirect node audit fields, or list of CSV paths.
     """
-    query = f"""
+    query = """
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -42,8 +40,6 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=Dat
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
-        WHERE {date_where('main_indirectmanagednodeaudit.created', since, until)}
-        ORDER BY main_indirectmanagednodeaudit.created ASC
     """
 
     return output.sql(db, query)

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -1,5 +1,3 @@
-import datetime
-
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -10,27 +8,21 @@ from metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit
 def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
-    assert instance.kwargs['since'] == since
-    assert instance.kwargs['until'] == until
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     """Test that main_indirectmanagednodeaudit calls copy_table."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -42,35 +34,12 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_contains_time_range(mock_copy_pandas):
-    """Test that the query includes the time range."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 3, 15, 10, 30, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 3, 16, 18, 45, tzinfo=datetime.timezone.utc)
-    mock_copy_pandas.return_value = pd.DataFrame()
-
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
-    instance.gather()
-
-    call_args = mock_copy_pandas.call_args
-    query = call_args[0][1]
-
-    # Query should contain time boundaries using created field
-    assert '2024-03-15' in query
-    assert '2024-03-16' in query
-    assert 'main_indirectmanagednodeaudit.created >=' in query
-    assert 'main_indirectmanagednodeaudit.created <' in query
-
-
-@patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
-    """Test that the SQL query has expected structure."""
+    """Test that the SQL query has expected structure and no date filter."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -88,3 +57,7 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
     assert 'facts' in query
     assert 'events' in query
     assert 'task_runs' in query or 'count' in query
+
+    # Snapshot collector: no date range filter on created
+    assert 'main_indirectmanagednodeaudit.created >=' not in query
+    assert 'main_indirectmanagednodeaudit.created <' not in query

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -207,7 +207,7 @@ def compute_anonymized_rollup(db, since, until, service_db=None):
 
     indirect_managed_nodes_data = []
     try:
-        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db).gather()
     except Exception as e:
         logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -852,11 +852,10 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
         'rollup_period_indirect_managed_nodes_all_total should be an integer'
     )
-    # 10:00h window: host_ids 1, 2 (2 unique)
-    # 11:00h window: host_ids 2, 3 (2 is a duplicate, 3 is new)
-    # Unique across both windows: 1, 2, 3 = 3
+    # Snapshot of full table: 4 records, host_ids 1, 2, 2, 3
+    # prepare() deduplicates within the snapshot to 3 unique host_ids (1, 2, 3)
     assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
-        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated across windows), '
+        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated in prepare()), '
         f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
     )
     assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
@@ -965,7 +964,7 @@ def test_from_gather_to_json(cleanup_glob):
         },
         'main_indirectmanagednodeaudit': {
             'func': main_indirectmanagednodeaudit,
-            'needs_since_until': True,
+            'needs_since_until': False,  # snapshot collector
         },
     }
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -70,28 +70,8 @@ def test_prepare_handles_missing_host_remote_id():
     assert result['indirect_nodes_total'] == 0
 
 
-def test_merge_combines_host_ids():
-    """Test that merge() deduplicates host IDs across multiple hourly collections."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data_all = {
-        'indirect_node_ids': ['remote1', 'remote2'],
-        'indirect_nodes_total': 2,
-    }
-
-    data_new = {
-        'indirect_node_ids': ['remote2', 'remote3'],
-        'indirect_nodes_total': 2,
-    }
-
-    result = rollup.merge(data_all, data_new)
-
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
-    assert result['indirect_nodes_total'] == 3
-
-
-def test_merge_handles_none():
-    """Test that merge() handles None for first merge."""
+def test_merge_returns_data_new():
+    """Test that merge() passes through the snapshot batch unchanged."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data_new = {

--- a/metrics_utility/test/test_collectors.py
+++ b/metrics_utility/test/test_collectors.py
@@ -34,7 +34,7 @@ class TestMainIndirectManagedNodeAuditTable:
 
         # Assert
         assert result == ['test_file.csv']
-        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection, since=since, until=until)
+        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection)
         mock_output.as_files.assert_called_once_with(mock_collector)
 
     @patch('metrics_utility.automation_controller_billing.collectors.get_optional_collectors')

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,4 +1,5 @@
--- 10:00-11:00 window: host_ids 1 and 2 (2 distinct indirect hosts).
+-- Snapshot test data: 4 records, host_ids 1, 2, 2, 3.
+-- prepare() deduplicates to 3 unique hosts (host_ids 1, 2, 3).
 -- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
@@ -38,8 +39,7 @@ WHERE j.name = 'default_unified_job_2025-06-13'
 ORDER BY j.id
 LIMIT 1;
 
--- 11:00-12:00 window: host_id 2 again (dedup test) and host_id 3 (new).
--- Expected unique count across both windows: 3 (host_ids 1, 2, 3).
+-- host_id 2 again and host_id 3 (new): deduplication in prepare() keeps 3 unique hosts.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
 )


### PR DESCRIPTION
[AAP-81123](https://redhat.atlassian.net/browse/AAP-81123)

## Description

Switches `main_indirectmanagednodeaudit` from an hourly time-windowed
collector to a daily full-table snapshot, matching the pattern used by
`execution_environments` and `table_metadata`.

- Collector removes `since`/`until` params and the `WHERE created >=`
  filter; registration changes from `daily_slicing` to `until_slicing`.
- `merge()` simplified to a pass-through (cross-batch deduplication is
  not needed with a single daily snapshot; within-snapshot dedup in
  `prepare()` is unchanged).

## Testing

### Prerequisites

- Postgres running with seed data imported:
  ```
  cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags,main_indirectmanagednodeaudit}.sql | psql
  ```

### Steps to Test

1. `uv run pytest -s -v metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py`
2. `uv run pytest -s -v metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py`
3. `uv run pytest -s -v metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py`

### Expected Results

All tests pass.

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.
