### PR TITLE
[AAP-78076] test(indirect-nodes): add null join and orphaned record tests

### DIFF
--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -56,7 +56,7 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
     assert 'canonical_facts' in query
     assert 'facts' in query
     assert 'events' in query
-    assert 'task_runs' in query or 'count' in query
+    assert 'task_runs' in query
 
     # Snapshot collector: no date range filter on created
     assert 'main_indirectmanagednodeaudit.created >=' not in query

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -61,3 +61,85 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
     # Snapshot collector: no date range filter on created
     assert 'main_indirectmanagednodeaudit.created >=' not in query
     assert 'main_indirectmanagednodeaudit.created <' not in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
+    """Records with NULL job_id, inventory_id, or organization_id are returned without error.
+
+    The LEFT JOINs produce NULL for the joined columns; the collector does not filter or raise.
+    """
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame(
+        {
+            'id': [1],
+            'created': [None],
+            'host_name': ['device-01'],
+            'host_remote_id': ['host-abc-1'],
+            'canonical_facts': ['{"fqdn": "device-01.example.com"}'],
+            'facts': ['{}'],
+            'events': ['[]'],
+            'task_runs': [3],
+            'job_created': [None],
+            'job_remote_id': [None],
+            'job_template_remote_id': [None],
+            'job_template_name': [None],
+            'inventory_remote_id': [None],
+            'inventory_name': [None],
+            'organization_remote_id': [None],
+            'organization_name': [None],
+            'project_remote_id': [None],
+            'project_name': [None],
+        }
+    )
+
+    instance = main_indirectmanagednodeaudit(db=mock_db)
+    result = instance.gather()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert result['job_remote_id'].iloc[0] is None or pd.isna(result['job_remote_id'].iloc[0])
+    assert result['inventory_remote_id'].iloc[0] is None or pd.isna(result['inventory_remote_id'].iloc[0])
+    assert result['organization_remote_id'].iloc[0] is None or pd.isna(result['organization_remote_id'].iloc[0])
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
+    """Records referencing a deleted job, inventory, or organization are returned without error.
+
+    A deleted foreign key produces the same NULL join result as a missing FK value;
+    the collector returns the row without filtering or raising.
+    """
+    mock_db = MagicMock()
+    # job_id=999 exists in the audit table but the referenced job was deleted;
+    # LEFT JOIN produces NULL for all job/org/project columns.
+    mock_copy_pandas.return_value = pd.DataFrame(
+        {
+            'id': [2],
+            'created': [None],
+            'host_name': ['orphaned-device'],
+            'host_remote_id': ['host-abc-2'],
+            'canonical_facts': ['{}'],
+            'facts': ['{}'],
+            'events': ['[]'],
+            'task_runs': [1],
+            'job_created': [None],
+            'job_remote_id': [999],
+            'job_template_remote_id': [None],
+            'job_template_name': [None],
+            'inventory_remote_id': [None],
+            'inventory_name': [None],
+            'organization_remote_id': [None],
+            'organization_name': [None],
+            'project_remote_id': [None],
+            'project_name': [None],
+        }
+    )
+
+    instance = main_indirectmanagednodeaudit(db=mock_db)
+    result = instance.gather()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert result['job_remote_id'].iloc[0] == 999
+    assert result['organization_remote_id'].iloc[0] is None or pd.isna(result['organization_remote_id'].iloc[0])


### PR DESCRIPTION
# [AAP-78076] Add null join and orphaned record tests for indirect node collector

## Description

- Adds two unit tests for error handling edge cases in the
  `main_indirectmanagednodeaudit` collector (Part 4 of indirect node
  collection).
- `test_main_indirectmanagednodeaudit_null_join_references`: asserts that
  records with NULL `job_id`, `inventory_id`, or `organization_id` are
  returned without error. The LEFT JOINs in the collector SQL produce NULL
  for the joined columns; the collector does not filter or raise.
- `test_main_indirectmanagednodeaudit_orphaned_records`: asserts that records
  whose referenced job, inventory, or organization has been deleted are
  returned without error, producing the same NULL join behavior.

## Type of Change

- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

No DB required - tests mock `_copy_table_pandas`.

### Steps to Test

```
uv run pytest metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py -v
```

### Expected Results

All 5 tests pass.