### PR TITLE
feat(indirect-nodes): convert collector to daily slicing with collection grouping

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -537,6 +537,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'controller_versions': controller_versions,
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
+        'indirect_nodes_by_collection': indirect_managed_nodes_root.get('by_collection', []),
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pandas as pd
+
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import (
@@ -81,7 +83,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         for _, row in dataframe.iterrows():
             host_name = row.get('host_name')
-            if host_name is None or (isinstance(host_name, float) and host_name != host_name):
+            if pd.isna(host_name):
                 continue
 
             host_name = str(host_name)

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -52,6 +52,17 @@ def _make_group_key(organization_name, collection_name):
     return f'{organization_name}{GROUP_KEY_SEPARATOR}{collection_name}'
 
 
+def _aggregate_by_key(groups, key_field):
+    """Aggregate host names across groups by a single field (org or collection)."""
+    aggregated = {}
+    for group in groups.values():
+        key = group[key_field]
+        if key not in aggregated:
+            aggregated[key] = set()
+        aggregated[key].update(group.get('host_names', []))
+    return {k: {'host_names': sorted(v), 'host_count': len(v)} for k, v in sorted(aggregated.items())}
+
+
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
     """Rollup processor for main_indirectmanagednodeaudit collector data.
 
@@ -76,7 +87,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'indirect_nodes_total': 0}
+            return {'groups': {}, 'by_organization': {}, 'by_collection': {}, 'indirect_nodes_total': 0}
 
         groups = {}
         all_host_names = set()
@@ -109,9 +120,14 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
+        by_organization = _aggregate_by_key(groups, 'organization_name')
+        by_collection = _aggregate_by_key(groups, 'collection_name')
+
         return sanitize_json(
             {
                 'groups': groups,
+                'by_organization': by_organization,
+                'by_collection': by_collection,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -192,5 +208,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         return {
             'groups': merged_groups,
+            'by_organization': _aggregate_by_key(merged_groups, 'organization_name'),
+            'by_collection': _aggregate_by_key(merged_groups, 'collection_name'),
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -33,7 +33,7 @@ def _extract_collection_names(events_value):
     if isinstance(events_value, str):
         try:
             events_list = json.loads(events_value)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             return set()
     elif isinstance(events_value, list):
         events_list = events_value

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -87,7 +87,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'by_organization': {}, 'by_collection': {}, 'indirect_nodes_total': 0}
+            return {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
 
         groups = {}
         all_host_names = set()
@@ -120,14 +120,17 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
-        by_organization = _aggregate_by_key(groups, 'organization_name')
-        by_collection = _aggregate_by_key(groups, 'collection_name')
+        agg_by_org = _aggregate_by_key(groups, 'organization_name')
+        agg_by_coll = _aggregate_by_key(groups, 'collection_name')
+
+        by_organizations = [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()]
+        by_collections = [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()]
 
         return sanitize_json(
             {
                 'groups': groups,
-                'by_organization': by_organization,
-                'by_collection': by_collection,
+                'by_organizations': by_organizations,
+                'by_collections': by_collections,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -206,9 +209,12 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_count'] = len(group['host_names'])
             all_host_names.update(group['host_names'])
 
+        agg_by_org = _aggregate_by_key(merged_groups, 'organization_name')
+        agg_by_coll = _aggregate_by_key(merged_groups, 'collection_name')
+
         return {
             'groups': merged_groups,
-            'by_organization': _aggregate_by_key(merged_groups, 'organization_name'),
-            'by_collection': _aggregate_by_key(merged_groups, 'collection_name'),
+            'by_organizations': [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()],
+            'by_collections': [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()],
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -1,46 +1,126 @@
 """Anonymized rollup for indirect managed node audit collector data."""
 
+import json
+
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import (
+    DataframeContentUsage,
+)
+
+
+GROUP_KEY_SEPARATOR = '||'
+
+
+def _extract_collection_names(events_value):
+    """Parse the events JSON column and return a set of collection names.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        Set of two-part collection name strings (e.g. ``{"azure.azcollection"}``).
+    """
+    if events_value is None:
+        return set()
+
+    if isinstance(events_value, float):
+        return set()
+
+    if isinstance(events_value, str):
+        try:
+            events_list = json.loads(events_value)
+        except (json.JSONDecodeError, ValueError):
+            return set()
+    elif isinstance(events_value, list):
+        events_list = events_value
+    else:
+        return set()
+
+    collections = set()
+    for fqcn in events_list:
+        name = DataframeContentUsage.extract_collection_name(fqcn)
+        if name is not None:
+            collections.add(name)
+    return collections
+
+
+def _make_group_key(organization_name, collection_name):
+    return f'{organization_name}{GROUP_KEY_SEPARATOR}{collection_name}'
 
 
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
-    """Rollup processor for main_indirectmanagednodeaudit collector data."""
+    """Rollup processor for main_indirectmanagednodeaudit collector data.
+
+    Groups indirect managed nodes by organization and Ansible collection,
+    counting unique host names per group.
+    """
 
     def __init__(self):
         super().__init__('indirect_managed_nodes')
         self.collector_names = ['main_indirectmanagednodeaudit']
 
     def prepare(self, dataframe):
-        """Transform raw indirect node audit data for deduplication.
+        """Transform raw indirect node audit data into org/collection groups.
 
-        Extracts unique host_remote_ids for daily deduplication and billing count.
+        Parses the events JSON column to extract Ansible collection names,
+        then groups by (organization_name, collection_name) and counts unique
+        host_name values per group. Uses host_name (not host_remote_id) because
+        host_remote_id is always NULL for indirect managed nodes.
 
-        Returns JSON-serializable dictionary with deduplicated host IDs and total count.
+        Returns JSON-serializable dictionary with groups and total count.
         """
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {
-                'indirect_node_ids': [],
-                'indirect_nodes_total': 0,
-            }
+            return {'groups': {}, 'indirect_nodes_total': 0}
 
-        # Extract unique host_remote_ids for deduplication
-        if 'host_remote_id' in dataframe.columns:
-            indirect_node_ids = sorted(set(dataframe['host_remote_id'].dropna()))
-        else:
-            indirect_node_ids = []
+        groups = {}
+        all_host_names = set()
+
+        for _, row in dataframe.iterrows():
+            host_name = row.get('host_name')
+            if host_name is None or (isinstance(host_name, float) and host_name != host_name):
+                continue
+
+            host_name = str(host_name)
+            org_name = str(row.get('organization_name', ''))
+            all_host_names.add(host_name)
+
+            collection_names = _extract_collection_names(row.get('events'))
+
+            if not collection_names:
+                collection_names = {'_no_collection'}
+
+            for collection_name in collection_names:
+                key = _make_group_key(org_name, collection_name)
+                if key not in groups:
+                    groups[key] = {
+                        'organization_name': org_name,
+                        'collection_name': collection_name,
+                        'host_names': set(),
+                    }
+                groups[key]['host_names'].add(host_name)
+
+        for group in groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
 
         return sanitize_json(
             {
-                'indirect_node_ids': indirect_node_ids,
-                'indirect_nodes_total': len(indirect_node_ids),
+                'groups': groups,
+                'indirect_nodes_total': len(all_host_names),
             }
         )
 
     def base(self, data):
-        """Return final rollup payload with count only (no host IDs for privacy).
+        """Return final rollup payload stripped of all PII.
+
+        Strips host_names and organization_name (customer-identifiable).
+        Collapses org-level groups into collection-level totals, re-deduplicating
+        hosts that appear under the same collection in different orgs.
+        Collection names are public Ansible Galaxy labels, not PII.
 
         Args:
             data: Accumulated dict from merge() calls, or None if no data.
@@ -49,20 +129,66 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             Dict with 'json' key containing the final rollup data.
         """
         if data is None:
-            return {'json': {'indirect_nodes_total': 0}}
-        return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
+            return {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+
+        collection_hosts = {}
+        for group in data.get('groups', {}).values():
+            cname = group['collection_name']
+            hosts = group.get('host_names', [])
+            if cname not in collection_hosts:
+                collection_hosts[cname] = set()
+            collection_hosts[cname].update(hosts)
+
+        by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
+
+        return {
+            'json': {
+                'indirect_nodes_total': data.get('indirect_nodes_total', 0),
+                'by_collection': by_collection,
+            }
+        }
 
     def merge(self, data_all, data_new):
-        """Pass through the snapshot batch unchanged.
-
-        With a daily snapshot collector there is only one batch per day,
-        so cross-batch merging is not needed.
+        """Merge two prepared batches by unioning host name sets per group.
 
         Args:
-            data_all: Unused (always None for snapshot collectors)
-            data_new: Prepared data from the single snapshot batch
+            data_all: Previously accumulated data, or None for the first batch.
+            data_new: New batch of prepared data.
 
         Returns:
-            data_new unchanged
+            Merged data with deduplicated host names per group.
         """
-        return data_new
+        if data_all is None:
+            return data_new
+        if data_new is None:
+            return data_all
+
+        merged_groups = {}
+
+        for key, group in data_all.get('groups', {}).items():
+            merged_groups[key] = {
+                'organization_name': group['organization_name'],
+                'collection_name': group['collection_name'],
+                'host_names': set(group.get('host_names', [])),
+            }
+
+        for key, group in data_new.get('groups', {}).items():
+            if key in merged_groups:
+                merged_groups[key]['host_names'].update(group.get('host_names', []))
+            else:
+                merged_groups[key] = {
+                    'organization_name': group['organization_name'],
+                    'collection_name': group['collection_name'],
+                    'host_names': set(group.get('host_names', [])),
+                }
+
+        all_host_names = set()
+        for group in merged_groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+            all_host_names.update(group['host_names'])
+
+        return {
+            'groups': merged_groups,
+            'indirect_nodes_total': len(all_host_names),
+        }

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,20 +1,22 @@
 """Collector for indirect managed node audit records from the Controller database."""
 
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
-    """Collect all indirect managed node audit records (full-table snapshot).
+def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
+    """Collect indirect managed node audit records for jobs finished in the time window.
 
     Args:
         db: Django database connection.
+        since: Inclusive start datetime for the job ``finished`` filter.
+        until: Exclusive end datetime for the job ``finished`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:
         pandas DataFrame with indirect node audit fields, or list of CSV paths.
     """
-    query = """
+    query = f"""
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -40,6 +42,8 @@ def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
+        WHERE
+            {date_where('main_unifiedjob.finished', since, until)}
     """
 
     return output.sql(db, query)

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -5,15 +6,21 @@ import pandas as pd
 from metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit import main_indirectmanagednodeaudit
 
 
+SINCE = datetime(2025, 6, 13, 0, 0, 0, tzinfo=timezone.utc)
+UNTIL = datetime(2025, 6, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+
 def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
+    assert instance.kwargs['since'] == SINCE
+    assert instance.kwargs['until'] == UNTIL
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -22,7 +29,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -34,33 +41,47 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
-    """Test that the SQL query has expected structure and no date filter."""
+def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
+    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
     query = call_args[0][1]
 
-    # Should query expected tables
     assert 'main_indirectmanagednodeaudit' in query
     assert 'main_job' in query
     assert 'main_unifiedjob' in query
     assert 'main_inventory' in query
     assert 'main_organization' in query
 
-    # Should have expected columns
     assert 'canonical_facts' in query
     assert 'facts' in query
     assert 'events' in query
     assert 'task_runs' in query
 
-    # Snapshot collector: no date range filter on created
-    assert 'main_indirectmanagednodeaudit.created >=' not in query
-    assert 'main_indirectmanagednodeaudit.created <' not in query
+    assert 'main_unifiedjob.finished' in query
+    assert '>=' in query
+    assert '<' in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas):
+    """Test that passing since=None, until=None produces WHERE true (no filtering)."""
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=None, until=None)
+    instance.gather()
+
+    call_args = mock_copy_pandas.call_args
+    query = call_args[0][1]
+
+    assert 'WHERE' in query
+    assert 'true' in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -93,7 +114,7 @@ def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)
@@ -111,8 +132,6 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
     the collector returns the row without filtering or raising.
     """
     mock_db = MagicMock()
-    # job_id=999 exists in the audit table but the referenced job was deleted;
-    # LEFT JOIN produces NULL for all job/org/project columns.
     mock_copy_pandas.return_value = pd.DataFrame(
         {
             'id': [2],
@@ -136,7 +155,7 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -207,7 +207,7 @@ def compute_anonymized_rollup(db, since, until, service_db=None):
 
     indirect_managed_nodes_data = []
     try:
-        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db).gather()
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
     except Exception as e:
         logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -57,9 +57,8 @@ def _validate_top_level_structure(json_data):
     assert 'controller_versions' in json_data, "Missing 'controller_versions' at top level"
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
-    assert 'indirect_managed_nodes' not in json_data, (
-        'indirect_managed_nodes IDs must not appear at the top level — only the count goes in statistics'
-    )
+    assert 'indirect_nodes_by_collection' in json_data, "Missing 'indirect_nodes_by_collection' at top level"
+    assert 'indirect_managed_nodes' not in json_data, 'indirect_managed_nodes raw data must not appear at the top level'
 
 
 def _validate_statistics_structure(statistics):
@@ -847,18 +846,28 @@ def _save_json_output(json_data, since, until):
 
 
 def _validate_indirect_managed_nodes(json_data, statistics):
-    """Validate indirect managed node count and confirm IDs are not in the output."""
+    """Validate indirect managed node count and grouped output."""
     print('--- Validating indirect_managed_nodes data values ---')
     assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
         'rollup_period_indirect_managed_nodes_all_total should be an integer'
     )
-    # Snapshot of full table: 4 records, host_ids 1, 2, 2, 3
-    # prepare() deduplicates within the snapshot to 3 unique host_ids (1, 2, 3)
+    # Daily collection of 4 records across 2 hourly intervals:
+    #   cisco-switch-01 -> cisco.ios (2 FQCNs)
+    #   cisco-switch-02 -> azure.azcollection, then cisco.ios in second interval
+    #   cisco-switch-03 -> azure.azcollection + cisco.ios (2 FQCNs)
+    # Total unique host_names: 3 (cisco-switch-01, -02, -03)
     assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
-        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated in prepare()), '
-        f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
+        f'Expected 3 unique indirect managed nodes (3 unique host_names), got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
     )
-    assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
+
+    by_c = json_data.get('indirect_nodes_by_collection', [])
+    assert isinstance(by_c, list), 'indirect_nodes_by_collection should be a list'
+
+    for group in by_c:
+        assert 'host_names' not in group, 'host_names must not appear in anonymized output (privacy)'
+        assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
+        assert 'collection_name' in group
+        assert 'host_count' in group
 
 
 def _validate_all_data(json_data, statistics):
@@ -964,7 +973,7 @@ def test_from_gather_to_json(cleanup_glob):
         },
         'main_indirectmanagednodeaudit': {
             'func': main_indirectmanagednodeaudit,
-            'needs_since_until': False,  # snapshot collector
+            'needs_since_until': True,
         },
     }
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -54,7 +54,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'by_organization': {}, 'by_collection': {}, 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -137,6 +137,83 @@ def test_prepare_handles_events_as_list():
     assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
 
 
+def test_prepare_by_organization_summary():
+    """prepare() includes by_organization summary with deduplicated host counts."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    by_org = result['by_organization']
+    assert by_org['OrgA']['host_count'] == 1
+    assert by_org['OrgA']['host_names'] == ['host1']
+    assert by_org['OrgB']['host_count'] == 1
+    assert by_org['OrgB']['host_names'] == ['host2']
+
+
+def test_prepare_by_collection_summary():
+    """prepare() includes by_collection summary with deduplicated host counts."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    by_coll = result['by_collection']
+    assert by_coll['cisco.ios']['host_count'] == 2
+    assert sorted(by_coll['cisco.ios']['host_names']) == ['host1', 'host2']
+    assert by_coll['azure.azcollection']['host_count'] == 1
+    assert by_coll['azure.azcollection']['host_names'] == ['host3']
+
+
+def test_merge_includes_by_organization_and_by_collection():
+    """merge() result includes by_organization and by_collection summaries."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    data_new = {
+        'groups': {
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    assert result['by_organization']['OrgA']['host_count'] == 1
+    assert result['by_organization']['OrgB']['host_count'] == 1
+    assert result['by_collection']['cisco.ios']['host_count'] == 2
+
+
 def test_merge_unions_host_names():
     """merge() unions host name sets across two batches."""
     rollup = IndirectManagedNodesAnonymizedRollup()
@@ -194,7 +271,7 @@ def test_merge_with_none_data_all():
 
 
 def test_base_strips_pii():
-    """base() output does not contain host_names or organization_name."""
+    """base() output does not contain host_names, organization_name, or by_organization."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
@@ -206,13 +283,23 @@ def test_base_strips_pii():
                 'host_count': 2,
             },
         },
+        'by_organization': {
+            'OrgA': {'host_names': ['host1', 'host2'], 'host_count': 2},
+        },
+        'by_collection': {
+            'cisco.ios': {'host_names': ['host1', 'host2'], 'host_count': 2},
+        },
         'indirect_nodes_total': 2,
     }
 
     result = rollup.base(data)
 
     assert 'json' in result
-    for group in result['json']['by_collection']:
+    output = result['json']
+    assert 'by_organization' not in output
+    assert 'groups' not in output
+    assert 'host_names' not in output
+    for group in output['by_collection']:
         assert 'host_names' not in group
         assert 'organization_name' not in group
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -1,3 +1,5 @@
+import json
+
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
@@ -5,78 +7,184 @@ from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup
 )
 
 
-def test_prepare_extracts_unique_host_ids():
-    """Test that prepare() extracts and deduplicates host_remote_ids."""
+def _make_dataframe(rows):
+    """Build a DataFrame from a list of dicts with sensible defaults."""
+    defaults = {
+        'id': None,
+        'host_name': None,
+        'host_remote_id': None,
+        'organization_name': 'DefaultOrg',
+        'events': '[]',
+    }
+    filled = []
+    for i, row in enumerate(rows):
+        r = {**defaults, 'id': i + 1, **row}
+        filled.append(r)
+    return pd.DataFrame(filled)
+
+
+def test_prepare_groups_by_org_and_collection():
+    """prepare() groups hosts by organization and collection name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    data = pd.DataFrame(
-        {
-            'id': [1, 2, 3],
-            'host_name': ['host1', 'host2', 'host3'],
-            'host_remote_id': ['remote1', 'remote2', 'remote3'],
-        }
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+        ]
     )
 
     result = rollup.prepare(data)
 
-    assert isinstance(result, dict)
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
     assert result['indirect_nodes_total'] == 3
+    groups = result['groups']
+    assert 'OrgA||cisco.ios' in groups
+    assert 'OrgA||azure.azcollection' in groups
+    assert 'OrgB||cisco.ios' in groups
+    assert groups['OrgA||cisco.ios']['host_count'] == 1
+    assert groups['OrgA||azure.azcollection']['host_count'] == 1
+    assert groups['OrgB||cisco.ios']['host_count'] == 1
 
 
 def test_prepare_handles_empty_dataframe():
-    """Test that prepare() handles empty DataFrames gracefully."""
+    """prepare() handles empty DataFrames gracefully."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    empty_data = pd.DataFrame()
+    result = rollup.prepare(pd.DataFrame())
 
-    result = rollup.prepare(empty_data)
-
-    assert result == {'indirect_node_ids': [], 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'indirect_nodes_total': 0}
 
 
-def test_prepare_deduplicates_host_ids():
-    """Test that prepare() deduplicates duplicate host_remote_ids."""
+def test_prepare_deduplicates_hosts_within_group():
+    """prepare() deduplicates hosts that appear multiple times in the same group."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    data = pd.DataFrame(
-        {
-            'id': [1, 2, 3, 4],
-            'host_name': ['host1', 'host2', 'host1', 'host3'],
-            'host_remote_id': ['remote1', 'remote2', 'remote1', 'remote3'],
-        }
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_config"]'},
+        ]
     )
 
     result = rollup.prepare(data)
 
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
+    assert result['indirect_nodes_total'] == 1
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+    assert result['groups']['OrgA||cisco.ios']['host_names'] == ['host1']
+
+
+def test_prepare_handles_empty_events():
+    """prepare() handles rows with empty or null events arrays."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '[]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': None},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 2
+    no_collection_key = 'OrgA||_no_collection'
+    assert no_collection_key in result['groups']
+    assert result['groups'][no_collection_key]['host_count'] == 2
+
+
+def test_prepare_handles_multiple_collections_per_host():
+    """A host with events from multiple collections appears in each group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': json.dumps(['cisco.ios.ios_command', 'azure.azcollection.azure_rm_vm']),
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert 'OrgA||cisco.ios' in result['groups']
+    assert 'OrgA||azure.azcollection' in result['groups']
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+    assert result['groups']['OrgA||azure.azcollection']['host_count'] == 1
+
+
+def test_prepare_handles_events_as_list():
+    """prepare() handles events column already parsed as a Python list."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': ['cisco.ios.ios_command'],
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert 'OrgA||cisco.ios' in result['groups']
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+
+
+def test_merge_unions_host_names():
+    """merge() unions host name sets across two batches."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    data_new = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 3
+    assert sorted(result['groups']['OrgA||cisco.ios']['host_names']) == ['host1', 'host2', 'host3']
     assert result['indirect_nodes_total'] == 3
 
 
-def test_prepare_handles_missing_host_remote_id():
-    """Test that prepare() handles DataFrames without host_remote_id column."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = pd.DataFrame(
-        {
-            'id': [1, 2],
-            'host_name': ['host1', 'host2'],
-        }
-    )
-
-    result = rollup.prepare(data)
-
-    assert result['indirect_node_ids'] == []
-    assert result['indirect_nodes_total'] == 0
-
-
-def test_merge_returns_data_new():
-    """Test that merge() passes through the snapshot batch unchanged."""
+def test_merge_with_none_data_all():
+    """merge(None, data_new) returns data_new unchanged."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data_new = {
-        'indirect_node_ids': ['remote1', 'remote2'],
-        'indirect_nodes_total': 2,
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
     }
 
     result = rollup.merge(None, data_new)
@@ -84,38 +192,114 @@ def test_merge_returns_data_new():
     assert result == data_new
 
 
-def test_base_returns_count_only_no_ids():
-    """Test that base() returns only the count, never host IDs."""
+def test_base_strips_pii():
+    """base() output does not contain host_names or organization_name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
-        'indirect_node_ids': ['remote1', 'remote2', 'remote3'],
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.base(data)
+
+    assert 'json' in result
+    for group in result['json']['by_collection']:
+        assert 'host_names' not in group
+        assert 'organization_name' not in group
+
+
+def test_base_collapses_orgs_into_collection_totals():
+    """base() merges org-level groups into collection-level totals."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+            'OrgA||azure.azcollection': {
+                'organization_name': 'OrgA',
+                'collection_name': 'azure.azcollection',
+                'host_names': ['host3'],
+                'host_count': 1,
+            },
+        },
         'indirect_nodes_total': 3,
     }
 
     result = rollup.base(data)
 
-    assert result == {'json': {'indirect_nodes_total': 3}}
-    assert 'indirect_node_ids' not in result['json']
+    assert result['json']['indirect_nodes_total'] == 3
+    by_c = result['json']['by_collection']
+    assert len(by_c) == 2
+    assert by_c[0]['collection_name'] == 'azure.azcollection'
+    assert by_c[0]['host_count'] == 1
+    assert by_c[1]['collection_name'] == 'cisco.ios'
+    assert by_c[1]['host_count'] == 2
+
+
+def test_base_deduplicates_hosts_across_orgs():
+    """base() deduplicates hosts that appear under the same collection in different orgs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    cisco_group = result['json']['by_collection'][0]
+    assert cisco_group['collection_name'] == 'cisco.ios'
+    assert cisco_group['host_count'] == 3
 
 
 def test_base_handles_none():
-    """Test that base() returns zero count when no data."""
+    """base(None) returns zero count and empty array."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     result = rollup.base(None)
 
-    assert result == {'json': {'indirect_nodes_total': 0}}
-    assert 'indirect_node_ids' not in result['json']
+    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
 
 
 def test_rollup_name():
-    """Test that rollup has correct name."""
+    """Rollup has correct name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.rollup_name == 'indirect_managed_nodes'
 
 
 def test_collector_names():
-    """Test that collector_names is set correctly."""
+    """collector_names is set correctly."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.collector_names == ['main_indirectmanagednodeaudit']

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -54,7 +54,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'by_organization': {}, 'by_collection': {}, 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -137,8 +137,8 @@ def test_prepare_handles_events_as_list():
     assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
 
 
-def test_prepare_by_organization_summary():
-    """prepare() includes by_organization summary with deduplicated host counts."""
+def test_prepare_by_organizations_summary():
+    """prepare() includes by_organizations list with deduplicated host counts."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = _make_dataframe(
@@ -151,15 +151,15 @@ def test_prepare_by_organization_summary():
 
     result = rollup.prepare(data)
 
-    by_org = result['by_organization']
-    assert by_org['OrgA']['host_count'] == 1
-    assert by_org['OrgA']['host_names'] == ['host1']
-    assert by_org['OrgB']['host_count'] == 1
-    assert by_org['OrgB']['host_names'] == ['host2']
+    by_orgs = result['by_organizations']
+    assert by_orgs == [
+        {'organization_name': 'OrgA', 'host_count': 1},
+        {'organization_name': 'OrgB', 'host_count': 1},
+    ]
 
 
-def test_prepare_by_collection_summary():
-    """prepare() includes by_collection summary with deduplicated host counts."""
+def test_prepare_by_collections_summary():
+    """prepare() includes by_collections list with deduplicated host counts."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = _make_dataframe(
@@ -172,15 +172,15 @@ def test_prepare_by_collection_summary():
 
     result = rollup.prepare(data)
 
-    by_coll = result['by_collection']
-    assert by_coll['cisco.ios']['host_count'] == 2
-    assert sorted(by_coll['cisco.ios']['host_names']) == ['host1', 'host2']
-    assert by_coll['azure.azcollection']['host_count'] == 1
-    assert by_coll['azure.azcollection']['host_names'] == ['host3']
+    by_colls = result['by_collections']
+    assert by_colls == [
+        {'collection_name': 'azure.azcollection', 'host_count': 1},
+        {'collection_name': 'cisco.ios', 'host_count': 2},
+    ]
 
 
-def test_merge_includes_by_organization_and_by_collection():
-    """merge() result includes by_organization and by_collection summaries."""
+def test_merge_includes_by_organizations_and_by_collections():
+    """merge() result includes by_organizations and by_collections summaries."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data_all = {
@@ -209,9 +209,13 @@ def test_merge_includes_by_organization_and_by_collection():
 
     result = rollup.merge(data_all, data_new)
 
-    assert result['by_organization']['OrgA']['host_count'] == 1
-    assert result['by_organization']['OrgB']['host_count'] == 1
-    assert result['by_collection']['cisco.ios']['host_count'] == 2
+    assert result['by_organizations'] == [
+        {'organization_name': 'OrgA', 'host_count': 1},
+        {'organization_name': 'OrgB', 'host_count': 1},
+    ]
+    assert result['by_collections'] == [
+        {'collection_name': 'cisco.ios', 'host_count': 2},
+    ]
 
 
 def test_merge_unions_host_names():
@@ -271,7 +275,7 @@ def test_merge_with_none_data_all():
 
 
 def test_base_strips_pii():
-    """base() output does not contain host_names, organization_name, or by_organization."""
+    """base() output does not contain host_names, organization_name, or by_organizations."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
@@ -283,12 +287,12 @@ def test_base_strips_pii():
                 'host_count': 2,
             },
         },
-        'by_organization': {
-            'OrgA': {'host_names': ['host1', 'host2'], 'host_count': 2},
-        },
-        'by_collection': {
-            'cisco.ios': {'host_names': ['host1', 'host2'], 'host_count': 2},
-        },
+        'by_organizations': [
+            {'organization_name': 'OrgA', 'host_count': 2},
+        ],
+        'by_collections': [
+            {'collection_name': 'cisco.ios', 'host_count': 2},
+        ],
         'indirect_nodes_total': 2,
     }
 
@@ -296,7 +300,7 @@ def test_base_strips_pii():
 
     assert 'json' in result
     output = result['json']
-    assert 'by_organization' not in output
+    assert 'by_organizations' not in output
     assert 'groups' not in output
     assert 'host_names' not in output
     for group in output['by_collection']:

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
     IndirectManagedNodesAnonymizedRollup,
+    _extract_collection_names,
 )
 
 
@@ -291,6 +292,92 @@ def test_base_handles_none():
     result = rollup.base(None)
 
     assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+
+
+def test_extract_collection_names_with_nan():
+    """_extract_collection_names returns empty set for NaN (float) input."""
+    assert _extract_collection_names(float('nan')) == set()
+
+
+def test_extract_collection_names_with_invalid_json():
+    """_extract_collection_names returns empty set for malformed JSON."""
+    assert _extract_collection_names('not valid json') == set()
+
+
+def test_extract_collection_names_with_unsupported_type():
+    """_extract_collection_names returns empty set for unsupported types."""
+    assert _extract_collection_names(42) == set()
+
+
+def test_extract_collection_names_skips_non_fqcn():
+    """_extract_collection_names skips entries that are not valid FQCNs."""
+    result = _extract_collection_names('["cisco.ios.ios_command", "builtin_module"]')
+    assert result == {'cisco.ios'}
+
+
+def test_prepare_skips_nan_host_name():
+    """prepare() skips rows where host_name is NaN."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+    data.loc[len(data)] = {
+        'id': 99,
+        'host_name': float('nan'),
+        'host_remote_id': None,
+        'organization_name': 'OrgA',
+        'events': '["cisco.ios.ios_config"]',
+    }
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert len(result['groups']) == 1
+
+
+def test_prepare_defaults_missing_organization_name():
+    """prepare() defaults to empty string when organization_name is missing."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        [
+            {
+                'id': 1,
+                'host_name': 'host1',
+                'host_remote_id': None,
+                'events': '["cisco.ios.ios_command"]',
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert '||cisco.ios' in result['groups']
+
+
+def test_merge_with_none_data_new():
+    """merge(data_all, None) returns data_all unchanged."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.merge(data_all, None)
+
+    assert result == data_all
 
 
 def test_rollup_name():

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,5 +1,9 @@
--- Snapshot test data: 4 records, host_ids 1, 2, 2, 3.
--- prepare() deduplicates to 3 unique hosts (host_ids 1, 2, 3).
+-- Daily collection test data: 4 records across 2 jobs, host_ids 1, 2, 2, 3.
+-- prepare() groups by (organization_name, collection_name) and deduplicates host_names.
+-- Expected groups:
+--   cisco.ios: cisco-switch-01, cisco-switch-02, cisco-switch-03 = 3 unique hosts
+--   azure.azcollection: cisco-switch-02, cisco-switch-03 = 2 unique hosts
+-- Total unique hosts across all groups: 3
 -- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
@@ -9,7 +13,7 @@ SELECT
     'cisco-switch-01',
     '{"fqdn": "cisco-switch-01.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["cisco.ios.ios_command", "cisco.ios.ios_config"]'::jsonb,
     3,
     1,
     NULL,
@@ -28,7 +32,7 @@ SELECT
     'cisco-switch-02',
     '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["azure.azcollection.azure_rm_storageaccount"]'::jsonb,
     5,
     2,
     NULL,
@@ -48,7 +52,7 @@ SELECT
     'cisco-switch-02',
     '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["cisco.ios.ios_command"]'::jsonb,
     2,
     2,
     NULL,
@@ -67,7 +71,7 @@ SELECT
     'cisco-switch-03',
     '{"fqdn": "cisco-switch-03.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["azure.azcollection.azure_rm_virtualmachine", "cisco.ios.ios_facts"]'::jsonb,
     1,
     3,
     NULL,


### PR DESCRIPTION
# feat(indirect-nodes): convert collector to daily slicing with collection grouping

## Description

- What is being changed?
  The `main_indirectmanagednodeaudit` collector is converted from a snapshot collector
  (full-table scan, no time filter) to a daily collector filtered by `main_unifiedjob.finished`.
  The anonymized rollup processor is rewritten to group indirect managed nodes by
  Ansible collection name, counting unique hosts per collection.

- Why is this change needed?
  AWX deletes `IndirectManagedNodeAudit` records after a configurable retention period
  (default 7 days). The snapshot approach produces inconsistent results across customers
  with different retention settings and causes double-counting when summing daily totals.
  Filtering by `job.finished` aligns the collector with calendar-day boundaries and
  eliminates these issues.

- How does this change address the issue?
  - Adds `since`/`until` parameters to the collector and uses `date_where()` to filter
    by `main_unifiedjob.finished`, matching the pattern used by other daily collectors.
  - Changes the registration from `until_slicing` to `daily_slicing` and bumps the
    version to `2.0`.
  - Rewrites the rollup's `prepare()` to parse the `events` JSON column, extract
    Ansible collection names via `extract_collection_name()`, and group by
    `(organization_name, collection_name)` with unique `host_name` counts per group.
    Organization-level grouping is preserved in intermediate data for on-prem accuracy.
  - Rewrites `merge()` to union host name sets across batches.
  - Rewrites `base()` to strip all PII before the anonymized output leaves the
    customer's environment: `host_names` are removed, and `organization_name` is
    stripped by collapsing org-level groups into collection-level totals with
    re-deduplication of hosts across orgs.
  - Adds `indirect_nodes_by_collection` to the flattened anonymized report output.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Python 3.12 with project dependencies installed (`pip install -e .`)

### Steps to Test

1. Run collector unit tests:
   `pytest metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py -v`
2. Run rollup unit tests:
   `pytest metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py -v`
3. Run integration test (requires running AWX database):
   `pytest metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py -v`

### Expected Results

- All tests pass