### PR TITLE
[AAP-78076] test(indirect-nodes): add OperationalError propagation test

### DIFF
--- a/metrics_utility/test/test_collectors.py
+++ b/metrics_utility/test/test_collectors.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, Mock, patch
 
-from django.db.utils import ProgrammingError
+import pytest
+
+from django.db.utils import OperationalError, ProgrammingError
 
 from metrics_utility.automation_controller_billing.collectors import (
     cli_main_indirectmanagednodeaudit,
@@ -114,3 +116,27 @@ class TestMainIndirectManagedNodeAuditTable:
             ' Falling back to behavior without indirect managed node audit data.',
             specific_error,
         )
+
+    @patch('metrics_utility.automation_controller_billing.collectors.main_indirectmanagednodeaudit')
+    @patch('metrics_utility.automation_controller_billing.collectors.get_optional_collectors')
+    @patch('metrics_utility.automation_controller_billing.collectors.connection')
+    def test_main_indirectmanagednodeaudit_operational_error_propagates(
+        self,
+        mock_connection,
+        mock_get_optional_collectors,
+        mock_main_indirectmanagednodeaudit,
+    ):
+        """OperationalError (e.g. connection refused) is not caught and propagates up.
+
+        This is distinct from ProgrammingError (missing table), which is caught and logged.
+        """
+        mock_get_optional_collectors.return_value = {'main_indirectmanagednodeaudit'}
+        mock_main_indirectmanagednodeaudit.side_effect = OperationalError('connection refused')
+
+        since = Mock()
+        since.isoformat.return_value = '2024-01-01T00:00:00'
+        until = Mock()
+        until.isoformat.return_value = '2024-01-02T00:00:00'
+
+        with pytest.raises(OperationalError):
+            cli_main_indirectmanagednodeaudit(since=since, until=until, output=None)


### PR DESCRIPTION
[AAP-78076]

## Description

Adds a missing negative case from the AAP-78076 test plan: verifying that an `OperationalError`
(e.g. DB connection refused) raised by the `main_indirectmanagednodeaudit` collector is not
caught by `cli_main_indirectmanagednodeaudit` and propagates up to the caller, as distinct from
`ProgrammingError` (missing table) which is intentionally caught and logged as a warning.

## Testing

### Prerequisites

- Postgres running with seed data imported:
  ```
  cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags,main_indirectmanagednodeaudit}.sql | psql
  ```

### Steps to Test

```
uv run pytest -s -v metrics_utility/test/test_collectors.py
```

### Expected Results

All 5 tests in `test_collectors.py` pass.

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.