### PR TITLE
Feature/perf test indirect nodes

### DIFF
--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,20 +1,26 @@
 """Collector for indirect managed node audit records from the Controller database."""
 
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
-    """Collect all indirect managed node audit records (full-table snapshot).
+def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
+    """Collect indirect managed node audit records.
+
+    When since and until are omitted the query returns all records (full-table
+    snapshot). Pass since/until to restrict results to a specific time window
+    based on the related job's finished timestamp.
 
     Args:
         db: Django database connection.
+        since: Optional inclusive start datetime for the job ``finished`` filter.
+        until: Optional exclusive end datetime for the job ``finished`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:
         pandas DataFrame with indirect node audit fields, or list of CSV paths.
     """
-    query = """
+    query = f"""
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -40,6 +46,8 @@ def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
+        WHERE
+            {date_where('main_unifiedjob.finished', since, until)}
     """
 
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,22 +1,20 @@
 """Collector for indirect managed node audit records from the Controller database."""
 
-from ..util import DataframeOutput, collector, date_where
+from ..util import DataframeOutput, collector
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
-    """Collect indirect managed node audit records for jobs finished in the time window.
+def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
+    """Collect all indirect managed node audit records (full-table snapshot).
 
     Args:
         db: Django database connection.
-        since: Inclusive start datetime for the job ``finished`` filter.
-        until: Exclusive end datetime for the job ``finished`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:
         pandas DataFrame with indirect node audit fields, or list of CSV paths.
     """
-    query = f"""
+    query = """
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -42,8 +40,6 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=Dat
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
-        WHERE
-            {date_where('main_unifiedjob.finished', since, until)}
     """
 
     return output.sql(db, query)

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -14,13 +14,11 @@ def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
-    assert instance.kwargs['since'] == SINCE
-    assert instance.kwargs['until'] == UNTIL
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -29,7 +27,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -41,12 +39,12 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
-    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
+def test_main_indirectmanagednodeaudit_query_columns_and_joins(mock_copy_pandas):
+    """Test that the SQL query selects all expected columns and joins."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -63,18 +61,14 @@ def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
     assert 'events' in query
     assert 'task_runs' in query
 
-    assert 'main_unifiedjob.finished' in query
-    assert '>=' in query
-    assert '<' in query
-
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas):
-    """Test that passing since=None, until=None produces WHERE true (no filtering)."""
+    """Test that omitting since/until produces WHERE true (full-table scan)."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=None, until=None)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -82,6 +76,23 @@ def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas
 
     assert 'WHERE' in query
     assert 'true' in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
+    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance.gather()
+
+    call_args = mock_copy_pandas.call_args
+    query = call_args[0][1]
+
+    assert 'main_unifiedjob.finished' in query
+    assert '>=' in query
+    assert '<' in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -114,7 +125,7 @@ def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)
@@ -155,7 +166,7 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -145,6 +145,7 @@ def fill_perf_db_data(
         inventory_id=init_data['inventory_id'],
         org_id=init_data['org_id'],
         indirect_count=indirect_count,
+        unique_suffix=init_data['unique_suffix'],
     )
 
     print_counts()

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -11,6 +11,7 @@ from helpers import (
     create_credentials,
     create_execution_environments,
     create_hosts,
+    create_indirect_managed_node_audits,
     create_instance,
     create_inventory,
     create_job,
@@ -36,10 +37,13 @@ def print_counts():
     jhs_count = result[0][0] if result else 0
     result = run('SELECT COUNT(*) FROM main_jobevent;')
     event_count = result[0][0] if result else 0
+    result = run('SELECT COUNT(*) FROM main_indirectmanagednodeaudit;')
+    indirect_count = result[0][0] if result else 0
     print(f'Total hosts: {host_count}')
     print(f'Total jobs: {job_count}')
     print(f'Total job host summaries: {jhs_count}')
     print(f'Total job events: {event_count}')
+    print(f'Total indirect managed node audit records: {indirect_count}')
 
 
 def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffix=None):
@@ -104,7 +108,9 @@ def fill_init_data(host_count=10, task_count=50, template_count=10, unique_suffi
     }
 
 
-def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=10, start_date=None, end_date=None, no_events=False):
+def fill_perf_db_data(
+    host_count=10, job_count=5, task_count=50, template_count=10, start_date=None, end_date=None, no_events=False, indirect_count=100
+):
     """Fill the database with performance test data.
 
     Note: This function does NOT clean existing data. Use clean_all_data.py to clean before filling.
@@ -117,15 +123,29 @@ def fill_perf_db_data(host_count=10, job_count=5, task_count=50, template_count=
         start_date: Start of the date range for job timestamps
         end_date: End of the date range for job timestamps
         no_events: Skip generating job events entirely
+        indirect_count: Number of indirect managed node audit records to create
     """
-    print(f'=== Configuration: {host_count} hosts, {job_count} jobs, {task_count} tasks/job, {template_count} templates ===')
+    print(
+        f'=== Configuration: {host_count} hosts, {job_count} jobs, {task_count} tasks/job, '
+        f'{template_count} templates, {indirect_count} indirect nodes ==='
+    )
 
     create_jobevent_partitions(start_date, end_date)
 
     init_data = fill_init_data(host_count=host_count, task_count=task_count, template_count=template_count)
 
+    job_ids = []
     for i in range(job_count):
-        fill_job(init_data, i, start_date, end_date, no_events=no_events)
+        job_id = fill_job(init_data, i, start_date, end_date, no_events=no_events)
+        job_ids.append(job_id)
+
+    create_indirect_managed_node_audits(
+        job_ids=job_ids,
+        host_ids=init_data['host_ids'],
+        inventory_id=init_data['inventory_id'],
+        org_id=init_data['org_id'],
+        indirect_count=indirect_count,
+    )
 
     print_counts()
 
@@ -169,7 +189,7 @@ def fill_job(init_data, job_index, start_date, end_date, no_events=False):
     create_job_credentials(job_id, init_data['credential_ids'])
     if not no_events:
         fill_jobevent(init_data, job_id, job_index, job_created)
-    return
+    return job_id
 
 
 if __name__ == '__main__':
@@ -220,6 +240,7 @@ if __name__ == '__main__':
         help='End of the datetime range for job timestamps (e.g. "2024-01-02" or "2024-01-01 06:00:00"). Default: 2024-01-31 23:59:59',
     )
     parser.add_argument('--no-events', action='store_true', default=False, help='Skip generating job events')
+    parser.add_argument('--indirect-count', type=int, default=100, help='Number of indirect managed node audit records to create (default: 100)')
 
     args = parser.parse_args()
 
@@ -245,4 +266,5 @@ if __name__ == '__main__':
         start_date=start_date,
         end_date=end_date,
         no_events=args.no_events,
+        indirect_count=args.indirect_count,
     )

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -1305,7 +1305,7 @@ def create_instance(version='4.5.0', node_type='control'):
     return instance_id
 
 
-def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id, indirect_count=100):
+def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id, indirect_count=100, unique_suffix=None):
     """Create indirect managed node audit records spread across the given jobs.
 
     Args:
@@ -1314,34 +1314,39 @@ def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id,
         inventory_id: Inventory ID for all records
         org_id: Organization ID for all records
         indirect_count: Total number of audit records to create
+        unique_suffix: Optional suffix embedded in host names to avoid collisions across runs
     """
     if not job_ids:
         print('No job IDs provided; skipping indirect managed node audit creation.')
         return []
 
+    suffix = f'-{unique_suffix}' if unique_suffix else ''
     print(f'Creating {indirect_count} indirect managed node audit records across {len(job_ids)} jobs...')
 
     values = []
     for i in range(indirect_count):
         job_id = job_ids[i % len(job_ids)]
-        host_id = host_ids[i % len(host_ids)] if host_ids else 'NULL'
-        host_id_sql = str(host_id) if host_ids else 'NULL'
-        host_name = f'indirect-host-{i}.example.com'
+        host_id_sql = str(host_ids[i % len(host_ids)]) if host_ids else 'NULL'
+        host_name = f'indirect-host-{i}{suffix}.example.com'
         canonical_facts = json.dumps({'fqdn': host_name}).replace("'", "''")
         values.append(
             f'(NOW(), NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '
             f"'{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '[]'::jsonb, 1)"
         )
 
-    sql = f"""
+    _INSERT_BATCH_SIZE = 500
+    insert_sql = """
     INSERT INTO main_indirectmanagednodeaudit
         (created, modified, job_id, organization_id, inventory_id, host_id,
          name, canonical_facts, facts, events, count)
-    VALUES {','.join(values)}
+    VALUES {rows}
     RETURNING id;
     """
-    output = run(sql)
-    ids = parse_ids(output) if output else []
+    ids = []
+    for batch_start in range(0, len(values), _INSERT_BATCH_SIZE):
+        batch = values[batch_start : batch_start + _INSERT_BATCH_SIZE]
+        output = run(insert_sql.format(rows=','.join(batch)))
+        ids.extend(parse_ids(output) if output else [])
     print(f'Created {len(ids)} indirect managed node audit records')
     return ids
 

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -496,6 +496,15 @@ def run(sql_script):
 # =============================================================================
 
 
+def delete_indirect_managed_node_audits():
+    """Delete all indirect managed node audit records."""
+    sql = """
+    DELETE FROM main_indirectmanagednodeaudit;
+    """
+    print('Deleting main_indirectmanagednodeaudit...')
+    return run(sql)
+
+
 def delete_job_events():
     """Delete all job events."""
     sql = """
@@ -636,7 +645,7 @@ def delete_all():
     """
     Delete all data from tables in correct order (respecting foreign key constraints).
 
-    Order: job_events -> job_host_summaries -> jobs ->
+    Order: indirect_managed_node_audits -> job_events -> job_host_summaries -> jobs ->
            unified_job_credentials (many-to-many) -> unified_jobs ->
            unified_job_template_credentials (many-to-many) ->
            job_templates -> projects -> unified_job_templates ->
@@ -645,6 +654,7 @@ def delete_all():
     """
     print('=== Deleting all performance test data ===')
 
+    delete_indirect_managed_node_audits()
     delete_job_events()
     delete_job_host_summaries()
     delete_jobs()
@@ -1293,6 +1303,47 @@ def create_instance(version='4.5.0', node_type='control'):
     if instance_id is None:
         raise RuntimeError('Failed to create main_instance row')
     return instance_id
+
+
+def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id, indirect_count=100):
+    """Create indirect managed node audit records spread across the given jobs.
+
+    Args:
+        job_ids: List of job IDs to distribute records across
+        host_ids: List of host IDs to reference (cycling, nullable)
+        inventory_id: Inventory ID for all records
+        org_id: Organization ID for all records
+        indirect_count: Total number of audit records to create
+    """
+    if not job_ids:
+        print('No job IDs provided; skipping indirect managed node audit creation.')
+        return []
+
+    print(f'Creating {indirect_count} indirect managed node audit records across {len(job_ids)} jobs...')
+
+    values = []
+    for i in range(indirect_count):
+        job_id = job_ids[i % len(job_ids)]
+        host_id = host_ids[i % len(host_ids)] if host_ids else 'NULL'
+        host_id_sql = str(host_id) if host_ids else 'NULL'
+        host_name = f'indirect-host-{i}.example.com'
+        canonical_facts = json.dumps({'fqdn': host_name}).replace("'", "''")
+        values.append(
+            f'(NOW(), NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '
+            f"'{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '[]'::jsonb, 1)"
+        )
+
+    sql = f"""
+    INSERT INTO main_indirectmanagednodeaudit
+        (created, modified, job_id, organization_id, inventory_id, host_id,
+         name, canonical_facts, facts, events, count)
+    VALUES {','.join(values)}
+    RETURNING id;
+    """
+    output = run(sql)
+    ids = parse_ids(output) if output else []
+    print(f'Created {len(ids)} indirect managed node audit records')
+    return ids
 
 
 if __name__ == '__main__':

--- a/tools/anonymized_db_perf_data/rollup_performance_test.py
+++ b/tools/anonymized_db_perf_data/rollup_performance_test.py
@@ -33,6 +33,7 @@ from django.db import connection  # noqa: E402
 from metrics_utility.library.collectors.controller import (  # noqa: E402
     execution_environments,
     job_host_summary_service,
+    main_indirectmanagednodeaudit,
     main_jobevent_service,
     unified_jobs,
 )
@@ -150,6 +151,12 @@ def main():
         all_metrics.append(metrics)
         collector_data['main_jobevent_service'] = data
 
+    # Test main_indirectmanagednodeaudit
+    metrics, data = run_task('main_indirectmanagednodeaudit', lambda: main_indirectmanagednodeaudit(db=connection).gather())
+    if metrics:
+        all_metrics.append(metrics)
+        collector_data['main_indirectmanagednodeaudit'] = data
+
     # Test rollup computation
     print('\n' + '=' * 60)
     print('PHASE 2: Testing Rollup Computation')
@@ -177,6 +184,8 @@ def main():
     job_count = cursor.fetchone()[0]
     cursor.execute('SELECT COUNT(*) FROM main_jobevent;')
     event_count = cursor.fetchone()[0]
+    cursor.execute('SELECT COUNT(*) FROM main_indirectmanagednodeaudit;')
+    indirect_count = cursor.fetchone()[0]
 
     # Print summary
     print('\n' + '=' * 60)
@@ -222,7 +231,8 @@ def main():
         f.write(f'- **Test Period:** {since.strftime("%Y-%m-%d")} to {until.strftime("%Y-%m-%d")}\n')
         f.write(f'- **Total Jobs:** {job_count:,}\n')
         f.write(f'- **Total Hosts:** {host_count:,}\n')
-        f.write(f'- **Total Events:** {event_count:,}\n\n')
+        f.write(f'- **Total Events:** {event_count:,}\n')
+        f.write(f'- **Total Indirect Node Audit Records:** {indirect_count:,}\n\n')
 
         f.write('## Performance Results\n\n')
         f.write('### Individual Task Performance\n\n')

--- a/tools/anonymized_db_perf_data/rollup_performance_test.py
+++ b/tools/anonymized_db_perf_data/rollup_performance_test.py
@@ -3,7 +3,7 @@
 Test anonymized rollup performance by running each task separately.
 
 Measures time and memory for:
-- Each collector (execution_environments, unified_jobs, job_host_summary, main_jobevent)
+- Each collector (execution_environments, unified_jobs, job_host_summary, main_jobevent, main_indirectmanagednodeaudit)
 - Rollup computation
 
 Usage:
@@ -167,6 +167,7 @@ def main():
         'unified_jobs': collector_data['unified_jobs'],
         'job_host_summary': collector_data['job_host_summary_service'],
         'main_jobevent': collector_data['main_jobevent_service'],
+        'indirect_managed_nodes': collector_data.get('main_indirectmanagednodeaudit', []),
     }
 
     metrics, _ = run_task(

--- a/tools/anonymized_db_perf_data/run_perf.py
+++ b/tools/anonymized_db_perf_data/run_perf.py
@@ -69,10 +69,14 @@ def print_counts():
     cursor.execute('SELECT COUNT(*) FROM main_jobevent;')
     event_count = cursor.fetchone()[0]
 
+    cursor.execute('SELECT COUNT(*) FROM main_indirectmanagednodeaudit;')
+    indirect_count = cursor.fetchone()[0]
+
     print(f'Total hosts: {host_count}')
     print(f'Total jobs: {job_count}')
     print(f'Total job host summaries: {jhs_count}')
     print(f'Total job events: {event_count}')
+    print(f'Total indirect node audit records: {indirect_count}')
     print()
 
 


### PR DESCRIPTION
[AAP-82717]

## Description

- **What is being changed?** Adds performance testing coverage for the `main_indirectmanagednodeaudit` collector in the `tools/anonymized_db_perf_data/` harness. Also converts the collector from a date-filtered query to a full-table snapshot, and updates all callers and tests accordingly.
- **Why is this change needed?** The `main_indirectmanagednodeaudit` collector was recently implemented but had no representation in the perf harness - no data generation, no benchmark timing, and no deletion. Without it, performance regressions in the indirect node query go undetected.
- **How does this change address the issue?** Follows the existing patterns in the harness (batch inserts, unique_suffix for collision avoidance, per-collector timing, DB count reporting) and wires the collector end-to-end through fill, benchmark, and rollup phases.

## Testing

### Steps to Test

1. Run the unit tests:
   ```
   uv run pytest -s -v metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
   ```

2. Run the perf harness end-to-end:
   ```
   cd tools/anonymized_db_perf_data
   python clean_all_data.py --force
   python fill_perf_db_data.py --host-count 100 --job-count 20 --indirect-count 100
   python rollup_performance_test.py
   ```

3. Verify cleanup includes indirect node records:
   ```
   python clean_all_data.py --force
   ```

### Expected Results

- All 6 unit tests in `test_collectors_main_indirectmanagednodeaudit.py` pass
- `fill_perf_db_data.py` reports `Total indirect managed node audit records: 100`
- `rollup_performance_test.py` Phase 1 includes a `main_indirectmanagednodeaudit` timing row
- Phase 2 rollup computation runs without error and includes indirect node data
- After `clean_all_data.py`, `SELECT COUNT(*) FROM main_indirectmanagednodeaudit;` returns 0

## Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [x] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.