### PR TITLE
Remove unused by_organizations and by_collections fields from indirect node rollup

### DIFF
--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -52,17 +52,6 @@ def _make_group_key(organization_name, collection_name):
     return f'{organization_name}{GROUP_KEY_SEPARATOR}{collection_name}'
 
 
-def _aggregate_by_key(groups, key_field):
-    """Aggregate host names across groups by a single field (org or collection)."""
-    aggregated = {}
-    for group in groups.values():
-        key = group[key_field]
-        if key not in aggregated:
-            aggregated[key] = set()
-        aggregated[key].update(group.get('host_names', []))
-    return {k: {'host_names': sorted(v), 'host_count': len(v)} for k, v in sorted(aggregated.items())}
-
-
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
     """Rollup processor for main_indirectmanagednodeaudit collector data.
 
@@ -87,7 +76,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
+            return {'groups': {}, 'indirect_nodes_total': 0}
 
         groups = {}
         all_host_names = set()
@@ -120,17 +109,9 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
-        agg_by_org = _aggregate_by_key(groups, 'organization_name')
-        agg_by_coll = _aggregate_by_key(groups, 'collection_name')
-
-        by_organizations = [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()]
-        by_collections = [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()]
-
         return sanitize_json(
             {
                 'groups': groups,
-                'by_organizations': by_organizations,
-                'by_collections': by_collections,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -209,12 +190,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_count'] = len(group['host_names'])
             all_host_names.update(group['host_names'])
 
-        agg_by_org = _aggregate_by_key(merged_groups, 'organization_name')
-        agg_by_coll = _aggregate_by_key(merged_groups, 'collection_name')
-
         return {
             'groups': merged_groups,
-            'by_organizations': [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()],
-            'by_collections': [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()],
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -54,7 +54,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -137,87 +137,6 @@ def test_prepare_handles_events_as_list():
     assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
 
 
-def test_prepare_by_organizations_summary():
-    """prepare() includes by_organizations list with deduplicated host counts."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = _make_dataframe(
-        [
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
-            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
-        ]
-    )
-
-    result = rollup.prepare(data)
-
-    by_orgs = result['by_organizations']
-    assert by_orgs == [
-        {'organization_name': 'OrgA', 'host_count': 1},
-        {'organization_name': 'OrgB', 'host_count': 1},
-    ]
-
-
-def test_prepare_by_collections_summary():
-    """prepare() includes by_collections list with deduplicated host counts."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = _make_dataframe(
-        [
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
-            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
-            {'host_name': 'host3', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
-        ]
-    )
-
-    result = rollup.prepare(data)
-
-    by_colls = result['by_collections']
-    assert by_colls == [
-        {'collection_name': 'azure.azcollection', 'host_count': 1},
-        {'collection_name': 'cisco.ios', 'host_count': 2},
-    ]
-
-
-def test_merge_includes_by_organizations_and_by_collections():
-    """merge() result includes by_organizations and by_collections summaries."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data_all = {
-        'groups': {
-            'OrgA||cisco.ios': {
-                'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
-                'host_names': ['host1'],
-                'host_count': 1,
-            },
-        },
-        'indirect_nodes_total': 1,
-    }
-
-    data_new = {
-        'groups': {
-            'OrgB||cisco.ios': {
-                'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
-                'host_names': ['host2'],
-                'host_count': 1,
-            },
-        },
-        'indirect_nodes_total': 1,
-    }
-
-    result = rollup.merge(data_all, data_new)
-
-    assert result['by_organizations'] == [
-        {'organization_name': 'OrgA', 'host_count': 1},
-        {'organization_name': 'OrgB', 'host_count': 1},
-    ]
-    assert result['by_collections'] == [
-        {'collection_name': 'cisco.ios', 'host_count': 2},
-    ]
-
-
 def test_merge_unions_host_names():
     """merge() unions host name sets across two batches."""
     rollup = IndirectManagedNodesAnonymizedRollup()
@@ -275,7 +194,7 @@ def test_merge_with_none_data_all():
 
 
 def test_base_strips_pii():
-    """base() output does not contain host_names, organization_name, or by_organizations."""
+    """base() output does not contain host_names or organization_name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
@@ -287,12 +206,6 @@ def test_base_strips_pii():
                 'host_count': 2,
             },
         },
-        'by_organizations': [
-            {'organization_name': 'OrgA', 'host_count': 2},
-        ],
-        'by_collections': [
-            {'collection_name': 'cisco.ios', 'host_count': 2},
-        ],
         'indirect_nodes_total': 2,
     }
 
@@ -300,7 +213,6 @@ def test_base_strips_pii():
 
     assert 'json' in result
     output = result['json']
-    assert 'by_organizations' not in output
     assert 'groups' not in output
     assert 'host_names' not in output
     for group in output['by_collection']:


### PR DESCRIPTION
prepare() and merge() were computing two midway aggregations (by_organizations and by_collections) that base() never reads. It rebuilds its own collection summary directly from groups. The _aggregate_by_key helper existed solely to produce these fields.

This removes the dead fields, the helper, and the three tests that covered only the removed behaviour.