### PR TITLE
[AAP-83031] add module-level breakdown to indirect nodes anonymized payload

### DIFF
--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -538,6 +538,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
         'indirect_nodes_by_collection': indirect_managed_nodes_root.get('by_collection', []),
+        'indirect_nodes_by_module': indirect_managed_nodes_root.get('by_module', []),
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -30,7 +30,8 @@ def _parse_events(events_value):
         return []
     if isinstance(events_value, str):
         try:
-            return json.loads(events_value)
+            parsed = json.loads(events_value)
+            return parsed if isinstance(parsed, list) else []
         except ValueError:
             return []
     if isinstance(events_value, list):

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -14,6 +14,30 @@ from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_co
 GROUP_KEY_SEPARATOR = '||'
 
 
+def _parse_events(events_value):
+    """Parse the events JSON column into a list of FQCNs.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        List of FQCN strings, or empty list if unparseable.
+    """
+    if events_value is None:
+        return []
+    if isinstance(events_value, float):
+        return []
+    if isinstance(events_value, str):
+        try:
+            return json.loads(events_value)
+        except ValueError:
+            return []
+    if isinstance(events_value, list):
+        return events_value
+    return []
+
+
 def _extract_collection_names(events_value):
     """Parse the events JSON column and return a set of collection names.
 
@@ -24,28 +48,31 @@ def _extract_collection_names(events_value):
     Returns:
         Set of two-part collection name strings (e.g. ``{"azure.azcollection"}``).
     """
-    if events_value is None:
-        return set()
-
-    if isinstance(events_value, float):
-        return set()
-
-    if isinstance(events_value, str):
-        try:
-            events_list = json.loads(events_value)
-        except ValueError:
-            return set()
-    elif isinstance(events_value, list):
-        events_list = events_value
-    else:
-        return set()
-
     collections = set()
-    for fqcn in events_list:
+    for fqcn in _parse_events(events_value):
         name = DataframeContentUsage.extract_collection_name(fqcn)
         if name is not None:
             collections.add(name)
     return collections
+
+
+def _extract_module_names(events_value):
+    """Parse the events JSON column and return a set of full FQCNs (module names).
+
+    Only FQCNs with a valid namespace.collection prefix are included.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        Set of full FQCN strings (e.g. ``{"azure.azcollection.azure_rm_vm"}``).
+    """
+    modules = set()
+    for fqcn in _parse_events(events_value):
+        if DataframeContentUsage.extract_collection_name(fqcn) is not None:
+            modules.add(fqcn)
+    return modules
 
 
 def _make_group_key(organization_name, collection_name):
@@ -76,9 +103,10 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'indirect_nodes_total': 0}
+            return {'groups': {}, 'module_groups': {}, 'indirect_nodes_total': 0}
 
         groups = {}
+        module_groups = {}
         all_host_names = set()
 
         for _, row in dataframe.iterrows():
@@ -90,8 +118,9 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             org_name = str(row.get('organization_name', ''))
             all_host_names.add(host_name)
 
-            collection_names = _extract_collection_names(row.get('events'))
+            events = row.get('events')
 
+            collection_names = _extract_collection_names(events)
             if not collection_names:
                 collection_names = {'_no_collection'}
 
@@ -105,13 +134,32 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                     }
                 groups[key]['host_names'].add(host_name)
 
+            module_names = _extract_module_names(events)
+            if not module_names:
+                module_names = {'_no_module'}
+
+            for module_name in module_names:
+                key = _make_group_key(org_name, module_name)
+                if key not in module_groups:
+                    module_groups[key] = {
+                        'organization_name': org_name,
+                        'module_name': module_name,
+                        'host_names': set(),
+                    }
+                module_groups[key]['host_names'].add(host_name)
+
         for group in groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+
+        for group in module_groups.values():
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
         return sanitize_json(
             {
                 'groups': groups,
+                'module_groups': module_groups,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -131,7 +179,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             Dict with 'json' key containing the final rollup data.
         """
         if data is None:
-            return {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+            return {'json': {'indirect_nodes_total': 0, 'by_collection': [], 'by_module': []}}
 
         collection_hosts = {}
         for group in data.get('groups', {}).values():
@@ -143,10 +191,21 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
 
+        module_hosts = {}
+        for group in data.get('module_groups', {}).values():
+            mname = group['module_name']
+            hosts = group.get('host_names', [])
+            if mname not in module_hosts:
+                module_hosts[mname] = set()
+            module_hosts[mname].update(hosts)
+
+        by_module = [{'module_name': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
+
         return {
             'json': {
                 'indirect_nodes_total': data.get('indirect_nodes_total', 0),
                 'by_collection': by_collection,
+                'by_module': by_module,
             }
         }
 
@@ -184,13 +243,37 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                     'host_names': set(group.get('host_names', [])),
                 }
 
+        merged_module_groups = {}
+
+        for key, group in data_all.get('module_groups', {}).items():
+            merged_module_groups[key] = {
+                'organization_name': group['organization_name'],
+                'module_name': group['module_name'],
+                'host_names': set(group.get('host_names', [])),
+            }
+
+        for key, group in data_new.get('module_groups', {}).items():
+            if key in merged_module_groups:
+                merged_module_groups[key]['host_names'].update(group.get('host_names', []))
+            else:
+                merged_module_groups[key] = {
+                    'organization_name': group['organization_name'],
+                    'module_name': group['module_name'],
+                    'host_names': set(group.get('host_names', [])),
+                }
+
         all_host_names = set()
         for group in merged_groups.values():
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
             all_host_names.update(group['host_names'])
 
+        for group in merged_module_groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+
         return {
             'groups': merged_groups,
+            'module_groups': merged_module_groups,
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -58,6 +58,7 @@ def _validate_top_level_structure(json_data):
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
     assert 'indirect_nodes_by_collection' in json_data, "Missing 'indirect_nodes_by_collection' at top level"
+    assert 'indirect_nodes_by_module' in json_data, "Missing 'indirect_nodes_by_module' at top level"
     assert 'indirect_managed_nodes' not in json_data, 'indirect_managed_nodes raw data must not appear at the top level'
 
 
@@ -868,6 +869,15 @@ def _validate_indirect_managed_nodes(json_data, statistics):
         assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
         assert 'collection_name' in group
         assert 'host_count' in group
+
+    by_m = json_data.get('indirect_nodes_by_module', [])
+    assert isinstance(by_m, list), 'indirect_nodes_by_module should be a list'
+
+    for entry in by_m:
+        assert 'host_names' not in entry, 'host_names must not appear in anonymized output (privacy)'
+        assert 'organization_name' not in entry, 'organization_name must not appear in anonymized output (privacy)'
+        assert 'module_name' in entry
+        assert 'host_count' in entry
 
 
 def _validate_all_data(json_data, statistics):

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -421,6 +421,20 @@ def test_extract_module_names_with_invalid_json():
     assert _extract_module_names('not valid json') == set()
 
 
+def test_extract_collection_names_with_non_list_json():
+    """_extract_collection_names returns empty set when JSON decodes to a non-list (null, number, object)."""
+    assert _extract_collection_names('null') == set()
+    assert _extract_collection_names('42') == set()
+    assert _extract_collection_names('{}') == set()
+
+
+def test_extract_module_names_with_non_list_json():
+    """_extract_module_names returns empty set when JSON decodes to a non-list (null, number, object)."""
+    assert _extract_module_names('null') == set()
+    assert _extract_module_names('42') == set()
+    assert _extract_module_names('{}') == set()
+
+
 def test_prepare_groups_by_module():
     """prepare() populates module_groups keyed by org and full FQCN."""
     rollup = IndirectManagedNodesAnonymizedRollup()

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -5,6 +5,7 @@ import pandas as pd
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
     IndirectManagedNodesAnonymizedRollup,
     _extract_collection_names,
+    _extract_module_names,
 )
 
 
@@ -54,7 +55,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'module_groups': {}, 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -294,7 +295,7 @@ def test_base_handles_none():
 
     result = rollup.base(None)
 
-    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': [], 'by_module': []}}
 
 
 def test_extract_collection_names_with_nan():
@@ -393,3 +394,268 @@ def test_collector_names():
     """collector_names is set correctly."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.collector_names == ['main_indirectmanagednodeaudit']
+
+
+# --- module-level tests ---
+
+
+def test_extract_module_names_returns_full_fqcn():
+    """_extract_module_names returns the full FQCN, not just the collection prefix."""
+    result = _extract_module_names('["cisco.ios.ios_command", "azure.azcollection.azure_rm_vm"]')
+    assert result == {'cisco.ios.ios_command', 'azure.azcollection.azure_rm_vm'}
+
+
+def test_extract_module_names_skips_non_fqcn():
+    """_extract_module_names skips entries without a valid namespace.collection prefix."""
+    result = _extract_module_names('["cisco.ios.ios_command", "builtin_module"]')
+    assert result == {'cisco.ios.ios_command'}
+
+
+def test_extract_module_names_with_nan():
+    """_extract_module_names returns empty set for NaN input."""
+    assert _extract_module_names(float('nan')) == set()
+
+
+def test_extract_module_names_with_invalid_json():
+    """_extract_module_names returns empty set for malformed JSON."""
+    assert _extract_module_names('not valid json') == set()
+
+
+def test_prepare_groups_by_module():
+    """prepare() populates module_groups keyed by org and full FQCN."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_config"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    module_groups = result['module_groups']
+    assert 'OrgA||cisco.ios.ios_command' in module_groups
+    assert 'OrgA||cisco.ios.ios_config' in module_groups
+    assert 'OrgB||cisco.ios.ios_command' in module_groups
+    assert module_groups['OrgA||cisco.ios.ios_command']['host_count'] == 1
+    assert module_groups['OrgA||cisco.ios.ios_config']['host_count'] == 1
+    assert module_groups['OrgB||cisco.ios.ios_command']['host_count'] == 1
+
+
+def test_prepare_deduplicates_hosts_within_module_group():
+    """prepare() deduplicates hosts within the same module group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['module_groups']['OrgA||cisco.ios.ios_command']['host_count'] == 1
+    assert result['module_groups']['OrgA||cisco.ios.ios_command']['host_names'] == ['host1']
+
+
+def test_prepare_host_appears_in_multiple_module_groups():
+    """A host touched by multiple modules appears in each module group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': json.dumps(['azure.azcollection.azure_rm_vm', 'azure.azcollection.azure_rm_network_interface']),
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert 'OrgA||azure.azcollection.azure_rm_vm' in result['module_groups']
+    assert 'OrgA||azure.azcollection.azure_rm_network_interface' in result['module_groups']
+    assert result['module_groups']['OrgA||azure.azcollection.azure_rm_vm']['host_count'] == 1
+    assert result['module_groups']['OrgA||azure.azcollection.azure_rm_network_interface']['host_count'] == 1
+
+
+def test_prepare_no_events_uses_no_module_fallback():
+    """prepare() buckets hosts with no events under _no_module in module_groups."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '[]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert 'OrgA||_no_module' in result['module_groups']
+    assert result['module_groups']['OrgA||_no_module']['host_count'] == 1
+
+
+def test_merge_unions_module_group_host_names():
+    """merge() unions host name sets in module_groups across two batches."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    data_new = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    merged = result['module_groups']['OrgA||cisco.ios.ios_command']
+    assert merged['host_count'] == 3
+    assert sorted(merged['host_names']) == ['host1', 'host2', 'host3']
+
+
+def test_base_produces_by_module():
+    """base() outputs a by_module list stripped of PII."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgA||cisco.ios.ios_config': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_config',
+                'host_names': ['host3'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    by_module = result['json']['by_module']
+    assert len(by_module) == 2
+    assert by_module[0] == {'module_name': 'cisco.ios.ios_command', 'host_count': 2}
+    assert by_module[1] == {'module_name': 'cisco.ios.ios_config', 'host_count': 1}
+    for entry in by_module:
+        assert 'host_names' not in entry
+        assert 'organization_name' not in entry
+
+
+def test_base_deduplicates_module_hosts_across_orgs():
+    """base() deduplicates hosts under the same module across different orgs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgB||cisco.ios.ios_command': {
+                'organization_name': 'OrgB',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    by_module = result['json']['by_module']
+    assert len(by_module) == 1
+    assert by_module[0]['module_name'] == 'cisco.ios.ios_command'
+    assert by_module[0]['host_count'] == 3
+
+
+def test_base_by_module_sorted_by_module_name():
+    """base() sorts by_module entries by module name."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_config': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_config',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+            'OrgA||azure.azcollection.azure_rm_vm': {
+                'organization_name': 'OrgA',
+                'module_name': 'azure.azcollection.azure_rm_vm',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.base(data)
+
+    names = [e['module_name'] for e in result['json']['by_module']]
+    assert names == sorted(names)
+
+
+def test_base_by_collection_unchanged_with_module_data():
+    """Adding module_groups does not affect by_collection output."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.base(data)
+
+    assert result['json']['by_collection'] == [{'collection_name': 'cisco.ios', 'host_count': 1}]
+    assert result['json']['by_module'] == [{'module_name': 'cisco.ios.ios_command', 'host_count': 1}]


### PR DESCRIPTION
## Description

This PR extends the indirect nodes anonymized rollup to include a per-module breakdown alongside the existing per-collection breakdown.

- **What is being changed?** A new `indirect_nodes_by_module` array is added to the anonymized payload. Each entry contains a `module_name` (full FQCN, e.g. `cisco.ios.ios_command`) and a `host_count`. The existing `indirect_nodes_by_collection` array and `rollup_period_indirect_managed_nodes_all_total` statistic are unchanged.
- **Why is this change needed?** Collection-level data shows which collections are in use but not which specific capabilities customers rely on. Module-level data enables partner engagement, partner retention, and certification prioritization use cases requested by product stakeholders.
- **How does this change address the issue?** The full FQCNs are already present in the `events` column of `main_indirectmanagednodeaudit` and are already fetched by the existing SQL query. The rollup was previously stripping the module portion. This PR adds a parallel `module_groups` structure in `prepare()`, `merge()`, and `base()` that retains the full FQCN. No SQL changes, no collector changes, no scheduling changes.

## Testing

### Prerequisites

No special setup required. All changes are in-memory rollup logic.

### Steps to Test

1. Run the rollup unit tests: `pytest metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py -v`
2. Run the broader anonymized rollup suite: `pytest metrics_utility/test/test_anonymized_rollups/ -v`

### Expected Results

All 34 tests in `test_indirect_managed_nodes_anonymized_rollup.py` pass, including 12 new module-level tests. No regressions in the broader suite.

## Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [x] Requires coordination with other teams
  - Analytics team must be notified of the new `indirect_nodes_by_module` field before promotion. They are already aware of the pipeline via the existing `indirect_nodes_by_collection` work.
- [ ] Blocked by PR/MR: #XXX

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.

## Notes for Reviewers

`indirect_nodes_by_module` host counts can exceed `indirect_nodes_by_collection` counts for the same collection. A host touched by two modules from the same collection appears in both module entries but only once in the collection total. This is expected and consistent with how `by_collection` counts relate to `indirect_nodes_total`.

Module names are public Ansible Galaxy labels and are not customer-identifiable, so no additional anonymization beyond what `base()` already applies is required.