### PR TITLE
fix(perf-tools): fix bugs in anonymized_db_perf_data harness found during live-instance testing

### DIFF
--- a/tools/anonymized_db_perf_data/README.md
+++ b/tools/anonymized_db_perf_data/README.md
@@ -24,3 +24,23 @@ You can see inside out folder anonymized.json with computed results. And also ro
 The fill perf db data can be called multiple times, each time it adds new data.
 
 You can easily run off the disk. For proper large data testing, we need around 50 GB of data (mine laptom dont have so much free space anymore...).
+
+## Running against a remote instance (e.g. Jenkins-provisioned)
+
+When running against a real AAP instance where you want the metrics-service collection pipeline to pick up the generated data, pass explicit recent dates so the hourly collectors find them:
+
+```
+./fill_perf_db_data.py --host-count 1000 --job-count 100 \
+  --since=$(date -d yesterday +%Y-%m-%d) \
+  --until=$(date -d yesterday +%Y-%m-%d)
+```
+
+On macOS use `gdate` (from `brew install coreutils`) instead of `date -d`:
+
+```
+./fill_perf_db_data.py --host-count 1000 --job-count 100 \
+  --since=$(gdate -d yesterday +%Y-%m-%d) \
+  --until=$(gdate -d yesterday +%Y-%m-%d)
+```
+
+Without explicit dates the script defaults to January 2024, which is suitable for isolated benchmarking but will not be collected by the live pipeline.

--- a/tools/anonymized_db_perf_data/fill_perf_db_data.py
+++ b/tools/anonymized_db_perf_data/fill_perf_db_data.py
@@ -224,8 +224,8 @@ if __name__ == '__main__':
     prepare()
 
     parser = argparse.ArgumentParser(description='Fill database with performance test data')
-    parser.add_argument('--host-count', type=int, default=30, help='Number of hosts to create (default: 10)')
-    parser.add_argument('--job-count', type=int, default=20, help='Number of jobs to create (default: 5)')
+    parser.add_argument('--host-count', type=int, default=30, help='Number of hosts to create (default: 30)')
+    parser.add_argument('--job-count', type=int, default=20, help='Number of jobs to create (default: 20)')
     parser.add_argument('--task-count', type=int, default=50, help='Number of tasks per job (default: 50)')
     parser.add_argument('--template-count', type=int, default=10, help='Number of job templates to create (default: 10)')
     parser.add_argument(

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -1330,14 +1330,13 @@ def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id,
         host_name = f'indirect-host-{i}{suffix}.example.com'
         canonical_facts = json.dumps({'fqdn': host_name}).replace("'", "''")
         values.append(
-            f'(NOW(), NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '
-            f"'{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '[]'::jsonb, 1)"
+            f"(NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '[]'::jsonb, 1)"
         )
 
     _INSERT_BATCH_SIZE = 500
     insert_sql = """
     INSERT INTO main_indirectmanagednodeaudit
-        (created, modified, job_id, organization_id, inventory_id, host_id,
+        (created, job_id, organization_id, inventory_id, host_id,
          name, canonical_facts, facts, events, count)
     VALUES {rows}
     RETURNING id;

--- a/tools/anonymized_db_perf_data/rollup_performance_test.py
+++ b/tools/anonymized_db_perf_data/rollup_performance_test.py
@@ -13,7 +13,7 @@ Usage:
 import sys
 import time
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -101,8 +101,8 @@ def main():
     args = parser.parse_args()
 
     # Configuration
-    since = datetime.strptime(args.since, '%Y-%m-%d')
-    until = datetime.strptime(args.until, '%Y-%m-%d')
+    since = datetime.strptime(args.since, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+    until = datetime.strptime(args.until, '%Y-%m-%d').replace(tzinfo=timezone.utc)
     output_dir = Path(__file__).parent / 'out'
     output_dir.mkdir(exist_ok=True)
 

--- a/tools/anonymized_db_perf_data/run_all_dataset_sizes.py
+++ b/tools/anonymized_db_perf_data/run_all_dataset_sizes.py
@@ -97,7 +97,8 @@ def run_dataset(config, index, total):
         f'python tools/anonymized_db_perf_data/fill_perf_db_data.py '
         f'--job-count={config["job_count"]} '
         f'--host-count={config["host_count"]} '
-        f'--task-count={config["task_count"]}'
+        f'--task-count={config["task_count"]} '
+        f'--since={config["test_since"]} --until={config["test_until"]}'
     )
     if not run_command(cmd, f'Generating {name} dataset'):
         return {'success': False, 'elapsed': time.time() - start_time}


### PR DESCRIPTION
## Description

- What is being changed? Five fixes to the `tools/anonymized_db_perf_data/` perf harness, found when running the scripts against a real AAP instance for the first time.
- Why is this change needed? Several issues do not surface against the local mock database but break on a real AWX instance.
- How does this change address the issue? Each fix is targeted at the specific failure mode observed.

**`helpers.py`** - Remove `modified` from the `main_indirectmanagednodeaudit` INSERT. Unlike most AWX models, `IndirectManagedNodeAudit` inherits directly from `BaseModel` rather than the standard `CreatedModifiedModel` chain, so the table has no `modified` column. This is intentional design - audit records are created but never updated. All other INSERTs in the harness correctly reflect their table schemas.

**`rollup_performance_test.py`** - Parse `--since`/`--until` as timezone-aware datetimes. The `date_where` utility raises `ValueError` on naive datetime inputs. This surfaces against a real instance but not the local mock. The affected collectors are `unified_jobs` and `job_host_summary_service`, which both call `date_where` directly.

**`run_all_dataset_sizes.py`** - Pass explicit `--since`/`--until` to the fill step. Previously the fill step used the default January 2024 date range while the rollup queried January 2024 explicitly via `test_since`/`test_until` config - they happened to match, but only by coincidence. Now the fill step receives the same explicit dates as the rollup, making the relationship clear and robust.

**`fill_perf_db_data.py`** - Fix stale help text for `--host-count` and `--job-count`, which still described old default values.

**`README.md`** - Add a section documenting how to pass explicit recent dates when running against a Jenkins-provisioned instance, so the metrics-service collection pipeline picks up the generated data rather than ignoring it due to historical timestamps.

## Testing

### Prerequisites

- Local `make compose` running, or a real AAP instance with AWX database accessible
- metrics-utility checked out with `uv sync`

### Steps to Test

1. `cd tools/anonymized_db_perf_data`
2. `python clean_all_data.py --force`
3. `python fill_perf_db_data.py --job-count 5 --host-count 10 --indirect-count 25 --no-events`
4. Confirm indirect node audit records are created (count > 0 in the database counts output)
5. `python rollup_performance_test.py`
6. Confirm all collectors complete without a `ValueError` and `main_indirectmanagednodeaudit` appears in the summary table

### Expected Results

- Fill script inserts the requested number of indirect node audit records without errors
- Benchmark script runs all collectors to completion without errors
- `run_all_dataset_sizes.py` fill and rollup steps use consistent date ranges

## Required Actions

None.

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.