### PR TITLE
fix(indirect-nodes): rename Segment payload fields, fix perf harness events, add scale tiers

### DIFF
--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -130,7 +130,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                 if key not in groups:
                     groups[key] = {
                         'organization_name': org_name,
-                        'collection_name': collection_name,
+                        'collection': collection_name,
                         'host_names': set(),
                     }
                 groups[key]['host_names'].add(host_name)
@@ -144,7 +144,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                 if key not in module_groups:
                     module_groups[key] = {
                         'organization_name': org_name,
-                        'module_name': module_name,
+                        'module': module_name,
                         'host_names': set(),
                     }
                 module_groups[key]['host_names'].add(host_name)
@@ -184,23 +184,23 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         collection_hosts = {}
         for group in data.get('groups', {}).values():
-            cname = group['collection_name']
+            cname = group['collection']
             hosts = group.get('host_names', [])
             if cname not in collection_hosts:
                 collection_hosts[cname] = set()
             collection_hosts[cname].update(hosts)
 
-        by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
+        by_collection = [{'collection': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
 
         module_hosts = {}
         for group in data.get('module_groups', {}).values():
-            mname = group['module_name']
+            mname = group['module']
             hosts = group.get('host_names', [])
             if mname not in module_hosts:
                 module_hosts[mname] = set()
             module_hosts[mname].update(hosts)
 
-        by_module = [{'module_name': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
+        by_module = [{'module': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
 
         return {
             'json': {
@@ -230,7 +230,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         for key, group in data_all.get('groups', {}).items():
             merged_groups[key] = {
                 'organization_name': group['organization_name'],
-                'collection_name': group['collection_name'],
+                'collection': group['collection'],
                 'host_names': set(group.get('host_names', [])),
             }
 
@@ -240,7 +240,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             else:
                 merged_groups[key] = {
                     'organization_name': group['organization_name'],
-                    'collection_name': group['collection_name'],
+                    'collection': group['collection'],
                     'host_names': set(group.get('host_names', [])),
                 }
 
@@ -249,7 +249,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         for key, group in data_all.get('module_groups', {}).items():
             merged_module_groups[key] = {
                 'organization_name': group['organization_name'],
-                'module_name': group['module_name'],
+                'module': group['module'],
                 'host_names': set(group.get('host_names', [])),
             }
 
@@ -259,7 +259,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             else:
                 merged_module_groups[key] = {
                     'organization_name': group['organization_name'],
-                    'module_name': group['module_name'],
+                    'module': group['module'],
                     'host_names': set(group.get('host_names', [])),
                 }
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -867,7 +867,7 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     for group in by_c:
         assert 'host_names' not in group, 'host_names must not appear in anonymized output (privacy)'
         assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'collection_name' in group
+        assert 'collection' in group
         assert 'host_count' in group
 
     by_m = json_data.get('indirect_nodes_by_module', [])
@@ -876,7 +876,7 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     for entry in by_m:
         assert 'host_names' not in entry, 'host_names must not appear in anonymized output (privacy)'
         assert 'organization_name' not in entry, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'module_name' in entry
+        assert 'module' in entry
         assert 'host_count' in entry
 
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -146,7 +146,7 @@ def test_merge_unions_host_names():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -158,7 +158,7 @@ def test_merge_unions_host_names():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -181,7 +181,7 @@ def test_merge_with_none_data_all():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -202,7 +202,7 @@ def test_base_strips_pii():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -229,19 +229,19 @@ def test_base_collapses_orgs_into_collection_totals():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
             'OrgB||cisco.ios': {
                 'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2'],
                 'host_count': 1,
             },
             'OrgA||azure.azcollection': {
                 'organization_name': 'OrgA',
-                'collection_name': 'azure.azcollection',
+                'collection': 'azure.azcollection',
                 'host_names': ['host3'],
                 'host_count': 1,
             },
@@ -254,9 +254,9 @@ def test_base_collapses_orgs_into_collection_totals():
     assert result['json']['indirect_nodes_total'] == 3
     by_c = result['json']['by_collection']
     assert len(by_c) == 2
-    assert by_c[0]['collection_name'] == 'azure.azcollection'
+    assert by_c[0]['collection'] == 'azure.azcollection'
     assert by_c[0]['host_count'] == 1
-    assert by_c[1]['collection_name'] == 'cisco.ios'
+    assert by_c[1]['collection'] == 'cisco.ios'
     assert by_c[1]['host_count'] == 2
 
 
@@ -268,13 +268,13 @@ def test_base_deduplicates_hosts_across_orgs():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgB||cisco.ios': {
                 'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -285,7 +285,7 @@ def test_base_deduplicates_hosts_across_orgs():
     result = rollup.base(data)
 
     cisco_group = result['json']['by_collection'][0]
-    assert cisco_group['collection_name'] == 'cisco.ios'
+    assert cisco_group['collection'] == 'cisco.ios'
     assert cisco_group['host_count'] == 3
 
 
@@ -371,7 +371,7 @@ def test_merge_with_none_data_new():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -523,7 +523,7 @@ def test_merge_unions_module_group_host_names():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -536,7 +536,7 @@ def test_merge_unions_module_group_host_names():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -560,13 +560,13 @@ def test_base_produces_by_module():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgA||cisco.ios.ios_config': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_config',
+                'module': 'cisco.ios.ios_config',
                 'host_names': ['host3'],
                 'host_count': 1,
             },
@@ -578,8 +578,8 @@ def test_base_produces_by_module():
 
     by_module = result['json']['by_module']
     assert len(by_module) == 2
-    assert by_module[0] == {'module_name': 'cisco.ios.ios_command', 'host_count': 2}
-    assert by_module[1] == {'module_name': 'cisco.ios.ios_config', 'host_count': 1}
+    assert by_module[0] == {'module': 'cisco.ios.ios_command', 'host_count': 2}
+    assert by_module[1] == {'module': 'cisco.ios.ios_config', 'host_count': 1}
     for entry in by_module:
         assert 'host_names' not in entry
         assert 'organization_name' not in entry
@@ -594,13 +594,13 @@ def test_base_deduplicates_module_hosts_across_orgs():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgB||cisco.ios.ios_command': {
                 'organization_name': 'OrgB',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -612,11 +612,11 @@ def test_base_deduplicates_module_hosts_across_orgs():
 
     by_module = result['json']['by_module']
     assert len(by_module) == 1
-    assert by_module[0]['module_name'] == 'cisco.ios.ios_command'
+    assert by_module[0]['module'] == 'cisco.ios.ios_command'
     assert by_module[0]['host_count'] == 3
 
 
-def test_base_by_module_sorted_by_module_name():
+def test_base_by_module_sorted_by_module():
     """base() sorts by_module entries by module name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
@@ -625,13 +625,13 @@ def test_base_by_module_sorted_by_module_name():
         'module_groups': {
             'OrgA||cisco.ios.ios_config': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_config',
+                'module': 'cisco.ios.ios_config',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
             'OrgA||azure.azcollection.azure_rm_vm': {
                 'organization_name': 'OrgA',
-                'module_name': 'azure.azcollection.azure_rm_vm',
+                'module': 'azure.azcollection.azure_rm_vm',
                 'host_names': ['host2'],
                 'host_count': 1,
             },
@@ -641,7 +641,7 @@ def test_base_by_module_sorted_by_module_name():
 
     result = rollup.base(data)
 
-    names = [e['module_name'] for e in result['json']['by_module']]
+    names = [e['module'] for e in result['json']['by_module']]
     assert names == sorted(names)
 
 
@@ -653,7 +653,7 @@ def test_base_by_collection_unchanged_with_module_data():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -661,7 +661,7 @@ def test_base_by_collection_unchanged_with_module_data():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -671,5 +671,5 @@ def test_base_by_collection_unchanged_with_module_data():
 
     result = rollup.base(data)
 
-    assert result['json']['by_collection'] == [{'collection_name': 'cisco.ios', 'host_count': 1}]
-    assert result['json']['by_module'] == [{'module_name': 'cisco.ios.ios_command', 'host_count': 1}]
+    assert result['json']['by_collection'] == [{'collection': 'cisco.ios', 'host_count': 1}]
+    assert result['json']['by_module'] == [{'module': 'cisco.ios.ios_command', 'host_count': 1}]

--- a/tools/anonymized_db_perf_data/helpers.py
+++ b/tools/anonymized_db_perf_data/helpers.py
@@ -1305,6 +1305,20 @@ def create_instance(version='4.5.0', node_type='control'):
     return instance_id
 
 
+# Realistic module names from collections that have event_query.yml in ee-supported-rhel9.
+# These are the collections whose modules trigger indirect node counting in AWX.
+_INDIRECT_NODE_MODULES = [
+    ['cisco.intersight.server_profile'],
+    ['cisco.intersight.vnic_lan_connectivity_policy', 'cisco.intersight.vnic_eth_adapter_policy'],
+    ['cisco.intersight.fabric_eth_network_policy'],
+    ['cisco.intersight.ntp_policy', 'cisco.intersight.network_config_policy'],
+    ['microsoft.ad.computer'],
+    ['vmware.vmware.guest_info'],
+    ['vmware.vmware.vm_info', 'vmware.vmware.guest_info'],
+    ['vmware.vmware.cluster_info'],
+]
+
+
 def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id, indirect_count=100, unique_suffix=None):
     """Create indirect managed node audit records spread across the given jobs.
 
@@ -1329,8 +1343,10 @@ def create_indirect_managed_node_audits(job_ids, host_ids, inventory_id, org_id,
         host_id_sql = str(host_ids[i % len(host_ids)]) if host_ids else 'NULL'
         host_name = f'indirect-host-{i}{suffix}.example.com'
         canonical_facts = json.dumps({'fqdn': host_name}).replace("'", "''")
+        events = json.dumps(_INDIRECT_NODE_MODULES[i % len(_INDIRECT_NODE_MODULES)]).replace("'", "''")
         values.append(
-            f"(NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '[]'::jsonb, 1)"
+            f'(NOW(), {job_id}, {org_id}, {inventory_id}, {host_id_sql}, '
+            f"'{host_name}', '{canonical_facts}'::jsonb, '{{}}'::jsonb, '{events}'::jsonb, 1)"
         )
 
     _INSERT_BATCH_SIZE = 500

--- a/tools/anonymized_db_perf_data/run_all_dataset_sizes.py
+++ b/tools/anonymized_db_perf_data/run_all_dataset_sizes.py
@@ -41,6 +41,7 @@ DATASETS = [
         'job_count': 20,
         'host_count': 100,
         'task_count': 50,
+        'indirect_count': 1000,
         'target_events': '~100K',
         'test_since': '2024-01-01',
         'test_until': '2024-02-01',
@@ -50,6 +51,7 @@ DATASETS = [
         'job_count': 20,
         'host_count': 1000,
         'task_count': 50,
+        'indirect_count': 100000,
         'target_events': '~1M',
         'test_since': '2024-01-01',
         'test_until': '2024-02-01',
@@ -59,6 +61,7 @@ DATASETS = [
         'job_count': 6900,
         'host_count': 869,
         'task_count': 50,
+        'indirect_count': 1000000,
         'target_events': '~300M total (~10M/day)',
         'test_since': '2024-01-15',
         'test_until': '2024-01-16',
@@ -98,6 +101,7 @@ def run_dataset(config, index, total):
         f'--job-count={config["job_count"]} '
         f'--host-count={config["host_count"]} '
         f'--task-count={config["task_count"]} '
+        f'--indirect-count={config["indirect_count"]} '
         f'--since={config["test_since"]} --until={config["test_until"]}'
     )
     if not run_command(cmd, f'Generating {name} dataset'):


### PR DESCRIPTION
## Description

- What is being changed? Three changes to the indirect nodes rollup and perf harness.
- Why is this change needed? Field names in the Segment payload were being filtered downstream; the perf harness was generating data that produced no useful signal in the anonymized output; dataset scales for the indirect node collector were not defined.
- How does this change address the issue? Each change is targeted at the specific problem.

**`indirect_managed_nodes_anonymized_rollup.py` + tests** - Rename `collection_name` → `collection` and `module_name` → `module` in the `by_collection` and `by_module` Segment payload fields. Fields containing `name` are filtered by downstream Segment destinations. This is a **breaking schema change** - the Analytics team must update any queries or dashboards that reference the old field names before this is promoted.

**`helpers.py`** - Populate the `events` field in synthetic indirect node audit records with realistic Ansible collection module names from the three collections that have `event_query.yml` in `ee-supported-rhel9`: `cisco.intersight`, `microsoft.ad`, and `vmware.vmware`. Previously `events` was set to `[]`, which caused all synthetic records to fall into the `_no_collection` / `_no_module` buckets in the Segment payload, making the test data useless for analytics purposes.

**`run_all_dataset_sizes.py`** - Add `indirect_count` to each dataset tier and pass it through to the fill step. The indirect node collector does a full-table scan with no date filter, so its relevant scale is total accumulated rows rather than rows per time window. Tiers: small=1K, medium=100K, large=1M. These align with realistic deployment accumulation over weeks, months, and a year-plus of indirect node collection.

## Testing

### Prerequisites

- Local `make compose` running
- metrics-utility checked out with `uv sync`

### Steps to Test

1. Run `cd tools/anonymized_db_perf_data && python clean_all_data.py --force`
2. Run `python fill_perf_db_data.py --job-count 5 --host-count 10 --indirect-count 25 --no-events`
3. Confirm indirect node records are created with realistic collection names in `events`
4. Run `python rollup_performance_test.py`
5. Confirm `indirect_nodes_by_collection` entries use `collection` key (not `collection_name`) and `indirect_nodes_by_module` entries use `module` key (not `module_name`)
6. Run `uv run pytest metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py`

### Expected Results

- Indirect node records have non-empty `events` with real collection module names
- Anonymized payload uses `collection` and `module` field names
- All 36 tests pass

## Required Actions

- [x] Requires coordination with other teams - Analytics team must update queries/dashboards referencing `collection_name` and `module_name` before this is promoted

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.