### PR TITLE
fix(segment): rename module_name/collection_name to module/collection in events modules rollup

### DIFF
--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -728,14 +728,14 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
         # Drop host_ids from stats (we only need unique_hosts_total, not the raw host_ids list)
         # Rename module_name -> module and collection_name -> collection so Segment does not
         # filter the fields (Segment drops properties whose key contains "name").
-        _RENAMES = {'module_name': 'module', 'collection_name': 'collection'}
         for stats_list in [module_stats, collection_stats, role_stats]:
             for item in stats_list:
                 if 'host_ids' in item:
                     del item['host_ids']
-                for old, new in _RENAMES.items():
-                    if old in item:
-                        item[new] = item.pop(old)
+                if 'module_name' in item:
+                    item['module'] = item.pop('module_name')
+                if 'collection_name' in item:
+                    item['collection'] = item.pop('collection_name')
 
         # Compute modules_used_to_automate_total from unique_modules list
         modules_used_to_automate_total = len(unique_modules)

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -21,6 +21,19 @@ _COLLECTION_RE = re.compile(r'^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?
 _COLLECTION_PATTERN = r'^([A-Za-z0-9_]+\.[A-Za-z0-9_]+)\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$'
 
 
+def _normalize_stats_item(item: dict) -> None:
+    """Remove host_ids and rename module_name/collection_name keys for Segment compatibility.
+
+    Segment drops properties whose key contains 'name', so module_name -> module
+    and collection_name -> collection before the payload is sent.
+    """
+    item.pop('host_ids', None)
+    if 'module_name' in item:
+        item['module'] = item.pop('module_name')
+    if 'collection_name' in item:
+        item['collection'] = item.pop('collection_name')
+
+
 def extract_collection_name(x: str | None) -> str | None:
     """Extract the ``namespace.collection`` prefix from a fully-qualified module name.
 
@@ -725,17 +738,10 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
                 },
             }
 
-        # Drop host_ids from stats (we only need unique_hosts_total, not the raw host_ids list)
-        # Rename module_name -> module and collection_name -> collection so Segment does not
-        # filter the fields (Segment drops properties whose key contains "name").
+        # Drop host_ids and rename module_name/collection_name for Segment compatibility.
         for stats_list in [module_stats, collection_stats, role_stats]:
             for item in stats_list:
-                if 'host_ids' in item:
-                    del item['host_ids']
-                if 'module_name' in item:
-                    item['module'] = item.pop('module_name')
-                if 'collection_name' in item:
-                    item['collection'] = item.pop('collection_name')
+                _normalize_stats_item(item)
 
         # Compute modules_used_to_automate_total from unique_modules list
         modules_used_to_automate_total = len(unique_modules)

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -726,10 +726,16 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
             }
 
         # Drop host_ids from stats (we only need unique_hosts_total, not the raw host_ids list)
+        # Rename module_name -> module and collection_name -> collection so Segment does not
+        # filter the fields (Segment drops properties whose key contains "name").
+        _RENAMES = {'module_name': 'module', 'collection_name': 'collection'}
         for stats_list in [module_stats, collection_stats, role_stats]:
             for item in stats_list:
                 if 'host_ids' in item:
                     del item['host_ids']
+                for old, new in _RENAMES.items():
+                    if old in item:
+                        item[new] = item.pop(old)
 
         # Compute modules_used_to_automate_total from unique_modules list
         modules_used_to_automate_total = len(unique_modules)

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
@@ -437,8 +437,8 @@ def validate_module_stats(result):
     assert result['statistics']['rollup_period_modules_total'] == 6
 
     required_fields = [
-        'module_name',
-        'collection_name',
+        'module',
+        'collection',
         'jobs_total',
         'unique_hosts_total',
         'processed_events_total',
@@ -461,7 +461,7 @@ def validate_collection_stats(result):
     assert len(collection_stats) == 2
 
     required_fields = [
-        'collection_name',
+        'collection',
         'collection_source',
         'jobs_total',
         'processed_events_total',
@@ -486,7 +486,7 @@ def validate_role_stats(result):
 
     required_fields = [
         'role',
-        'collection_name',
+        'collection',
         'collection_source',
         'jobs_total',
         'tasks_total',
@@ -506,7 +506,7 @@ def validate_role_stats(result):
     valid_sources = {'certified', 'community', 'validated', 'partner'}
     for role_stat in known_collection_roles:
         assert role_stat['collection_source'] in valid_sources
-        assert role_stat['collection_name'] is not None and role_stat['collection_name'] != ''
+        assert role_stat['collection'] is not None and role_stat['collection'] != ''
 
 
 def validate_playbooks(result):

--- a/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
@@ -146,8 +146,8 @@ def test_anonymize_data_custom_module_stats_removed():
     """module_stats entries with collection_source == 'Custom' should be removed."""
     data = {
         'module_stats': [
-            {'module_name': 'my_module', 'collection_name': 'my.col', 'collection_source': 'Custom', 'total': 5},
-            {'module_name': 'ansible.builtin.copy', 'collection_name': 'ansible.builtin', 'collection_source': 'certified', 'total': 10},
+            {'module': 'my_module', 'collection': 'my.col', 'collection_source': 'Custom', 'total': 5},
+            {'module': 'ansible.builtin.copy', 'collection': 'ansible.builtin', 'collection_source': 'certified', 'total': 10},
         ],
     }
     anonymize_data(data)
@@ -159,21 +159,21 @@ def test_anonymize_data_custom_collection_stats_removed():
     """collection_stats entries with collection_source == 'Custom' should be removed."""
     data = {
         'collection_stats': [
-            {'collection_name': 'my.col', 'collection_source': 'Custom', 'total': 3},
-            {'collection_name': 'ansible.posix', 'collection_source': 'certified', 'total': 7},
+            {'collection': 'my.col', 'collection_source': 'Custom', 'total': 3},
+            {'collection': 'ansible.posix', 'collection_source': 'certified', 'total': 7},
         ],
     }
     anonymize_data(data)
     assert len(data['collection_stats']) == 1
-    assert data['collection_stats'][0]['collection_name'] == 'ansible.posix'
+    assert data['collection_stats'][0]['collection'] == 'ansible.posix'
 
 
 def test_anonymize_data_custom_role_stats_removed():
     """role_stats entries with collection_source == 'Custom' should be removed."""
     data = {
         'role_stats': [
-            {'role': 'my_role', 'collection_name': 'my.col', 'collection_source': 'Custom', 'total': 2},
-            {'role': 'network', 'collection_name': 'redhat.rhel_system_roles', 'collection_source': 'certified', 'total': 8},
+            {'role': 'my_role', 'collection': 'my.col', 'collection_source': 'Custom', 'total': 2},
+            {'role': 'network', 'collection': 'redhat.rhel_system_roles', 'collection_source': 'certified', 'total': 8},
         ],
     }
     anonymize_data(data)

--- a/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
@@ -748,3 +748,59 @@ def test_events_modules_aggregations_basic():
     )
     assert result['warnings_total'] == 2, f'Expected 2 warnings, got {result["warnings_total"]}'
     assert result['deprecations_total'] == 1, f'Expected 1 deprecated event, got {result["deprecations_total"]}'
+
+
+def test_base_renames_module_name_and_collection_name():
+    """base() renames module_name->module and collection_name->collection in all stats lists."""
+    rollup = EventModulesAnonymizedRollup()
+    data = {
+        'collected_events_total': 1,
+        'warnings_total': 0,
+        'deprecations_total': 0,
+        'module_stats': [
+            {'module_name': 'cisco.ios.ios_command', 'collection_name': 'cisco.ios', 'collection_source': 'certified', 'jobs_total': 1},
+        ],
+        'collection_stats': [
+            {'collection_name': 'cisco.ios', 'collection_source': 'certified', 'jobs_total': 1},
+        ],
+        'role_stats': [
+            {'role': 'my_role', 'collection_name': 'cisco.ios', 'collection_source': 'certified', 'jobs_total': 1},
+        ],
+        'unique_modules': ['cisco.ios.ios_command'],
+        'modules_per_playbook': {},
+        'unique_hosts': ['host1'],
+    }
+    result = rollup.base(data)['json']
+
+    assert 'module' in result['module_stats'][0]
+    assert 'module_name' not in result['module_stats'][0]
+    assert result['module_stats'][0]['module'] == 'cisco.ios.ios_command'
+
+    assert 'collection' in result['module_stats'][0]
+    assert 'collection_name' not in result['module_stats'][0]
+    assert result['module_stats'][0]['collection'] == 'cisco.ios'
+
+    assert 'collection' in result['collection_stats'][0]
+    assert 'collection_name' not in result['collection_stats'][0]
+
+    assert 'collection' in result['role_stats'][0]
+    assert 'collection_name' not in result['role_stats'][0]
+
+
+def test_base_handles_items_without_module_name():
+    """base() does not fail when module_name or collection_name are absent."""
+    rollup = EventModulesAnonymizedRollup()
+    data = {
+        'collected_events_total': 1,
+        'warnings_total': 0,
+        'deprecations_total': 0,
+        'module_stats': [{'collection_source': 'certified', 'jobs_total': 1}],
+        'collection_stats': [{'collection_source': 'certified', 'jobs_total': 1}],
+        'role_stats': [],
+        'unique_modules': [],
+        'modules_per_playbook': {},
+        'unique_hosts': [],
+    }
+    result = rollup.base(data)['json']
+    assert 'module_name' not in result['module_stats'][0]
+    assert 'collection_name' not in result['collection_stats'][0]

--- a/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_events_modules_anonymized_rollups.py
@@ -442,10 +442,10 @@ def test_events_modules_aggregations_basic():
     assert result['hosts_automated_total'] == 9
 
     # collection stats assertions (current aggregation schema)
-    coll_by_name = {row['collection_name']: row for row in result['collection_stats']}
+    coll_by_name = {row['collection']: row for row in result['collection_stats']}
 
     # Verify per-module stats (aligned to current aggregation output)
-    stats_by_module = {row['module_name']: row for row in result['module_stats']}
+    stats_by_module = {row['module']: row for row in result['module_stats']}
 
     # Verify per-role stats (aligned to current aggregation output)
     stats_by_role = {row['role'] if row['role'] is not None else 'None': row for row in result['role_stats']}
@@ -460,11 +460,11 @@ def test_events_modules_aggregations_basic():
         assert win_copy_role_stats['tasks_total'] > 0
         assert 'jobs_total' in win_copy_role_stats
         # Verify collection_name and collection_source are present
-        assert 'collection_name' in win_copy_role_stats, 'role_stats should have collection_name field'
+        assert 'collection' in win_copy_role_stats, 'role_stats should have collection field'
         assert 'collection_source' in win_copy_role_stats, 'role_stats should have collection_source field'
-        # For collection-based roles, collection_name should be extracted (ansible.windows.win_copy_role -> ansible.windows)
-        assert win_copy_role_stats['collection_name'] == 'ansible.windows', (
-            f"Expected collection_name 'ansible.windows', got {win_copy_role_stats['collection_name']}"
+        # For collection-based roles, collection should be extracted (ansible.windows.win_copy_role -> ansible.windows)
+        assert win_copy_role_stats['collection'] == 'ansible.windows', (
+            f"Expected collection 'ansible.windows', got {win_copy_role_stats['collection']}"
         )
         assert win_copy_role_stats['collection_source'] == 'certified', (
             f"Expected collection_source 'certified', got {win_copy_role_stats['collection_source']}"
@@ -474,8 +474,8 @@ def test_events_modules_aggregations_basic():
     if 'custom.standalone_role' in stats_by_role:
         standalone_role_stats = stats_by_role['custom.standalone_role']
         # Standalone roles should have None collection_name and Custom collection_source
-        assert standalone_role_stats.get('collection_name') is None or standalone_role_stats.get('collection_name') == '', (
-            f'Standalone role should have None collection_name, got {standalone_role_stats.get("collection_name")}'
+        assert standalone_role_stats.get('collection') is None or standalone_role_stats.get('collection') == '', (
+            f'Standalone role should have None collection, got {standalone_role_stats.get("collection")}'
         )
         assert standalone_role_stats['collection_source'] == 'Custom', (
             f"Standalone role should have 'Custom' collection_source, got {standalone_role_stats['collection_source']}"

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -151,9 +151,9 @@ def _validate_module_stats_structure(json_data):
     if not json_data['module_stats']:
         return
     for module_stat in json_data['module_stats']:
-        assert 'module_name' in module_stat
+        assert 'module' in module_stat
         assert 'collection_source' in module_stat
-        assert 'collection_name' in module_stat
+        assert 'collection' in module_stat
         assert 'jobs_total' in module_stat
         assert 'unique_hosts_total' in module_stat
         assert 'processed_events_total' in module_stat
@@ -166,7 +166,7 @@ def _validate_collection_stats_structure(json_data):
     if not json_data['collection_stats']:
         return
     for collection_stat in json_data['collection_stats']:
-        assert 'collection_name' in collection_stat
+        assert 'collection' in collection_stat
         assert 'collection_source' in collection_stat
         assert 'jobs_total' in collection_stat
         assert 'processed_events_total' in collection_stat
@@ -239,7 +239,7 @@ def _validate_jobs_by_ansible_version_structure(json_data):
 def _validate_module_stats_values(json_data):
     """Validate module_stats actual values."""
     print('--- Validating module_stats data values ---')
-    module_stats_dict = {m['module_name']: m for m in json_data['module_stats']}
+    module_stats_dict = {m['module']: m for m in json_data['module_stats']}
 
     anonymized_modules = [m for m in json_data['module_stats'] if m.get('collection_source') == 'Custom']
     assert len(anonymized_modules) == 0, f'Should have 0 Custom modules (Custom collections removed), got {len(anonymized_modules)}'
@@ -262,7 +262,7 @@ def _validate_module_stats_values(json_data):
 def _validate_collection_stats_values(json_data):
     """Validate collection_stats actual values."""
     print('--- Validating collection_stats data values ---')
-    collection_stats_dict = {c['collection_name']: c for c in json_data['collection_stats']}
+    collection_stats_dict = {c['collection']: c for c in json_data['collection_stats']}
 
     a10_collection = collection_stats_dict.get('a10.acos_axapi')
     assert a10_collection is not None, 'Should have a10.acos_axapi collection'
@@ -289,10 +289,8 @@ def _validate_role_stats(json_data):
     for role_stat in anonymized_roles:
         if role_stat.get('role'):
             assert role_stat['role'] == 'Custom', f'Anonymized role name should be "Custom", got {role_stat.get("role")}'
-        if role_stat.get('collection_name'):
-            assert role_stat['collection_name'] == 'Custom', (
-                f'Anonymized collection_name in role_stat should be "Custom", got {role_stat.get("collection_name")}'
-            )
+        if role_stat.get('collection'):
+            assert role_stat['collection'] == 'Custom', f'Anonymized collection in role_stat should be "Custom", got {role_stat.get("collection")}'
 
 
 def _validate_jobs_by_installed_collections_versions(json_data):
@@ -463,7 +461,7 @@ def _validate_job_host_summary_values_multi_hour(json_data, statistics):
 def _validate_module_stats_values_multi_hour(json_data):
     """Validate module_stats actual values for multi-hour data (6 jobs total)."""
     print('--- Validating module_stats data values (multi-hour) ---')
-    module_stats_dict = {m['module_name']: m for m in json_data['module_stats']}
+    module_stats_dict = {m['module']: m for m in json_data['module_stats']}
 
     anonymized_modules = [m for m in json_data['module_stats'] if m.get('collection_source') == 'Custom']
     assert len(anonymized_modules) == 0, f'Should have 0 Custom modules (Custom collections removed), got {len(anonymized_modules)}'
@@ -489,7 +487,7 @@ def _validate_module_stats_values_multi_hour(json_data):
 def _validate_collection_stats_values_multi_hour(json_data):
     """Validate collection_stats actual values for multi-hour data (6 jobs total)."""
     print('--- Validating collection_stats data values (multi-hour) ---')
-    collection_stats_dict = {c['collection_name']: c for c in json_data['collection_stats']}
+    collection_stats_dict = {c['collection']: c for c in json_data['collection_stats']}
 
     a10_collection = collection_stats_dict.get('a10.acos_axapi')
     assert a10_collection is not None, 'Should have a10.acos_axapi collection'

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -260,7 +260,7 @@ def _validate_events_modules(result):
         f'Expected 1 deprecated event, got {result["statistics"]["rollup_period_deprecations_total"]}'
     )
 
-    module_names = [m['module_name'] for m in result['module_stats'] if 'module_name' in m]
+    module_names = [m['module'] for m in result['module_stats'] if 'module' in m]
     for module_name in [
         'ansible.netcommon.cli_config',
         'ansible.posix.firewalld',
@@ -275,11 +275,11 @@ def _validate_events_modules(result):
     assert isinstance(module_stats, list), 'module_stats should be a list'
     assert len(module_stats) == 6, 'Should have stats for all 6 modules'
 
-    win_copy_stats = [m for m in module_stats if m.get('module_name') == 'ansible.windows.win_copy']
+    win_copy_stats = [m for m in module_stats if m.get('module') == 'ansible.windows.win_copy']
     assert len(win_copy_stats) == 1, 'Should have exactly one entry for ansible.windows.win_copy'
     win_copy = win_copy_stats[0]
     assert win_copy['collection_source'] == 'certified'
-    assert win_copy['collection_name'] == 'ansible.windows'
+    assert win_copy['collection'] == 'ansible.windows'
     assert win_copy['jobs_total'] == 3
     assert win_copy['unique_hosts_total'] == 3
     assert win_copy['task_ok_total'] == 1
@@ -288,7 +288,7 @@ def _validate_events_modules(result):
     assert win_copy['jobs_duration_total_seconds'] == pytest.approx(2100.0)
     assert win_copy['processed_events_total'] == 5
 
-    yum_stats = [m for m in module_stats if m.get('module_name') == 'community.general.yum']
+    yum_stats = [m for m in module_stats if m.get('module') == 'community.general.yum']
     assert len(yum_stats) == 1, 'Should have exactly one entry for community.general.yum'
     yum = yum_stats[0]
     assert yum['collection_source'] == 'community'
@@ -302,7 +302,7 @@ def _validate_events_modules(result):
     assert isinstance(collection_stats, list), 'collection_stats should be a list'
     assert len(collection_stats) == 6, 'Should have stats for all 6 collections'
 
-    windows_collection = [c for c in collection_stats if c.get('collection_name') == 'ansible.windows']
+    windows_collection = [c for c in collection_stats if c.get('collection') == 'ansible.windows']
     assert len(windows_collection) == 1, 'Should have exactly one entry for ansible.windows collection'
     windows_coll = windows_collection[0]
     assert windows_coll['collection_source'] == 'certified'


### PR DESCRIPTION
## Description

- What is being changed? Rename `module_name` → `module` and `collection_name` → `collection` in the `module_stats`, `collection_stats`, and `role_stats` fields of the Segment payload.
- Why is this change needed? Segment downstream destinations filter out properties whose key contains `name`. These fields were being silently dropped.
- How does this change address the issue? The rename is applied in `events_modules_anonymized_rollup.py` `base()` at output time, so internal DataFrame column names are untouched throughout the processing pipeline.

## Testing

### Steps to Test

1. Run `uv run pytest metrics_utility/test/test_anonymized_rollups/`
2. Confirm `module_stats` entries use `module` and `collection` keys
3. Confirm `collection_stats` entries use `collection` key
4. Confirm `role_stats` entries use `collection` key

### Expected Results

All tests pass. No `module_name` or `collection_name` keys appear in the Segment payload output.

## Required Actions

- [x] Requires coordination with other teams - Analytics team must update any queries referencing `module_name` or `collection_name` in `module_stats`, `collection_stats`, or `role_stats`.

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [x] Tests are added or updated as needed.
- [ ] Changes are reviewed and approved by at least two team members.
- [x] Documentation is updated where applicable.