### PR TITLE
AWX schema CI - filter backports-zstd on Python 3.14+

### DIFF
--- a/.github/workflows/awx-schema.yml
+++ b/.github/workflows/awx-schema.yml
@@ -55,12 +55,19 @@ jobs:
         working-directory: awx
         run: |
           uv venv /tmp/awx-venv
+
           # Filter out uwsgi (needs crypt.h) — not needed for migrations
           sed '/^uwsgi==/d' requirements/requirements.txt > /tmp/awx-requirements-filtered.txt
+
+          # Filter out backports-zstd on Python 3.14+ (stdlib compression.zstd replaces it)
+          python -c 'import sys; sys.exit(0 if sys.version_info >= (3,14) else 1)' \
+            && sed -i '/^backports-zstd/d' /tmp/awx-requirements-filtered.txt
+
           uv pip install --python /tmp/awx-venv/bin/python \
             -r /tmp/awx-requirements-filtered.txt \
             -r requirements/requirements_git.txt \
             -r requirements/requirements_dev.txt
+
           uv pip install --python /tmp/awx-venv/bin/python -e .
 
       - name: "Run AWX migrations"


### PR DESCRIPTION
Follows #461 - awx schema extract job (AAP-75301)

The cron run failed in https://github.com/ansible/metrics-utility/actions/runs/29235262247/job/86768347053

backports-zstd is in awx requirements now, but can't be used with python 3.14 because it's already in stdlib since 3.14

we use whichever version our pyproject allows, which is currently 3.12, 3.13 or 3.14,
so adding a tweak to filter it out in >=3.14