### PR TITLE
AAP-82505 | fix: add nullable to requested fields

### DIFF
--- a/metrics_utility/schemas/config-1.0.jsonschema
+++ b/metrics_utility/schemas/config-1.0.jsonschema
@@ -83,7 +83,7 @@
       "type": ["integer", "null"]
     },
     "automated_since": {
-      "type": "integer"
+      "type": ["integer", "null"]
     },
     "compliant": {
       "type": ["boolean", "null"]
@@ -92,10 +92,10 @@
       "type": ["integer", "null"]
     },
     "date_expired": {
-      "type": "boolean"
+      "type": ["boolean", "null"]
     },
     "date_warning": {
-      "type": "boolean"
+      "type": ["boolean", "null"]
     },
     "free_instances": {
       "type": "integer"
@@ -104,7 +104,7 @@
       "type": ["integer", "null"]
     },
     "license_date": {
-      "type": "integer"
+      "type": ["integer", "null"]
     },
     "license_expiry": {
       "type": "integer"

--- a/metrics_utility/schemas/total_workers_vcpu-1.0.jsonschema
+++ b/metrics_utility/schemas/total_workers_vcpu-1.0.jsonschema
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "cluster_name": {
-      "type": "string",
+      "type": ["string", "null"],
       "minLength": 1,
       "maxLength": 255
     },


### PR DESCRIPTION
[AAP-82505]

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

Addresses https://github.com/ansible/metrics-utility/issues/452 by changing requested fields to allow nulls