### PR TITLE
jira-pr-link - switch to Python, append instead of overwrite

### DIFF
--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -91,21 +91,114 @@ jobs:
             exit 0
           fi
 
-          HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" \
-            --connect-timeout 10 \
-            --max-time 30 \
-            -X PUT \
-            -H "Content-Type: application/json" \
-            -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
-            "${JIRA_BASE_URL}/rest/api/2/issue/${TICKET}" \
-            -d "{\"fields\": {\"${JIRA_PR_FIELD_ID}\": \"${PR_URL}\"}}") || true
+          python3 << 'PYEOF'
+          import json, os, sys, urllib.request, urllib.error, base64
 
-          if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
-            echo "Updated ${TICKET} Git Pull Request field with ${PR_URL}"
-            echo "linked=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::Failed to update Jira ticket ${TICKET} (HTTP ${HTTP_CODE})"
-          fi
+          base_url = os.environ["JIRA_BASE_URL"]
+          email = os.environ["JIRA_USER_EMAIL"]
+          token = os.environ["JIRA_API_TOKEN"]
+          field_id = os.environ["JIRA_PR_FIELD_ID"]
+          ticket = os.environ["TICKET"]
+          pr_url = os.environ["PR_URL"]
+          github_output = os.environ["GITHUB_OUTPUT"]
+
+          auth = base64.b64encode(f"{email}:{token}".encode()).decode()
+          headers = {
+              "Authorization": f"Basic {auth}",
+              "Content-Type": "application/json",
+              "Accept": "application/json",
+          }
+
+          def set_output(key, value):
+              with open(github_output, "a") as f:
+                  f.write(f"{key}={value}\n")
+
+          def find_urls(node):
+              """Recursively extract all URLs from an ADF tree."""
+              urls = set()
+              if isinstance(node, dict):
+                  for key in ("href", "url"):
+                      if key in node:
+                          urls.add(node[key])
+                  if isinstance(node.get("text"), str) and node["text"].startswith("http"):
+                      urls.add(node["text"])
+                  for value in node.values():
+                      urls |= find_urls(value)
+              elif isinstance(node, list):
+                  for item in node:
+                      urls |= find_urls(item)
+              return urls
+
+          def make_link_paragraph(url):
+              return {
+                  "type": "paragraph",
+                  "content": [{
+                      "type": "text",
+                      "text": url,
+                      "marks": [{"type": "link", "attrs": {"href": url}}],
+                  }],
+              }
+
+          # Fetch current field value
+          get_url = f"{base_url}/rest/api/3/issue/{ticket}?fields={field_id}"
+          req = urllib.request.Request(get_url, headers=headers)
+          try:
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  data = json.loads(resp.read())
+          except urllib.error.HTTPError as e:
+              print(f"::warning::Failed to fetch Jira ticket {ticket} (HTTP {e.code})")
+              sys.exit(0)
+          except (urllib.error.URLError, TimeoutError) as e:
+              print(f"::warning::Failed to fetch Jira ticket {ticket} ({e})")
+              sys.exit(0)
+
+          current = data.get("fields", {}).get(field_id)
+
+          # Duplicate check — deep search through the entire ADF tree
+          if isinstance(current, str) and pr_url in current:
+              print(f"{pr_url} already linked on {ticket}, skipping")
+              set_output("linked", "true")
+              sys.exit(0)
+          if isinstance(current, dict) and pr_url in find_urls(current):
+              print(f"{pr_url} already linked on {ticket}, skipping")
+              set_output("linked", "true")
+              sys.exit(0)
+
+          new_paragraph = make_link_paragraph(pr_url)
+
+          if isinstance(current, dict) and current.get("content"):
+              current["content"].append(new_paragraph)
+              updated_adf = current
+          elif isinstance(current, str) and current.startswith("http"):
+              updated_adf = {
+                  "type": "doc",
+                  "version": 1,
+                  "content": [make_link_paragraph(current), new_paragraph],
+              }
+          else:
+              updated_adf = {
+                  "type": "doc",
+                  "version": 1,
+                  "content": [new_paragraph],
+              }
+
+          # Write back
+          put_url = f"{base_url}/rest/api/3/issue/{ticket}"
+          payload = json.dumps({"fields": {field_id: updated_adf}}).encode()
+          req = urllib.request.Request(put_url, data=payload, headers=headers, method="PUT")
+          try:
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  pass
+              print(f"Updated {ticket} Git Pull Request field with {pr_url}")
+              set_output("linked", "true")
+          except urllib.error.HTTPError as e:
+              body = e.read().decode() if hasattr(e, "read") else ""
+              print(f"::warning::Failed to update Jira ticket {ticket} (HTTP {e.code})")
+              if body:
+                  print(body)
+          except (urllib.error.URLError, TimeoutError) as e:
+              print(f"::warning::Failed to update Jira ticket {ticket} ({e})")
+          PYEOF
 
       - name: "Comment on PR with linked ticket"
         if: steps.jira-update.outputs.linked == 'true'
@@ -129,4 +222,3 @@ jobs:
               --repo "${{ github.repository }}" \
               --body "$BODY" || echo "::warning::Failed to post linked-ticket comment"
           fi
-


### PR DESCRIPTION
Related to: AAP-83170, #462, ansible/metrics-service#362
Replaces #491

Port the Python-based jira-pr-link workflow from metrics-service (ansible/metrics-service#347, ansible/metrics-service#362) to replace the bash/curl version that blindly overwrote the Jira field on each PR.

The workflow now reads the existing field value, checks for duplicates, and appends — so multiple PRs referencing the same Jira ticket all get linked. Also handles edge cases: null/empty field, plain string from the old v2 API, human-edited content (bullet lists, inlineCards), and substring false-positives.

After this, the workflow files are identical between metrics-utility and metrics-service.

---

wait until https://github.com/ansible/metrics-service/pull/362 gets merged - review there first, then this just copies it here