### PR TITLE
AAP-79941 | fix: revert cluster_name nullable in total_workers_vcpu-1.0 schema

### DIFF
--- a/metrics_utility/schemas/total_workers_vcpu-1.0.jsonschema
+++ b/metrics_utility/schemas/total_workers_vcpu-1.0.jsonschema
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "cluster_name": {
-      "type": ["string", "null"],
+      "type": "string",
       "minLength": 1,
       "maxLength": 255
     },


### PR DESCRIPTION
[AAP-79941]

## Summary

Reverts the `cluster_name` nullability change from #492 (dc90859). The four `config-1.0` fields in that PR were correct, but `cluster_name` in `total_workers_vcpu-1.0` should remain non-nullable.

## Why

**Producer side:** `cli_total_workers_vcpu()` reads `cluster_name` from `METRICS_UTILITY_CLUSTER_NAME` and raises `MissingRequiredEnvVar` if unset — null can never appear in a valid tarball.

**Consumer side (automation-analytics-backend):**
- `saas_cluster_name VARCHAR(255) NOT NULL` on both `vcpu_usage` and `vcpu_subswatch_sync` tables
- Handler validates `isinstance(cluster_name, str)` and rejects `None` with `ValueError`
- `cluster_name` is part of the `UNIQUE (timestamp, saas_cluster_name, install_uuid)` constraint — null would break deduplication
- Used in the composite billing `instance_id` (`{install_uuid}/{saas_cluster_name}`) sent to subscription watch

Making the schema nullable removes an early-warning safety net for misconfigured deployments without any legitimate use case.

## Test plan

- [ ] Verify schema still rejects `{"cluster_name": null, ...}` payloads
- [ ] Verify schema still accepts valid string cluster names

Closes https://github.com/ansible/metrics-utility/issues/452 (cluster_name portion)