### PR TITLE
CI - add mock segment server to pytest-service job

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -170,6 +170,18 @@ jobs:
         run: |
           cat tools/docker/{roles,latest,functions,conf_setting,main_hostmetric,main_instance,main_jobhostsummary,dab_feature_flags,main_indirectmanagednodeaudit}.sql | sudo su - postgres -c psql
 
+      - name: "Set up Go"
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: tools/mock-segment-server/go.mod
+
+      - name: "Start mock segment server"
+        timeout-minutes: 1
+        run: |
+          go build -C tools/mock-segment-server -o /tmp/mock-segment-server .
+          /tmp/mock-segment-server &
+          until curl -sf http://localhost:8765/requests > /dev/null; do sleep 1; done
+
       - name: "Clone metrics-service"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -208,5 +220,6 @@ jobs:
           METRICS_SERVICE_DATABASES__awx__PASSWORD: awx
           DJANGO_SETTINGS_MODULE: metrics_service.settings
           METRICS_SERVICE_MODE: test
+          MOCK_SEGMENT_URL: "http://localhost:8765"
         run: |
           uv run pytest -s -v

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -14,6 +14,7 @@ x-metrics-service: &metrics-service
     METRICS_SERVICE_DATABASES__awx__HOST: postgres
     METRICS_SERVICE_DATABASES__awx__USER: awx
     METRICS_SERVICE_DATABASES__awx__PASSWORD: awx
+    MOCK_SEGMENT_URL: "http://mock-segment:8765"
 
 services:
   seaweedfs:


### PR DESCRIPTION
Issue: AAP-75303

Counterpart to https://github.com/ansible/metrics-service/pull/366 so that m-s tests usign mock segment don't fail here.

Updates the metrics-service test env on metrics-utility CI.
(dups bits of the pytest job in pytest-service, until we unify both fully)

- Build and start mock-segment in the pytest-service job so metrics-service integration tests pass with local metrics-utility
- Add MOCK_SEGMENT_URL to compose metrics-service env anchor