### PR TITLE
[stable-0.7] feat(AAP-78070): indirect managed nodes daily collection

### DIFF
--- a/metrics_utility/anonymized_rollups/__init__.py
+++ b/metrics_utility/anonymized_rollups/__init__.py
@@ -3,7 +3,6 @@ from .anonymized_rollups import (
     anonymize_rollups,
     create_anonymized_object,
     flatten_json_report,
-    hash,
 )
 from .base_anonymized_rollup import BaseAnonymizedRollup
 from .controller_version_anonymized_rollup import ControllerVersionAnonymizedRollup
@@ -35,6 +34,5 @@ __all__ = [
     'anonymize_rollups',
     'create_anonymized_object',
     'flatten_json_report',
-    'hash',
     'sanitize_json',
 ]

--- a/metrics_utility/anonymized_rollups/__init__.py
+++ b/metrics_utility/anonymized_rollups/__init__.py
@@ -12,6 +12,7 @@ from .events_modules_anonymized_rollup import EventModulesAnonymizedRollup
 from .execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
 from .feature_flags_anonymized_rollup import FeatureFlagsAnonymizedRollup
 from .helpers import sanitize_json
+from .indirect_managed_nodes_anonymized_rollup import IndirectManagedNodesAnonymizedRollup
 from .jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from .jobs_anonymized_rollup import JobsAnonymizedRollup
 from .table_metadata_anonymized_rollup import TableMetadataAnonymizedRollup
@@ -25,6 +26,7 @@ __all__ = [
     'EventModulesAnonymizedRollup',
     'ExecutionEnvironmentsAnonymizedRollup',
     'FeatureFlagsAnonymizedRollup',
+    'IndirectManagedNodesAnonymizedRollup',
     'JobHostSummaryAnonymizedRollup',
     'JobsAnonymizedRollup',
     'TableMetadataAnonymizedRollup',

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List
+from collections.abc import Callable
+from typing import Any
 
 import pandas as pd
 
@@ -15,7 +16,7 @@ from metrics_utility.anonymized_rollups.task_executions_anonymized_rollup import
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import DataframeContentUsage
 
 
-def _installed_collection_name_is_unknown(collection_name: Any, known: Dict[str, Any]) -> bool:
+def _installed_collection_name_is_unknown(collection_name: Any, known: dict[str, Any]) -> bool:
     """
     Return True if the name should be anonymized to 'Custom': missing, blank, NA,
     or not present in the known collections map.
@@ -61,12 +62,12 @@ def create_anonymized_object(rollup_name: str):
         raise ValueError(f'Invalid rollup name: {rollup_name}')
 
 
-def _remove_custom_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _remove_custom_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return a new list with all items whose collection_source is 'Custom' removed."""
     return [item for item in items if item and item.get('collection_source') != 'Custom']
 
 
-def _remove_unknown_installed_collections(items: List[Dict[str, Any]], known_collections: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _remove_unknown_installed_collections(items: list[dict[str, Any]], known_collections: dict[str, Any]) -> list[dict[str, Any]]:
     """Return a new list with installed-collection entries not in the known whitelist removed."""
     return [item for item in items if item and not _installed_collection_name_is_unknown(item.get('collection', ''), known_collections)]
 
@@ -129,7 +130,7 @@ def _normalize_ansible_version_key(ansible_version: Any) -> str:
     return str(ansible_version)
 
 
-def _get_default_host_summary_fields() -> Dict[str, int]:
+def _get_default_host_summary_fields() -> dict[str, int]:
     """Get default values for host summary fields when no match is found."""
     return {
         'unreachable_total': 0,
@@ -144,7 +145,7 @@ def _get_default_host_summary_fields() -> Dict[str, int]:
     }
 
 
-def _extract_host_summary_fields(jhs_data: Dict[str, Any]) -> Dict[str, Any]:
+def _extract_host_summary_fields(jhs_data: dict[str, Any]) -> dict[str, Any]:
     """Extract host summary fields from job_host_summary data.
 
     Note: unique_hosts_total is not included here as it's only computed at the top level,
@@ -164,11 +165,11 @@ def _extract_host_summary_fields(jhs_data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _merge_jobs_with_host_summary(
-    jobs_list: List[Dict[str, Any]],
-    jhs_lookup: Dict[str, Dict[str, Any]],
-    key_extractor: Callable[[Dict[str, Any]], Any],
-    normalize_key: Callable[[Any], str] = None,
-) -> List[Dict[str, Any]]:
+    jobs_list: list[dict[str, Any]],
+    jhs_lookup: dict[str, dict[str, Any]],
+    key_extractor: Callable[[dict[str, Any]], Any],
+    normalize_key: Callable[[Any], str] | None = None,
+) -> list[dict[str, Any]]:
     """Merge job_host_summary data into jobs list using a lookup dictionary."""
     default_fields = _get_default_host_summary_fields()
     merged_jobs = []
@@ -190,14 +191,14 @@ def _merge_jobs_with_host_summary(
     return merged_jobs
 
 
-def _calculate_sum_from_list(items: List[Dict[str, Any]], field: str) -> Any:
+def _calculate_sum_from_list(items: list[dict[str, Any]], field: str) -> Any:
     """Calculate sum of a field from a list of dictionaries, returning 0 if list is empty."""
     if not items:
         return 0
     return sum(item.get(field, 0) for item in items)
 
 
-def _calculate_host_summary_totals(job_host_summary_by_job_type: List[Dict[str, Any]], host_ids: List[Any] = None) -> Dict[str, Any]:
+def _calculate_host_summary_totals(job_host_summary_by_job_type: list[dict[str, Any]], host_ids: list[Any] | None = None) -> dict[str, Any]:
     """Calculate host summary totals from job_type groups.
 
     Args:
@@ -218,7 +219,7 @@ def _calculate_host_summary_totals(job_host_summary_by_job_type: List[Dict[str, 
     }
 
 
-def _calculate_job_statistics(jobs_by_job_type: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _calculate_job_statistics(jobs_by_job_type: list[dict[str, Any]]) -> dict[str, Any]:
     """Calculate job statistics by summing from all job_type groups."""
     return {
         'rollup_period_jobs_total': _calculate_sum_from_list(jobs_by_job_type, 'jobs_total'),
@@ -232,17 +233,17 @@ def _calculate_job_statistics(jobs_by_job_type: List[Dict[str, Any]]) -> Dict[st
     }
 
 
-def _merge_ansible_versions(jobs_by_job_type: List[Dict[str, Any]]) -> List[str]:
+def _merge_ansible_versions(jobs_by_job_type: list[dict[str, Any]]) -> list[str]:
     """Merge ansible_versions from all job_type groups (unique values, sorted)."""
     ansible_versions_set = set()
     for job in jobs_by_job_type:
         ansible_versions = job.get('ansible_versions', [])
         if isinstance(ansible_versions, list):
             ansible_versions_set.update(ansible_versions)
-    return sorted(list(ansible_versions_set)) if ansible_versions_set else []
+    return sorted(ansible_versions_set) if ansible_versions_set else []
 
 
-def _calculate_execution_environments_total(execution_environments: Dict[str, Any]) -> Any:
+def _calculate_execution_environments_total(execution_environments: dict[str, Any]) -> Any:
     """Calculate execution_environments_total as sum of default and custom."""
     default_total = execution_environments.get('execution_environments_default_total')
     custom_total = execution_environments.get('execution_environments_custom_total')
@@ -251,7 +252,7 @@ def _calculate_execution_environments_total(execution_environments: Dict[str, An
     return (default_total or 0) + (custom_total or 0)
 
 
-def _calculate_task_statistics(jobs_by_job_type_merged: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _calculate_task_statistics(jobs_by_job_type_merged: list[dict[str, Any]]) -> dict[str, Any]:
     """Calculate task statistics from merged jobs_by_job_type."""
     task_ok = sum(job.get('ok_total', 0) for job in jobs_by_job_type_merged)
     task_failed = sum(job.get('failed_total', 0) for job in jobs_by_job_type_merged)
@@ -270,17 +271,17 @@ def _calculate_task_statistics(jobs_by_job_type_merged: List[Dict[str, Any]]) ->
 
 
 def _build_statistics(
-    events_modules: Dict[str, Any],
-    execution_environments: Dict[str, Any],
-    jobs: Dict[str, Any],
-    job_statistics: Dict[str, Any],
-    host_summary_totals: Dict[str, Any],
+    events_modules: dict[str, Any],
+    execution_environments: dict[str, Any],
+    jobs: dict[str, Any],
+    job_statistics: dict[str, Any],
+    host_summary_totals: dict[str, Any],
     job_host_pairs_total: Any,
     playbooks_total: int,
     execution_environments_total: Any,
     has_events: bool = True,
-    indirect_managed_nodes: Dict[str, Any] = None,
-) -> Dict[str, Any]:
+    indirect_managed_nodes: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build statistics dictionary with rollup_period_ prefix for all fields."""
     # Calculate indirect node count
     indirect_nodes_total = 0
@@ -330,7 +331,7 @@ def _build_statistics(
     return statistics
 
 
-def _inject_controller_version(jobs_by_controller_version: List[Dict[str, Any]], controller_versions: List[str]) -> List[Dict[str, Any]]:
+def _inject_controller_version(jobs_by_controller_version: list[dict[str, Any]], controller_versions: list[str]) -> list[dict[str, Any]]:
     """Inject the first controller_version from the controller_versions list into the
     single-item jobs_by_controller_version summary."""
     if not jobs_by_controller_version:
@@ -341,7 +342,7 @@ def _inject_controller_version(jobs_by_controller_version: List[Dict[str, Any]],
     return jobs_by_controller_version
 
 
-def _inject_controller_version_to_all_items(jobs_list: List[Dict[str, Any]], controller_versions: List[str]) -> List[Dict[str, Any]]:
+def _inject_controller_version_to_all_items(jobs_list: list[dict[str, Any]], controller_versions: list[str]) -> list[dict[str, Any]]:
     """Inject the first controller_version from the controller_versions list into every
     item of the given jobs grouping list."""
     first_version = controller_versions[0] if controller_versions else None
@@ -350,9 +351,9 @@ def _inject_controller_version_to_all_items(jobs_list: List[Dict[str, Any]], con
     return jobs_list
 
 
-def _extract_jobs_by_installed_collections_versions(jobs: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _extract_jobs_by_installed_collections_versions(jobs: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract and transform installed collections from jobs data."""
-    installed_collections: List[Dict[str, Any]] = jobs.get('installed_collections', []) or []
+    installed_collections: list[dict[str, Any]] = jobs.get('installed_collections', []) or []
     return [
         {
             'collection': item.get('collection_name', ''),
@@ -379,15 +380,15 @@ def _extract_jobs_by_installed_collections_versions(jobs: Dict[str, Any]) -> Lis
 
 
 def _merge_all_jobs_groupings(
-    jobs: Dict[str, Any],
-    job_host_summary_by_job_type: List[Dict[str, Any]],
-    job_host_summary_by_launch_type: List[Dict[str, Any]],
-    job_host_summary_by_ansible_version: List[Dict[str, Any]],
-) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    jobs: dict[str, Any],
+    job_host_summary_by_job_type: list[dict[str, Any]],
+    job_host_summary_by_launch_type: list[dict[str, Any]],
+    job_host_summary_by_ansible_version: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Merge job_host_summary data into all jobs groupings."""
     # Merge by job_type
-    jhs_lookup_by_job_type: Dict[str, Dict[str, Any]] = {jhs.get('job_type'): jhs for jhs in job_host_summary_by_job_type}
-    jobs_by_job_type: List[Dict[str, Any]] = jobs.get('by_job_type', []) or []
+    jhs_lookup_by_job_type: dict[str, dict[str, Any]] = {jhs.get('job_type'): jhs for jhs in job_host_summary_by_job_type}
+    jobs_by_job_type: list[dict[str, Any]] = jobs.get('by_job_type', []) or []
     jobs_by_job_type_merged = _merge_jobs_with_host_summary(
         jobs_by_job_type,
         jhs_lookup_by_job_type,
@@ -395,8 +396,8 @@ def _merge_all_jobs_groupings(
     )
 
     # Merge by launch_type
-    jhs_lookup_by_launch_type: Dict[str, Dict[str, Any]] = {jhs.get('launch_type'): jhs for jhs in job_host_summary_by_launch_type}
-    jobs_by_launch_type: List[Dict[str, Any]] = jobs.get('by_launch_type', []) or []
+    jhs_lookup_by_launch_type: dict[str, dict[str, Any]] = {jhs.get('launch_type'): jhs for jhs in job_host_summary_by_launch_type}
+    jobs_by_launch_type: list[dict[str, Any]] = jobs.get('by_launch_type', []) or []
     jobs_by_launch_type_merged = _merge_jobs_with_host_summary(
         jobs_by_launch_type,
         jhs_lookup_by_launch_type,
@@ -404,12 +405,12 @@ def _merge_all_jobs_groupings(
     )
 
     # Merge by ansible_version
-    jhs_lookup_by_ansible_version: Dict[str, Dict[str, Any]] = {}
+    jhs_lookup_by_ansible_version: dict[str, dict[str, Any]] = {}
     for jhs in job_host_summary_by_ansible_version:
         key = _normalize_ansible_version_key(jhs.get('ansible_version'))
         jhs_lookup_by_ansible_version[key] = jhs
 
-    jobs_by_ansible_version: List[Dict[str, Any]] = jobs.get('by_ansible_version', []) or []
+    jobs_by_ansible_version: list[dict[str, Any]] = jobs.get('by_ansible_version', []) or []
     jobs_by_ansible_version_merged = _merge_jobs_with_host_summary(
         jobs_by_ansible_version,
         jhs_lookup_by_ansible_version,
@@ -420,12 +421,12 @@ def _merge_all_jobs_groupings(
     return jobs_by_job_type_merged, jobs_by_launch_type_merged, jobs_by_ansible_version_merged
 
 
-def _as_list(value: Any) -> List[Any]:
+def _as_list(value: Any) -> list[Any]:
     """Return *value* unchanged when it is already a list; otherwise return an empty list."""
     return value if isinstance(value, list) else []
 
 
-def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
+def flatten_json_report(data: dict[str, Any]) -> dict[str, Any]:
     """
     Manually flattens the given nested report into:
       - statistics: object of primitive totals (includes credentials)
@@ -454,14 +455,14 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
     indirect_managed_nodes_root = data.get('indirect_managed_nodes', {})
 
     # Extract data structures
-    credentials_list: List[str] = _as_list(credentials_root)
-    jobs_by_job_type: List[Dict[str, Any]] = jobs.get('by_job_type', []) or []
-    job_host_summary_by_job_type: List[Dict[str, Any]] = job_host_summary_root.get('by_job_type', []) or []
-    job_host_summary_by_launch_type: List[Dict[str, Any]] = job_host_summary_root.get('by_launch_type', []) or []
-    job_host_summary_by_ansible_version: List[Dict[str, Any]] = job_host_summary_root.get('by_ansible_version', []) or []
+    credentials_list: list[str] = _as_list(credentials_root)
+    jobs_by_job_type: list[dict[str, Any]] = jobs.get('by_job_type', []) or []
+    job_host_summary_by_job_type: list[dict[str, Any]] = job_host_summary_root.get('by_job_type', []) or []
+    job_host_summary_by_launch_type: list[dict[str, Any]] = job_host_summary_root.get('by_launch_type', []) or []
+    job_host_summary_by_ansible_version: list[dict[str, Any]] = job_host_summary_root.get('by_ansible_version', []) or []
 
     # Extract top-level host_ids list to compute unique_hosts_total
-    host_ids: List[Any] = job_host_summary_root.get('host_ids', []) or []
+    host_ids: list[Any] = job_host_summary_root.get('host_ids', []) or []
 
     # Calculate statistics using helper functions
     host_summary_totals = _calculate_host_summary_totals(job_host_summary_by_job_type, host_ids)
@@ -490,9 +491,9 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
 
     # Extract arrays and collections
     # Only include event-related arrays if there are events
-    module_stats: List[Dict[str, Any]] = events_modules.get('module_stats', []) or []
-    collection_stats: List[Dict[str, Any]] = events_modules.get('collection_stats', []) or []
-    role_stats: List[Dict[str, Any]] = events_modules.get('role_stats', []) or []
+    module_stats: list[dict[str, Any]] = events_modules.get('module_stats', []) or []
+    collection_stats: list[dict[str, Any]] = events_modules.get('collection_stats', []) or []
+    role_stats: list[dict[str, Any]] = events_modules.get('role_stats', []) or []
     jobs_by_installed_collections_versions = _extract_jobs_by_installed_collections_versions(jobs)
 
     # Merge job_host_summary into jobs groupings
@@ -504,8 +505,8 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
     )
 
     # Build jobs_by_controller_version: inject first controller_version from the controller_version collector
-    jobs_by_controller_version: List[Dict[str, Any]] = jobs.get('jobs_by_controller_version', []) or []
-    controller_versions: List[str] = _as_list(controller_version_root)
+    jobs_by_controller_version: list[dict[str, Any]] = jobs.get('jobs_by_controller_version', []) or []
+    controller_versions: list[str] = _as_list(controller_version_root)
     jobs_by_controller_version = _inject_controller_version(jobs_by_controller_version, controller_versions)
 
     # Inject controller_version into every item of the three job groupings
@@ -518,7 +519,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
     statistics.update(task_statistics)
 
     # Assemble the flattened object
-    flattened: Dict[str, Any] = {
+    flattened: dict[str, Any] = {
         'statistics': statistics,
         'rollup_period_ansible_versions': ansible_versions_merged,
         'rollup_period_scm_types': _as_list(jobs.get('scm_types')),

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -346,7 +346,7 @@ def _build_statistics(
         'rollup_period_failed_hosts_total': host_summary_totals['failed_hosts_total'],
         'rollup_period_unreachable_hosts_total': host_summary_totals['unreachable_hosts_total'],
         # from indirect_managed_nodes
-        'rollup_period_indirect_managed_nodes_total': indirect_nodes_total,
+        'rollup_period_indirect_managed_nodes_all_total': indirect_nodes_total,
     }
 
     # Only include event-related fields if there are events
@@ -568,7 +568,6 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'controller_versions': controller_versions,
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
-        'indirect_managed_nodes': indirect_managed_nodes_root.get('indirect_node_ids', []) if indirect_managed_nodes_root else [],
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -568,6 +568,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'controller_versions': controller_versions,
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
+        'indirect_nodes_by_collection': indirect_managed_nodes_root.get('by_collection', []),
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -569,6 +569,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
         'indirect_nodes_by_collection': indirect_managed_nodes_root.get('by_collection', []),
+        'indirect_nodes_by_module': indirect_managed_nodes_root.get('by_module', []),
     }
 
     # Only include event-related arrays if there are events

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -1,7 +1,3 @@
-import hashlib
-import json
-import os
-
 from typing import Any, Callable, Dict, List
 
 import pandas as pd
@@ -11,17 +7,12 @@ from metrics_utility.anonymized_rollups.credentials_anonymized_rollup import Cre
 from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import EventModulesAnonymizedRollup
 from metrics_utility.anonymized_rollups.execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
 from metrics_utility.anonymized_rollups.feature_flags_anonymized_rollup import FeatureFlagsAnonymizedRollup
+from metrics_utility.anonymized_rollups.helpers import load_known_collections
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 from metrics_utility.anonymized_rollups.table_metadata_anonymized_rollup import TableMetadataAnonymizedRollup
 from metrics_utility.anonymized_rollups.task_executions_anonymized_rollup import TaskExecutionsAnonymizedRollup
-
-
-def hash(value, salt):
-    # has the value and salt, hash should be string
-    combined = (salt + ':' + value).encode('utf-8')
-    hashed = hashlib.sha256(combined).hexdigest()
-    return hashed
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import DataframeContentUsage
 
 
 def _installed_collection_name_is_unknown(collection_name: Any, known: Dict[str, Any]) -> bool:
@@ -70,7 +61,17 @@ def create_anonymized_object(rollup_name: str):
         raise ValueError(f'Invalid rollup name: {rollup_name}')
 
 
-def anonymize_data(data, salt):
+def _remove_custom_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a new list with all items whose collection_source is 'Custom' removed."""
+    return [item for item in items if item and item.get('collection_source') != 'Custom']
+
+
+def _remove_unknown_installed_collections(items: List[Dict[str, Any]], known_collections: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return a new list with installed-collection entries not in the known whitelist removed."""
+    return [item for item in items if item and not _installed_collection_name_is_unknown(item.get('collection', ''), known_collections)]
+
+
+def anonymize_data(data):
     """
     Anonymizes sensitive data in the flattened report structure.
     This function expects data to be already flattened by flatten_json_report().
@@ -88,74 +89,37 @@ def anonymize_data(data, salt):
             - role_stats: array of role statistics
             - jobs_by_installed_collections_versions: array of {collection, version, jobs_total, jobs_failed_total,
               jobs_successful_total} from installed collections
-        salt: Salt string for hashing (used for job_template_name hashing)
     """
     if not data or not isinstance(data, dict):
         return
 
-    # anonymize jobs_by_job_type job template name (if present)
-    # Note: jobs_by_job_type is now grouped by job_type, but may still have job_template_name for templates_total
-    if 'jobs_by_job_type' in data and data['jobs_by_job_type']:
-        for job in data['jobs_by_job_type']:
-            if job and 'job_template_name' in job and job['job_template_name']:
-                job['job_template_name'] = hash(job['job_template_name'], salt)
+    for key in ('module_stats', 'collection_stats', 'role_stats'):
+        if key in data:
+            data[key] = _remove_custom_items(data[key] or [])
 
-    # anonymize jobs_by_launch_type job template name (if present)
-    if 'jobs_by_launch_type' in data and data['jobs_by_launch_type']:
-        for job in data['jobs_by_launch_type']:
-            if job and 'job_template_name' in job and job['job_template_name']:
-                job['job_template_name'] = hash(job['job_template_name'], salt)
+    known_collections = load_known_collections()
 
-    # anonymize jobs_by_ansible_version job template name (if present)
-    if 'jobs_by_ansible_version' in data and data['jobs_by_ansible_version']:
-        for job in data['jobs_by_ansible_version']:
-            if job and 'job_template_name' in job and job['job_template_name']:
-                job['job_template_name'] = hash(job['job_template_name'], salt)
-
-    # anonymize module_stats - replace module name and collection name with 'Custom' for 'Custom' sources
-    if 'module_stats' in data and data['module_stats']:
-        for module in data['module_stats']:
-            if module and module.get('collection_source') == 'Custom':
-                if 'module_name' in module and module['module_name']:
-                    module['module_name'] = 'Custom'
-                if 'collection_name' in module and module['collection_name']:
-                    module['collection_name'] = 'Custom'
-
-    # anonymize collection_stats - replace collection name with 'Custom' for 'Custom' sources
-    if 'collection_stats' in data and data['collection_stats']:
-        for collection in data['collection_stats']:
-            if collection and collection.get('collection_source') == 'Custom':
-                if 'collection_name' in collection and collection['collection_name']:
-                    collection['collection_name'] = 'Custom'
-
-    # anonymize role_stats - replace role name and collection name with 'Custom' for 'Custom' sources
-    if 'role_stats' in data and data['role_stats']:
-        for role in data['role_stats']:
-            if role and role.get('collection_source') == 'Custom':
-                if 'role' in role and role['role']:
-                    role['role'] = 'Custom'
-                if 'collection_name' in role and role['collection_name']:
-                    role['collection_name'] = 'Custom'
-
-    # anonymize jobs_by_installed_collections_versions - replace collection and version with "Custom" for unknown collections
-    # Load collections.json to check if collection is known
-    collections_path = os.path.join(os.path.dirname(__file__), 'collections.json')
-    try:
-        with open(collections_path, 'r') as f:
-            collections = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        collections = {}
-
-    if 'jobs_by_installed_collections_versions' in data and data['jobs_by_installed_collections_versions']:
-        for collection_version in data['jobs_by_installed_collections_versions']:
-            if collection_version and 'collection' in collection_version:
-                collection_name = collection_version.get('collection', '')
-                if _installed_collection_name_is_unknown(collection_name, collections):
-                    collection_version['collection'] = 'Custom'
-                    collection_version['version'] = 'Custom'
-
-    # Note: modules_used_per_playbook anonymization removed since it's not in final output
-    # If needed in future, can be re-enabled when modules_used_per_playbook is added back to output
+    if 'jobs_by_installed_collections_versions' in data:
+        data['jobs_by_installed_collections_versions'] = _remove_unknown_installed_collections(
+            data['jobs_by_installed_collections_versions'] or [],
+            known_collections,
+        )
+    if 'indirect_nodes_by_collection' in data:
+        data['indirect_nodes_by_collection'] = [
+            item
+            for item in (data['indirect_nodes_by_collection'] or [])
+            if item and not _installed_collection_name_is_unknown(item.get('collection', ''), known_collections)
+        ]
+    if 'indirect_nodes_by_module' in data:
+        data['indirect_nodes_by_module'] = [
+            item
+            for item in (data['indirect_nodes_by_module'] or [])
+            if item
+            and not _installed_collection_name_is_unknown(
+                DataframeContentUsage.extract_collection_name(item.get('module', '')),
+                known_collections,
+            )
+        ]
 
 
 def _normalize_ansible_version_key(ansible_version: Any) -> str:
@@ -589,7 +553,6 @@ def anonymize_rollups(
     credentials_rollup,
     table_metadata_rollup,
     controller_version_rollup,
-    salt,
     *,
     feature_flags_rollup=None,
     task_executions_rollup=None,
@@ -606,7 +569,6 @@ def anonymize_rollups(
         credentials_rollup: Credentials statistics
         table_metadata_rollup: Table metadata statistics
         controller_version_rollup: Controller version statistics
-        salt: Salt string for hashing sensitive data
         feature_flags_rollup: Enabled feature flags list (optional, keyword-only)
         task_executions_rollup: Task execution observability statistics (optional, keyword-only)
         indirect_managed_nodes_rollup: Indirect managed nodes statistics (optional, keyword-only)
@@ -631,6 +593,6 @@ def anonymize_rollups(
     data = flatten_json_report(data)
 
     # Then anonymize the flattened structure
-    anonymize_data(data, salt)
+    anonymize_data(data)
 
     return data

--- a/metrics_utility/anonymized_rollups/anonymized_rollups.py
+++ b/metrics_utility/anonymized_rollups/anonymized_rollups.py
@@ -315,8 +315,14 @@ def _build_statistics(
     playbooks_total: int,
     execution_environments_total: Any,
     has_events: bool = True,
+    indirect_managed_nodes: Dict[str, Any] = None,
 ) -> Dict[str, Any]:
     """Build statistics dictionary with rollup_period_ prefix for all fields."""
+    # Calculate indirect node count
+    indirect_nodes_total = 0
+    if indirect_managed_nodes:
+        indirect_nodes_total = indirect_managed_nodes.get('indirect_nodes_total', 0)
+
     statistics = {
         # from execution_environments
         'rollup_period_execution_environments_total': execution_environments_total,
@@ -339,6 +345,8 @@ def _build_statistics(
         'rollup_period_successful_hosts_total': host_summary_totals['successful_hosts_total'],
         'rollup_period_failed_hosts_total': host_summary_totals['failed_hosts_total'],
         'rollup_period_unreachable_hosts_total': host_summary_totals['unreachable_hosts_total'],
+        # from indirect_managed_nodes
+        'rollup_period_indirect_managed_nodes_total': indirect_nodes_total,
     }
 
     # Only include event-related fields if there are events
@@ -479,6 +487,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
     controller_version_root = data.get('controller_version', [])
     feature_flags_root = data.get('feature_flags', [])
     task_executions_root = data.get('task_executions', [])
+    indirect_managed_nodes_root = data.get('indirect_managed_nodes', {})
 
     # Extract data structures
     credentials_list: List[str] = _as_list(credentials_root)
@@ -512,6 +521,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         playbooks_total,
         execution_environments_total,
         has_events,
+        indirect_managed_nodes_root,
     )
 
     # Extract arrays and collections
@@ -558,6 +568,7 @@ def flatten_json_report(data: Dict[str, Any]) -> Dict[str, Any]:
         'controller_versions': controller_versions,
         'feature_flags': _as_list(feature_flags_root),
         'observability_by_tasks': _as_list(task_executions_root),
+        'indirect_managed_nodes': indirect_managed_nodes_root.get('indirect_node_ids', []) if indirect_managed_nodes_root else [],
     }
 
     # Only include event-related arrays if there are events
@@ -581,6 +592,7 @@ def anonymize_rollups(
     *,
     feature_flags_rollup=None,
     task_executions_rollup=None,
+    indirect_managed_nodes_rollup=None,
 ):
     """
     Combines rollup data, flattens it, and anonymizes sensitive fields.
@@ -596,6 +608,7 @@ def anonymize_rollups(
         salt: Salt string for hashing sensitive data
         feature_flags_rollup: Enabled feature flags list (optional, keyword-only)
         task_executions_rollup: Task execution observability statistics (optional, keyword-only)
+        indirect_managed_nodes_rollup: Indirect managed nodes statistics (optional, keyword-only)
 
     Returns:
         Flattened and anonymized rollup data
@@ -610,6 +623,7 @@ def anonymize_rollups(
         'controller_version': controller_version_rollup,
         'feature_flags': feature_flags_rollup or [],
         'task_executions': task_executions_rollup or [],
+        'indirect_managed_nodes': indirect_managed_nodes_rollup or {},
     }
 
     # First flatten the nested structure

--- a/metrics_utility/anonymized_rollups/collections.json
+++ b/metrics_utility/anonymized_rollups/collections.json
@@ -3750,5 +3750,6 @@
     "zxbot.carbonio_ssinstall": "community",
     "zxbot.carbonio_upgrade": "community",
     "zzbytes.redteam": "community",
-    "zzpio.test": "community"
+    "zzpio.test": "community",
+    "ansible.builtin": "certified"
 }

--- a/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/events_modules_anonymized_rollup.py
@@ -1,11 +1,10 @@
 import json
-import os
 import re
 
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
-from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.anonymized_rollups.helpers import load_known_collections, sanitize_json
 from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import DataframeContentUsage
 
 
@@ -111,10 +110,7 @@ class EventModulesAnonymizedRollup(BaseAnonymizedRollup):
 
         self.collector_names = ['main_jobevent_service']
 
-        # Open the JSON file using path relative to this module
-        collections_path = os.path.join(os.path.dirname(__file__), 'collections.json')
-        with open(collections_path, 'r') as f:
-            self.collections = json.load(f)
+        self.collections = load_known_collections()
 
     def _create_lookup_dict(self, stats_list, groupby_cols):
         """Create a lookup dictionary keyed by grouping columns."""

--- a/metrics_utility/anonymized_rollups/helpers.py
+++ b/metrics_utility/anonymized_rollups/helpers.py
@@ -2,7 +2,9 @@
 Helper utilities for anonymized rollups.
 """
 
+import json
 import math
+import os
 
 
 try:
@@ -11,6 +13,21 @@ try:
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
+
+
+def load_known_collections():
+    """Load the public collections whitelist from collections.json.
+
+    Returns:
+        Dict mapping collection name to source category, or empty dict if the
+        file is missing or malformed.
+    """
+    collections_path = os.path.join(os.path.dirname(__file__), 'collections.json')
+    try:
+        with open(collections_path, 'r') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
 
 
 def sanitize_json(obj):

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -1,46 +1,147 @@
 """Anonymized rollup for indirect managed node audit collector data."""
 
+import json
+
+import pandas as pd
+
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import (
+    DataframeContentUsage,
+)
+
+
+GROUP_KEY_SEPARATOR = '||'
+
+
+def _extract_collection_names(events_value):
+    """Parse the events JSON column and return a set of collection names.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        Set of two-part collection name strings (e.g. ``{"azure.azcollection"}``).
+    """
+    if events_value is None:
+        return set()
+
+    if isinstance(events_value, float):
+        return set()
+
+    if isinstance(events_value, str):
+        try:
+            events_list = json.loads(events_value)
+        except ValueError:
+            return set()
+    elif isinstance(events_value, list):
+        events_list = events_value
+    else:
+        return set()
+
+    collections = set()
+    for fqcn in events_list:
+        name = DataframeContentUsage.extract_collection_name(fqcn)
+        if name is not None:
+            collections.add(name)
+    return collections
+
+
+def _make_group_key(organization_name, collection_name):
+    return f'{organization_name}{GROUP_KEY_SEPARATOR}{collection_name}'
+
+
+def _aggregate_by_key(groups, key_field):
+    """Aggregate host names across groups by a single field (org or collection)."""
+    aggregated = {}
+    for group in groups.values():
+        key = group[key_field]
+        if key not in aggregated:
+            aggregated[key] = set()
+        aggregated[key].update(group.get('host_names', []))
+    return {k: {'host_names': sorted(v), 'host_count': len(v)} for k, v in sorted(aggregated.items())}
 
 
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
-    """Rollup processor for main_indirectmanagednodeaudit collector data."""
+    """Rollup processor for main_indirectmanagednodeaudit collector data.
+
+    Groups indirect managed nodes by organization and Ansible collection,
+    counting unique host names per group.
+    """
 
     def __init__(self):
         super().__init__('indirect_managed_nodes')
         self.collector_names = ['main_indirectmanagednodeaudit']
 
     def prepare(self, dataframe):
-        """Transform raw indirect node audit data for deduplication.
+        """Transform raw indirect node audit data into org/collection groups.
 
-        Extracts unique host_remote_ids for daily deduplication and billing count.
+        Parses the events JSON column to extract Ansible collection names,
+        then groups by (organization_name, collection_name) and counts unique
+        host_name values per group. Uses host_name (not host_remote_id) because
+        host_remote_id is always NULL for indirect managed nodes.
 
-        Returns JSON-serializable dictionary with deduplicated host IDs and total count.
+        Returns JSON-serializable dictionary with groups and total count.
         """
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {
-                'indirect_node_ids': [],
-                'indirect_nodes_total': 0,
-            }
+            return {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
 
-        # Extract unique host_remote_ids for deduplication
-        if 'host_remote_id' in dataframe.columns:
-            indirect_node_ids = sorted(set(dataframe['host_remote_id'].dropna()))
-        else:
-            indirect_node_ids = []
+        groups = {}
+        all_host_names = set()
+
+        for _, row in dataframe.iterrows():
+            host_name = row.get('host_name')
+            if pd.isna(host_name):
+                continue
+
+            host_name = str(host_name)
+            org_name = str(row.get('organization_name', ''))
+            all_host_names.add(host_name)
+
+            collection_names = _extract_collection_names(row.get('events'))
+
+            if not collection_names:
+                collection_names = {'_no_collection'}
+
+            for collection_name in collection_names:
+                key = _make_group_key(org_name, collection_name)
+                if key not in groups:
+                    groups[key] = {
+                        'organization_name': org_name,
+                        'collection_name': collection_name,
+                        'host_names': set(),
+                    }
+                groups[key]['host_names'].add(host_name)
+
+        for group in groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+
+        agg_by_org = _aggregate_by_key(groups, 'organization_name')
+        agg_by_coll = _aggregate_by_key(groups, 'collection_name')
+
+        by_organizations = [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()]
+        by_collections = [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()]
 
         return sanitize_json(
             {
-                'indirect_node_ids': indirect_node_ids,
-                'indirect_nodes_total': len(indirect_node_ids),
+                'groups': groups,
+                'by_organizations': by_organizations,
+                'by_collections': by_collections,
+                'indirect_nodes_total': len(all_host_names),
             }
         )
 
     def base(self, data):
-        """Return final rollup payload with count only (no host IDs for privacy).
+        """Return final rollup payload stripped of all PII.
+
+        Strips host_names and organization_name (customer-identifiable).
+        Collapses org-level groups into collection-level totals, re-deduplicating
+        hosts that appear under the same collection in different orgs.
+        Collection names are public Ansible Galaxy labels, not PII.
 
         Args:
             data: Accumulated dict from merge() calls, or None if no data.
@@ -49,20 +150,71 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             Dict with 'json' key containing the final rollup data.
         """
         if data is None:
-            return {'json': {'indirect_nodes_total': 0}}
-        return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
+            return {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+
+        collection_hosts = {}
+        for group in data.get('groups', {}).values():
+            cname = group['collection_name']
+            hosts = group.get('host_names', [])
+            if cname not in collection_hosts:
+                collection_hosts[cname] = set()
+            collection_hosts[cname].update(hosts)
+
+        by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
+
+        return {
+            'json': {
+                'indirect_nodes_total': data.get('indirect_nodes_total', 0),
+                'by_collection': by_collection,
+            }
+        }
 
     def merge(self, data_all, data_new):
-        """Pass through the snapshot batch unchanged.
-
-        With a daily snapshot collector there is only one batch per day,
-        so cross-batch merging is not needed.
+        """Merge two prepared batches by unioning host name sets per group.
 
         Args:
-            data_all: Unused (always None for snapshot collectors)
-            data_new: Prepared data from the single snapshot batch
+            data_all: Previously accumulated data, or None for the first batch.
+            data_new: New batch of prepared data.
 
         Returns:
-            data_new unchanged
+            Merged data with deduplicated host names per group.
         """
-        return data_new
+        if data_all is None:
+            return data_new
+        if data_new is None:
+            return data_all
+
+        merged_groups = {}
+
+        for key, group in data_all.get('groups', {}).items():
+            merged_groups[key] = {
+                'organization_name': group['organization_name'],
+                'collection_name': group['collection_name'],
+                'host_names': set(group.get('host_names', [])),
+            }
+
+        for key, group in data_new.get('groups', {}).items():
+            if key in merged_groups:
+                merged_groups[key]['host_names'].update(group.get('host_names', []))
+            else:
+                merged_groups[key] = {
+                    'organization_name': group['organization_name'],
+                    'collection_name': group['collection_name'],
+                    'host_names': set(group.get('host_names', [])),
+                }
+
+        all_host_names = set()
+        for group in merged_groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+            all_host_names.update(group['host_names'])
+
+        agg_by_org = _aggregate_by_key(merged_groups, 'organization_name')
+        agg_by_coll = _aggregate_by_key(merged_groups, 'collection_name')
+
+        return {
+            'groups': merged_groups,
+            'by_organizations': [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()],
+            'by_collections': [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()],
+            'indirect_nodes_total': len(all_host_names),
+        }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -52,17 +52,6 @@ def _make_group_key(organization_name, collection_name):
     return f'{organization_name}{GROUP_KEY_SEPARATOR}{collection_name}'
 
 
-def _aggregate_by_key(groups, key_field):
-    """Aggregate host names across groups by a single field (org or collection)."""
-    aggregated = {}
-    for group in groups.values():
-        key = group[key_field]
-        if key not in aggregated:
-            aggregated[key] = set()
-        aggregated[key].update(group.get('host_names', []))
-    return {k: {'host_names': sorted(v), 'host_count': len(v)} for k, v in sorted(aggregated.items())}
-
-
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
     """Rollup processor for main_indirectmanagednodeaudit collector data.
 
@@ -87,7 +76,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
+            return {'groups': {}, 'indirect_nodes_total': 0}
 
         groups = {}
         all_host_names = set()
@@ -120,17 +109,9 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
-        agg_by_org = _aggregate_by_key(groups, 'organization_name')
-        agg_by_coll = _aggregate_by_key(groups, 'collection_name')
-
-        by_organizations = [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()]
-        by_collections = [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()]
-
         return sanitize_json(
             {
                 'groups': groups,
-                'by_organizations': by_organizations,
-                'by_collections': by_collections,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -209,12 +190,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             group['host_count'] = len(group['host_names'])
             all_host_names.update(group['host_names'])
 
-        agg_by_org = _aggregate_by_key(merged_groups, 'organization_name')
-        agg_by_coll = _aggregate_by_key(merged_groups, 'collection_name')
-
         return {
             'groups': merged_groups,
-            'by_organizations': [{'organization_name': k, 'host_count': v['host_count']} for k, v in agg_by_org.items()],
-            'by_collections': [{'collection_name': k, 'host_count': v['host_count']} for k, v in agg_by_coll.items()],
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -14,6 +14,31 @@ from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_co
 GROUP_KEY_SEPARATOR = '||'
 
 
+def _parse_events(events_value):
+    """Parse the events JSON column into a list of FQCNs.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        List of FQCN strings, or empty list if unparseable.
+    """
+    if events_value is None:
+        return []
+    if isinstance(events_value, float):
+        return []
+    if isinstance(events_value, str):
+        try:
+            parsed = json.loads(events_value)
+            return parsed if isinstance(parsed, list) else []
+        except ValueError:
+            return []
+    if isinstance(events_value, list):
+        return events_value
+    return []
+
+
 def _extract_collection_names(events_value):
     """Parse the events JSON column and return a set of collection names.
 
@@ -24,28 +49,31 @@ def _extract_collection_names(events_value):
     Returns:
         Set of two-part collection name strings (e.g. ``{"azure.azcollection"}``).
     """
-    if events_value is None:
-        return set()
-
-    if isinstance(events_value, float):
-        return set()
-
-    if isinstance(events_value, str):
-        try:
-            events_list = json.loads(events_value)
-        except ValueError:
-            return set()
-    elif isinstance(events_value, list):
-        events_list = events_value
-    else:
-        return set()
-
     collections = set()
-    for fqcn in events_list:
+    for fqcn in _parse_events(events_value):
         name = DataframeContentUsage.extract_collection_name(fqcn)
         if name is not None:
             collections.add(name)
     return collections
+
+
+def _extract_module_names(events_value):
+    """Parse the events JSON column and return a set of full FQCNs (module names).
+
+    Only FQCNs with a valid namespace.collection prefix are included.
+
+    Args:
+        events_value: Raw events column value - could be a JSON string,
+            a Python list, None, or NaN.
+
+    Returns:
+        Set of full FQCN strings (e.g. ``{"azure.azcollection.azure_rm_vm"}``).
+    """
+    modules = set()
+    for fqcn in _parse_events(events_value):
+        if DataframeContentUsage.extract_collection_name(fqcn) is not None:
+            modules.add(fqcn)
+    return modules
 
 
 def _make_group_key(organization_name, collection_name):
@@ -76,9 +104,10 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {'groups': {}, 'indirect_nodes_total': 0}
+            return {'groups': {}, 'module_groups': {}, 'indirect_nodes_total': 0}
 
         groups = {}
+        module_groups = {}
         all_host_names = set()
 
         for _, row in dataframe.iterrows():
@@ -90,8 +119,9 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             org_name = str(row.get('organization_name', ''))
             all_host_names.add(host_name)
 
-            collection_names = _extract_collection_names(row.get('events'))
+            events = row.get('events')
 
+            collection_names = _extract_collection_names(events)
             if not collection_names:
                 collection_names = {'_no_collection'}
 
@@ -105,13 +135,32 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                     }
                 groups[key]['host_names'].add(host_name)
 
+            module_names = _extract_module_names(events)
+            if not module_names:
+                module_names = {'_no_module'}
+
+            for module_name in module_names:
+                key = _make_group_key(org_name, module_name)
+                if key not in module_groups:
+                    module_groups[key] = {
+                        'organization_name': org_name,
+                        'module_name': module_name,
+                        'host_names': set(),
+                    }
+                module_groups[key]['host_names'].add(host_name)
+
         for group in groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+
+        for group in module_groups.values():
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
 
         return sanitize_json(
             {
                 'groups': groups,
+                'module_groups': module_groups,
                 'indirect_nodes_total': len(all_host_names),
             }
         )
@@ -131,7 +180,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             Dict with 'json' key containing the final rollup data.
         """
         if data is None:
-            return {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+            return {'json': {'indirect_nodes_total': 0, 'by_collection': [], 'by_module': []}}
 
         collection_hosts = {}
         for group in data.get('groups', {}).values():
@@ -143,10 +192,21 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
 
+        module_hosts = {}
+        for group in data.get('module_groups', {}).values():
+            mname = group['module_name']
+            hosts = group.get('host_names', [])
+            if mname not in module_hosts:
+                module_hosts[mname] = set()
+            module_hosts[mname].update(hosts)
+
+        by_module = [{'module_name': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
+
         return {
             'json': {
                 'indirect_nodes_total': data.get('indirect_nodes_total', 0),
                 'by_collection': by_collection,
+                'by_module': by_module,
             }
         }
 
@@ -184,13 +244,37 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                     'host_names': set(group.get('host_names', [])),
                 }
 
+        merged_module_groups = {}
+
+        for key, group in data_all.get('module_groups', {}).items():
+            merged_module_groups[key] = {
+                'organization_name': group['organization_name'],
+                'module_name': group['module_name'],
+                'host_names': set(group.get('host_names', [])),
+            }
+
+        for key, group in data_new.get('module_groups', {}).items():
+            if key in merged_module_groups:
+                merged_module_groups[key]['host_names'].update(group.get('host_names', []))
+            else:
+                merged_module_groups[key] = {
+                    'organization_name': group['organization_name'],
+                    'module_name': group['module_name'],
+                    'host_names': set(group.get('host_names', [])),
+                }
+
         all_host_names = set()
         for group in merged_groups.values():
             group['host_names'] = sorted(group['host_names'])
             group['host_count'] = len(group['host_names'])
             all_host_names.update(group['host_names'])
 
+        for group in merged_module_groups.values():
+            group['host_names'] = sorted(group['host_names'])
+            group['host_count'] = len(group['host_names'])
+
         return {
             'groups': merged_groups,
+            'module_groups': merged_module_groups,
             'indirect_nodes_total': len(all_host_names),
         }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -130,7 +130,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                 if key not in groups:
                     groups[key] = {
                         'organization_name': org_name,
-                        'collection_name': collection_name,
+                        'collection': collection_name,
                         'host_names': set(),
                     }
                 groups[key]['host_names'].add(host_name)
@@ -144,7 +144,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
                 if key not in module_groups:
                     module_groups[key] = {
                         'organization_name': org_name,
-                        'module_name': module_name,
+                        'module': module_name,
                         'host_names': set(),
                     }
                 module_groups[key]['host_names'].add(host_name)
@@ -184,23 +184,23 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
 
         collection_hosts = {}
         for group in data.get('groups', {}).values():
-            cname = group['collection_name']
+            cname = group['collection']
             hosts = group.get('host_names', [])
             if cname not in collection_hosts:
                 collection_hosts[cname] = set()
             collection_hosts[cname].update(hosts)
 
-        by_collection = [{'collection_name': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
+        by_collection = [{'collection': cname, 'host_count': len(hosts)} for cname, hosts in sorted(collection_hosts.items())]
 
         module_hosts = {}
         for group in data.get('module_groups', {}).values():
-            mname = group['module_name']
+            mname = group['module']
             hosts = group.get('host_names', [])
             if mname not in module_hosts:
                 module_hosts[mname] = set()
             module_hosts[mname].update(hosts)
 
-        by_module = [{'module_name': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
+        by_module = [{'module': mname, 'host_count': len(hosts)} for mname, hosts in sorted(module_hosts.items())]
 
         return {
             'json': {
@@ -230,7 +230,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         for key, group in data_all.get('groups', {}).items():
             merged_groups[key] = {
                 'organization_name': group['organization_name'],
-                'collection_name': group['collection_name'],
+                'collection': group['collection'],
                 'host_names': set(group.get('host_names', [])),
             }
 
@@ -240,7 +240,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             else:
                 merged_groups[key] = {
                     'organization_name': group['organization_name'],
-                    'collection_name': group['collection_name'],
+                    'collection': group['collection'],
                     'host_names': set(group.get('host_names', [])),
                 }
 
@@ -249,7 +249,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         for key, group in data_all.get('module_groups', {}).items():
             merged_module_groups[key] = {
                 'organization_name': group['organization_name'],
-                'module_name': group['module_name'],
+                'module': group['module'],
                 'host_names': set(group.get('host_names', [])),
             }
 
@@ -259,7 +259,7 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             else:
                 merged_module_groups[key] = {
                     'organization_name': group['organization_name'],
-                    'module_name': group['module_name'],
+                    'module': group['module'],
                     'host_names': set(group.get('host_names', [])),
                 }
 

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -1,0 +1,43 @@
+"""Anonymized rollup for indirect managed node audit collector data."""
+
+import pandas as pd
+
+from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
+from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.metric_utils import INDIRECT
+
+
+class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
+    """Rollup processor for main_indirectmanagednodeaudit collector data."""
+
+    def __init__(self):
+        super().__init__('indirect_managed_nodes')
+        self.collector_names = ['main_indirectmanagednodeaudit']
+
+    def prepare(self, dataframe):
+        """Transform raw indirect node audit data, adding managed_node_type tag.
+
+        Injects managed_node_type = INDIRECT constant to tag all records as
+        indirectly-managed nodes for downstream billing/rollup processing.
+
+        Returns JSON-serializable dictionary for storage in HourlyMetricsCollection.
+        """
+        dataframe = self._convert_id_columns_to_strings(dataframe)
+
+        if dataframe.empty:
+            return {}
+
+        dataframe['managed_node_type'] = INDIRECT
+
+        # Convert DataFrame to dict and handle datetime serialization
+        records = dataframe.to_dict(orient='records')
+
+        # Convert pandas Timestamp objects to ISO format strings
+        for record in records:
+            for key, value in record.items():
+                if pd.isna(value):
+                    record[key] = None
+                elif hasattr(value, 'isoformat'):
+                    record[key] = value.isoformat()
+
+        return sanitize_json(records)

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -1,10 +1,7 @@
 """Anonymized rollup for indirect managed node audit collector data."""
 
-import pandas as pd
-
 from metrics_utility.anonymized_rollups.base_anonymized_rollup import BaseAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
-from metrics_utility.metric_utils import INDIRECT
 
 
 class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
@@ -15,29 +12,55 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         self.collector_names = ['main_indirectmanagednodeaudit']
 
     def prepare(self, dataframe):
-        """Transform raw indirect node audit data, adding managed_node_type tag.
+        """Transform raw indirect node audit data for deduplication.
 
-        Injects managed_node_type = INDIRECT constant to tag all records as
-        indirectly-managed nodes for downstream billing/rollup processing.
+        Extracts unique host_remote_ids for daily deduplication and billing count.
 
-        Returns JSON-serializable dictionary for storage in HourlyMetricsCollection.
+        Returns JSON-serializable dictionary with deduplicated host IDs and total count.
         """
         dataframe = self._convert_id_columns_to_strings(dataframe)
 
         if dataframe.empty:
-            return {}
+            return {
+                'indirect_node_ids': [],
+                'indirect_nodes_total': 0,
+            }
 
-        dataframe['managed_node_type'] = INDIRECT
+        # Extract unique host_remote_ids for deduplication
+        if 'host_remote_id' in dataframe.columns:
+            indirect_node_ids = sorted(set(dataframe['host_remote_id'].dropna()))
+        else:
+            indirect_node_ids = []
 
-        # Convert DataFrame to dict and handle datetime serialization
-        records = dataframe.to_dict(orient='records')
+        return sanitize_json(
+            {
+                'indirect_node_ids': indirect_node_ids,
+                'indirect_nodes_total': len(indirect_node_ids),
+            }
+        )
 
-        # Convert pandas Timestamp objects to ISO format strings
-        for record in records:
-            for key, value in record.items():
-                if pd.isna(value):
-                    record[key] = None
-                elif hasattr(value, 'isoformat'):
-                    record[key] = value.isoformat()
+    def merge(self, data_all, data_new):
+        """Merge two indirect node rollups by deduplicating host IDs.
 
-        return sanitize_json(records)
+        Combines indirect_node_ids from multiple hourly collections,
+        maintaining uniqueness for accurate daily billing counts.
+
+        Args:
+            data_all: Accumulated data from previous merges (or None for first merge)
+            data_new: New data to merge in
+
+        Returns:
+            Merged dictionary with deduplicated indirect_node_ids and updated total
+        """
+        if data_all is None:
+            return data_new
+
+        # Merge and deduplicate indirect_node_ids
+        ids_all = set(data_all.get('indirect_node_ids', []))
+        ids_new = set(data_new.get('indirect_node_ids', []))
+        indirect_node_ids = sorted(ids_all.union(ids_new))
+
+        return {
+            'indirect_node_ids': indirect_node_ids,
+            'indirect_nodes_total': len(indirect_node_ids),
+        }

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -39,6 +39,19 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
             }
         )
 
+    def base(self, data):
+        """Return final rollup payload with count only (no host IDs for privacy).
+
+        Args:
+            data: Accumulated dict from merge() calls, or None if no data.
+
+        Returns:
+            Dict with 'json' key containing the final rollup data.
+        """
+        if data is None:
+            return {'json': {'indirect_nodes_total': 0}}
+        return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
+
     def merge(self, data_all, data_new):
         """Merge two indirect node rollups by deduplicating host IDs.
 

--- a/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/anonymized_rollups/indirect_managed_nodes_anonymized_rollup.py
@@ -53,27 +53,16 @@ class IndirectManagedNodesAnonymizedRollup(BaseAnonymizedRollup):
         return {'json': {'indirect_nodes_total': data.get('indirect_nodes_total', 0)}}
 
     def merge(self, data_all, data_new):
-        """Merge two indirect node rollups by deduplicating host IDs.
+        """Pass through the snapshot batch unchanged.
 
-        Combines indirect_node_ids from multiple hourly collections,
-        maintaining uniqueness for accurate daily billing counts.
+        With a daily snapshot collector there is only one batch per day,
+        so cross-batch merging is not needed.
 
         Args:
-            data_all: Accumulated data from previous merges (or None for first merge)
-            data_new: New data to merge in
+            data_all: Unused (always None for snapshot collectors)
+            data_new: Prepared data from the single snapshot batch
 
         Returns:
-            Merged dictionary with deduplicated indirect_node_ids and updated total
+            data_new unchanged
         """
-        if data_all is None:
-            return data_new
-
-        # Merge and deduplicate indirect_node_ids
-        ids_all = set(data_all.get('indirect_node_ids', []))
-        ids_new = set(data_new.get('indirect_node_ids', []))
-        indirect_node_ids = sorted(ids_all.union(ids_new))
-
-        return {
-            'indirect_node_ids': indirect_node_ids,
-            'indirect_nodes_total': len(indirect_node_ids),
-        }
+        return data_new

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -138,14 +138,14 @@ def cli_main_host_daily(since, until, output):
     return output.as_files(collector)
 
 
-@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=daily_slicing)
+@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=until_slicing)
 def cli_main_indirectmanagednodeaudit(since, until, output):
     if 'main_indirectmanagednodeaudit' not in get_optional_collectors():
         return None
 
     # the table does not exist in 2.4, may be 2.6+
     try:
-        collector = main_indirectmanagednodeaudit(db=connection, since=since, until=until)
+        collector = main_indirectmanagednodeaudit(db=connection)
         return output.as_files(collector)
     except (ProgrammingError, UndefinedTable) as e:
         logger.warning(

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -138,14 +138,14 @@ def cli_main_host_daily(since, until, output):
     return output.as_files(collector)
 
 
-@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=until_slicing)
+@register('main_indirectmanagednodeaudit', '1.0', format='csv', fnc_slicing=daily_slicing)
 def cli_main_indirectmanagednodeaudit(since, until, output):
     if 'main_indirectmanagednodeaudit' not in get_optional_collectors():
         return None
 
     # the table does not exist in 2.4, may be 2.6+
     try:
-        collector = main_indirectmanagednodeaudit(db=connection)
+        collector = main_indirectmanagednodeaudit(db=connection, since=since, until=until)
         return output.as_files(collector)
     except (ProgrammingError, UndefinedTable) as e:
         logger.warning(

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -5,12 +5,16 @@ from ..util import DataframeOutput, collector, date_where
 
 @collector
 def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
-    """Collect indirect managed node audit records for jobs finished in the time window.
+    """Collect indirect managed node audit records.
+
+    When since and until are omitted the query returns all records (full-table
+    snapshot). Pass since/until to restrict results to a specific time window
+    based on the related job's finished timestamp.
 
     Args:
         db: Django database connection.
-        since: Inclusive start datetime for the job ``finished`` filter.
-        until: Exclusive end datetime for the job ``finished`` filter.
+        since: Optional inclusive start datetime for the job ``finished`` filter.
+        until: Optional exclusive end datetime for the job ``finished`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -48,6 +48,7 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=Dat
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
         WHERE
             {date_where('main_unifiedjob.finished', since, until)}
+        ORDER BY main_indirectmanagednodeaudit.created ASC
     """
 
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,9 +1,20 @@
-from ..util import DataframeOutput, collector, date_where
+"""Collector for indirect managed node audit records from the Controller database."""
+
+from ..util import DataframeOutput, collector
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
-    query = f"""
+def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
+    """Collect all indirect managed node audit records (full-table snapshot).
+
+    Args:
+        db: Django database connection.
+        output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
+
+    Returns:
+        pandas DataFrame with indirect node audit fields, or list of CSV paths.
+    """
+    query = """
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -29,8 +40,6 @@ def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=Dat
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
-        WHERE {date_where('main_indirectmanagednodeaudit.created', since, until)}
-        ORDER BY main_indirectmanagednodeaudit.created ASC
     """
 
     return output.sql(db, query)

--- a/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
+++ b/metrics_utility/library/collectors/controller/main_indirectmanagednodeaudit.py
@@ -1,20 +1,22 @@
 """Collector for indirect managed node audit records from the Controller database."""
 
-from ..util import DataframeOutput, collector
+from ..util import DataframeOutput, collector, date_where
 
 
 @collector
-def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
-    """Collect all indirect managed node audit records (full-table snapshot).
+def main_indirectmanagednodeaudit(*, db=None, since=None, until=None, output=DataframeOutput()):
+    """Collect indirect managed node audit records for jobs finished in the time window.
 
     Args:
         db: Django database connection.
+        since: Inclusive start datetime for the job ``finished`` filter.
+        until: Exclusive end datetime for the job ``finished`` filter.
         output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
 
     Returns:
         pandas DataFrame with indirect node audit fields, or list of CSV paths.
     """
-    query = """
+    query = f"""
         SELECT
             main_indirectmanagednodeaudit.id,
             main_indirectmanagednodeaudit.created as created,
@@ -40,6 +42,8 @@ def main_indirectmanagednodeaudit(*, db=None, output=DataframeOutput()):
         LEFT JOIN main_inventory ON main_inventory.id = main_indirectmanagednodeaudit.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
         LEFT JOIN main_unifiedjobtemplate AS main_unifiedjobtemplate_project ON main_unifiedjobtemplate_project.id = main_job.project_id
+        WHERE
+            {date_where('main_unifiedjob.finished', since, until)}
     """
 
     return output.sql(db, query)

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -14,13 +14,11 @@ def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
-    assert instance.kwargs['since'] == SINCE
-    assert instance.kwargs['until'] == UNTIL
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -29,7 +27,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -41,12 +39,12 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
-    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
+def test_main_indirectmanagednodeaudit_query_columns_and_joins(mock_copy_pandas):
+    """Test that the SQL query selects all expected columns and joins."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -63,18 +61,14 @@ def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
     assert 'events' in query
     assert 'task_runs' in query
 
-    assert 'main_unifiedjob.finished' in query
-    assert '>=' in query
-    assert '<' in query
-
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas):
-    """Test that passing since=None, until=None produces WHERE true (no filtering)."""
+    """Test that omitting since/until produces WHERE true (full-table scan)."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=None, until=None)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -82,6 +76,23 @@ def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas
 
     assert 'WHERE' in query
     assert 'true' in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
+    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance.gather()
+
+    call_args = mock_copy_pandas.call_args
+    query = call_args[0][1]
+
+    assert 'main_unifiedjob.finished' in query
+    assert '>=' in query
+    assert '<' in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -114,7 +125,7 @@ def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)
@@ -155,7 +166,7 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -1,5 +1,3 @@
-import datetime
-
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -10,27 +8,21 @@ from metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit
 def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
-    assert instance.kwargs['since'] == since
-    assert instance.kwargs['until'] == until
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     """Test that main_indirectmanagednodeaudit calls copy_table."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -42,35 +34,12 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_contains_time_range(mock_copy_pandas):
-    """Test that the query includes the time range."""
-    mock_db = MagicMock()
-    since = datetime.datetime(2024, 3, 15, 10, 30, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 3, 16, 18, 45, tzinfo=datetime.timezone.utc)
-    mock_copy_pandas.return_value = pd.DataFrame()
-
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
-    instance.gather()
-
-    call_args = mock_copy_pandas.call_args
-    query = call_args[0][1]
-
-    # Query should contain time boundaries using created field
-    assert '2024-03-15' in query
-    assert '2024-03-16' in query
-    assert 'main_indirectmanagednodeaudit.created >=' in query
-    assert 'main_indirectmanagednodeaudit.created <' in query
-
-
-@patch('metrics_utility.library.collectors.util._copy_table_pandas')
 def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
-    """Test that the SQL query has expected structure."""
+    """Test that the SQL query has expected structure and no date filter."""
     mock_db = MagicMock()
-    since = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-    until = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db, since=since, until=until)
+    instance = main_indirectmanagednodeaudit(db=mock_db)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
@@ -88,3 +57,7 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
     assert 'facts' in query
     assert 'events' in query
     assert 'task_runs' in query or 'count' in query
+
+    # Snapshot collector: no date range filter on created
+    assert 'main_indirectmanagednodeaudit.created >=' not in query
+    assert 'main_indirectmanagednodeaudit.created <' not in query

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -56,8 +56,90 @@ def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
     assert 'canonical_facts' in query
     assert 'facts' in query
     assert 'events' in query
-    assert 'task_runs' in query or 'count' in query
+    assert 'task_runs' in query
 
     # Snapshot collector: no date range filter on created
     assert 'main_indirectmanagednodeaudit.created >=' not in query
     assert 'main_indirectmanagednodeaudit.created <' not in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
+    """Records with NULL job_id, inventory_id, or organization_id are returned without error.
+
+    The LEFT JOINs produce NULL for the joined columns; the collector does not filter or raise.
+    """
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame(
+        {
+            'id': [1],
+            'created': [None],
+            'host_name': ['device-01'],
+            'host_remote_id': ['host-abc-1'],
+            'canonical_facts': ['{"fqdn": "device-01.example.com"}'],
+            'facts': ['{}'],
+            'events': ['[]'],
+            'task_runs': [3],
+            'job_created': [None],
+            'job_remote_id': [None],
+            'job_template_remote_id': [None],
+            'job_template_name': [None],
+            'inventory_remote_id': [None],
+            'inventory_name': [None],
+            'organization_remote_id': [None],
+            'organization_name': [None],
+            'project_remote_id': [None],
+            'project_name': [None],
+        }
+    )
+
+    instance = main_indirectmanagednodeaudit(db=mock_db)
+    result = instance.gather()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert result['job_remote_id'].iloc[0] is None or pd.isna(result['job_remote_id'].iloc[0])
+    assert result['inventory_remote_id'].iloc[0] is None or pd.isna(result['inventory_remote_id'].iloc[0])
+    assert result['organization_remote_id'].iloc[0] is None or pd.isna(result['organization_remote_id'].iloc[0])
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
+    """Records referencing a deleted job, inventory, or organization are returned without error.
+
+    A deleted foreign key produces the same NULL join result as a missing FK value;
+    the collector returns the row without filtering or raising.
+    """
+    mock_db = MagicMock()
+    # job_id=999 exists in the audit table but the referenced job was deleted;
+    # LEFT JOIN produces NULL for all job/org/project columns.
+    mock_copy_pandas.return_value = pd.DataFrame(
+        {
+            'id': [2],
+            'created': [None],
+            'host_name': ['orphaned-device'],
+            'host_remote_id': ['host-abc-2'],
+            'canonical_facts': ['{}'],
+            'facts': ['{}'],
+            'events': ['[]'],
+            'task_runs': [1],
+            'job_created': [None],
+            'job_remote_id': [999],
+            'job_template_remote_id': [None],
+            'job_template_name': [None],
+            'inventory_remote_id': [None],
+            'inventory_name': [None],
+            'organization_remote_id': [None],
+            'organization_name': [None],
+            'project_remote_id': [None],
+            'project_name': [None],
+        }
+    )
+
+    instance = main_indirectmanagednodeaudit(db=mock_db)
+    result = instance.gather()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert result['job_remote_id'].iloc[0] == 999
+    assert result['organization_remote_id'].iloc[0] is None or pd.isna(result['organization_remote_id'].iloc[0])

--- a/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
+++ b/metrics_utility/test/library/test_collectors_main_indirectmanagednodeaudit.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -5,15 +6,21 @@ import pandas as pd
 from metrics_utility.library.collectors.controller.main_indirectmanagednodeaudit import main_indirectmanagednodeaudit
 
 
+SINCE = datetime(2025, 6, 13, 0, 0, 0, tzinfo=timezone.utc)
+UNTIL = datetime(2025, 6, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+
 def test_main_indirectmanagednodeaudit_basic():
     """Test main_indirectmanagednodeaudit collector basic functionality."""
     mock_db = MagicMock()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
 
     assert hasattr(instance, 'gather')
     assert hasattr(instance, 'kwargs')
     assert instance.kwargs['db'] == mock_db
+    assert instance.kwargs['since'] == SINCE
+    assert instance.kwargs['until'] == UNTIL
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -22,7 +29,7 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame({'id': [1, 2], 'canonical_facts': ['{}', '{}']})
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     mock_copy_pandas.assert_called_once()
@@ -34,33 +41,47 @@ def test_main_indirectmanagednodeaudit_calls_copy_table(mock_copy_pandas):
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
-def test_main_indirectmanagednodeaudit_query_structure(mock_copy_pandas):
-    """Test that the SQL query has expected structure and no date filter."""
+def test_main_indirectmanagednodeaudit_query_has_date_filter(mock_copy_pandas):
+    """Test that the SQL query filters by main_unifiedjob.finished when since/until are provided."""
     mock_db = MagicMock()
     mock_copy_pandas.return_value = pd.DataFrame()
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     instance.gather()
 
     call_args = mock_copy_pandas.call_args
     query = call_args[0][1]
 
-    # Should query expected tables
     assert 'main_indirectmanagednodeaudit' in query
     assert 'main_job' in query
     assert 'main_unifiedjob' in query
     assert 'main_inventory' in query
     assert 'main_organization' in query
 
-    # Should have expected columns
     assert 'canonical_facts' in query
     assert 'facts' in query
     assert 'events' in query
     assert 'task_runs' in query
 
-    # Snapshot collector: no date range filter on created
-    assert 'main_indirectmanagednodeaudit.created >=' not in query
-    assert 'main_indirectmanagednodeaudit.created <' not in query
+    assert 'main_unifiedjob.finished' in query
+    assert '>=' in query
+    assert '<' in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_indirectmanagednodeaudit_no_date_filter_when_none(mock_copy_pandas):
+    """Test that passing since=None, until=None produces WHERE true (no filtering)."""
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=None, until=None)
+    instance.gather()
+
+    call_args = mock_copy_pandas.call_args
+    query = call_args[0][1]
+
+    assert 'WHERE' in query
+    assert 'true' in query
 
 
 @patch('metrics_utility.library.collectors.util._copy_table_pandas')
@@ -93,7 +114,7 @@ def test_main_indirectmanagednodeaudit_null_join_references(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)
@@ -111,8 +132,6 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
     the collector returns the row without filtering or raising.
     """
     mock_db = MagicMock()
-    # job_id=999 exists in the audit table but the referenced job was deleted;
-    # LEFT JOIN produces NULL for all job/org/project columns.
     mock_copy_pandas.return_value = pd.DataFrame(
         {
             'id': [2],
@@ -136,7 +155,7 @@ def test_main_indirectmanagednodeaudit_orphaned_records(mock_copy_pandas):
         }
     )
 
-    instance = main_indirectmanagednodeaudit(db=mock_db)
+    instance = main_indirectmanagednodeaudit(db=mock_db, since=SINCE, until=UNTIL)
     result = instance.gather()
 
     assert isinstance(result, pd.DataFrame)

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all.py
@@ -233,7 +233,7 @@ def test_all_jobs_combined(cleanup_test_data):
     input_data = create_all_csv_files(data_dir, all_jobs, all_events, all_jobhostsummary)
 
     # Run the anonymized rollup computation
-    result = compute_anonymized_rollup_from_raw_data(input_data=input_data, salt='test_salt')
+    result = compute_anonymized_rollup_from_raw_data(input_data=input_data)
 
     # Save result and split into chunks
     save_result_and_chunks(result, since, until, year, month, day)
@@ -441,7 +441,7 @@ def validate_module_stats(result):
     """Validate module statistics."""
     module_stats = result['module_stats']
     assert isinstance(module_stats, list)
-    assert len(module_stats) == 6
+    assert len(module_stats) == 5
     assert result['statistics']['rollup_period_modules_total'] == 6
 
     required_fields = [
@@ -466,7 +466,7 @@ def validate_collection_stats(result):
     """Validate collection statistics."""
     collection_stats = result['collection_stats']
     assert isinstance(collection_stats, list)
-    assert len(collection_stats) == 3
+    assert len(collection_stats) == 2
 
     required_fields = [
         'collection_name',

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_all_no_events.py
@@ -230,7 +230,7 @@ def test_all_jobs_combined_no_events(cleanup_test_data):
     input_data = create_all_csv_files(data_dir, all_jobs, all_events, all_jobhostsummary)
 
     # Run the anonymized rollup computation
-    result = compute_anonymized_rollup_from_raw_data(input_data=input_data, salt='test_salt')
+    result = compute_anonymized_rollup_from_raw_data(input_data=input_data)
 
     # Save result and split into chunks
     save_result_and_chunks(result, since, until, year, month, day)

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job1.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job1.py
@@ -59,7 +59,6 @@ def test_big_test1():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job2.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job2.py
@@ -59,7 +59,6 @@ def test_big_test2():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job3.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job3.py
@@ -59,7 +59,6 @@ def test_big_test3():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job4.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job4.py
@@ -59,7 +59,6 @@ def test_big_test4():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job5.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job5.py
@@ -59,7 +59,6 @@ def test_big_test5():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job6.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job6.py
@@ -59,7 +59,6 @@ def test_big_test6():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job7.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job7.py
@@ -59,7 +59,6 @@ def test_big_test7():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job8.py
+++ b/metrics_utility/test/test_anonymized_rollups/big_test1/test_big_test_job8.py
@@ -59,7 +59,6 @@ def test_big_test8():
         # Compute anonymized rollups
         result = compute_anonymized_rollup_from_raw_data(
             input_data=input_data,
-            salt='test_salt',
         )
 
         # Verify job_host_summary rollup

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -21,6 +21,7 @@ from metrics_utility.anonymized_rollups.events_modules_anonymized_rollup import 
 from metrics_utility.anonymized_rollups.execution_environments_anonymized_rollup import ExecutionEnvironmentsAnonymizedRollup
 from metrics_utility.anonymized_rollups.feature_flags_anonymized_rollup import FeatureFlagsAnonymizedRollup
 from metrics_utility.anonymized_rollups.helpers import sanitize_json
+from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import IndirectManagedNodesAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobhostsummary_anonymized_rollup import JobHostSummaryAnonymizedRollup
 from metrics_utility.anonymized_rollups.jobs_anonymized_rollup import JobsAnonymizedRollup
 from metrics_utility.anonymized_rollups.table_metadata_anonymized_rollup import TableMetadataAnonymizedRollup
@@ -31,6 +32,7 @@ from metrics_utility.library.collectors.controller import (
     execution_environments,
     feature_flags_service,
     job_host_summary_service,
+    main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
     unified_jobs,
@@ -120,6 +122,9 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt):
     task_executions = load_anonymized_rollup_data(TaskExecutionsAnonymizedRollup(), input_data.get('task_executions', []))
     task_executions_result = TaskExecutionsAnonymizedRollup().base(task_executions)
 
+    indirect_managed_nodes = load_anonymized_rollup_data(IndirectManagedNodesAnonymizedRollup(), input_data.get('indirect_managed_nodes', []))
+    indirect_managed_nodes_result = IndirectManagedNodesAnonymizedRollup().base(indirect_managed_nodes)
+
     anonymized_rollup = anonymize_rollups(
         events_modules_rollup=events_modules_result['json'],
         execution_environments_rollup=execution_environments_result['json'],
@@ -131,6 +136,7 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt):
         feature_flags_rollup=feature_flags_result['json'],
         salt=salt,
         task_executions_rollup=task_executions_result['json'],
+        indirect_managed_nodes_rollup=indirect_managed_nodes_result['json'],
     )
     # Sanitize the result to replace NaN and infinity values with None (valid JSON)
     anonymized_rollup = sanitize_json(anonymized_rollup)
@@ -200,6 +206,12 @@ def compute_anonymized_rollup(db, salt, since, until, service_db=None):
         except Exception as e:
             logger.error(f'Failed to gather task_executions data: {e}')
 
+    indirect_managed_nodes_data = []
+    try:
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
+    except Exception as e:
+        logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
+
     input_data = {
         'execution_environments': execution_environments_data,
         'unified_jobs': unified_jobs_data,
@@ -210,6 +222,7 @@ def compute_anonymized_rollup(db, salt, since, until, service_db=None):
         'controller_version': controller_version_data,
         'feature_flags': feature_flags_data,
         'task_executions': task_executions_data,
+        'indirect_managed_nodes': indirect_managed_nodes_data,
     }
 
     # load data for each collector

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -208,7 +208,7 @@ def compute_anonymized_rollup(db, salt, since, until, service_db=None):
 
     indirect_managed_nodes_data = []
     try:
-        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db).gather()
     except Exception as e:
         logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
 

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -208,7 +208,7 @@ def compute_anonymized_rollup(db, salt, since, until, service_db=None):
 
     indirect_managed_nodes_data = []
     try:
-        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db).gather()
+        indirect_managed_nodes_data = main_indirectmanagednodeaudit(db=db, since=since, until=until).gather()
     except Exception as e:
         logger.error(f'Failed to gather indirect_managed_nodes data: {e}')
 

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -89,7 +89,7 @@ def load_anonymized_rollup_data(rollup_object: BaseAnonymizedRollup, dataframe_l
     return concat_data
 
 
-def compute_anonymized_rollup_from_raw_data(input_data, salt):
+def compute_anonymized_rollup_from_raw_data(input_data):
 
     # delete everything in the directory ./out/batches (including subdirectories)
     if os.path.exists(OUT_BATCHES_DIR):
@@ -134,7 +134,6 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt):
         table_metadata_rollup=table_metadata_result['json'],
         controller_version_rollup=controller_version_result['json'],
         feature_flags_rollup=feature_flags_result['json'],
-        salt=salt,
         task_executions_rollup=task_executions_result['json'],
         indirect_managed_nodes_rollup=indirect_managed_nodes_result['json'],
     )
@@ -149,7 +148,7 @@ def compute_anonymized_rollup_from_raw_data(input_data, salt):
     return anonymized_rollup
 
 
-def compute_anonymized_rollup(db, salt, since, until, service_db=None):
+def compute_anonymized_rollup(db, since, until, service_db=None):
     # This will contain list of files that belongs to particular collector
     execution_environments_data = []
     try:
@@ -226,6 +225,6 @@ def compute_anonymized_rollup(db, salt, since, until, service_db=None):
     }
 
     # load data for each collector
-    json_data = compute_anonymized_rollup_from_raw_data(input_data, salt)
+    json_data = compute_anonymized_rollup_from_raw_data(input_data)
 
     return json_data

--- a/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
@@ -185,3 +185,58 @@ def test_inject_controller_version_no_versions_injects_none():
     jobs = [{'job_type': 'run'}]
     result = _inject_controller_version(jobs, [])
     assert result[0]['controller_version'] is None
+
+
+# ---------------------------------------------------------------------------
+# anonymize_data – indirect_nodes_by_collection / indirect_nodes_by_module
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_data_indirect_nodes_by_collection_removes_private():
+    """anonymize_data strips private collection names from indirect_nodes_by_collection."""
+    data = {
+        'indirect_nodes_by_collection': [
+            {'collection': 'cisco.ios', 'host_count': 5},
+            {'collection': 'acme.private_collection', 'host_count': 3},
+        ],
+    }
+    anonymize_data(data)
+    names = [e['collection'] for e in data['indirect_nodes_by_collection']]
+    assert 'cisco.ios' in names
+    assert 'acme.private_collection' not in names
+
+
+def test_anonymize_data_indirect_nodes_by_collection_removes_no_collection_sentinel():
+    """anonymize_data strips the _no_collection sentinel from indirect_nodes_by_collection."""
+    data = {
+        'indirect_nodes_by_collection': [
+            {'collection': '_no_collection', 'host_count': 2},
+        ],
+    }
+    anonymize_data(data)
+    assert data['indirect_nodes_by_collection'] == []
+
+
+def test_anonymize_data_indirect_nodes_by_module_removes_private():
+    """anonymize_data strips modules whose collection prefix is private from indirect_nodes_by_module."""
+    data = {
+        'indirect_nodes_by_module': [
+            {'module': 'cisco.ios.ios_command', 'host_count': 5},
+            {'module': 'acme.private_collection.some_module', 'host_count': 3},
+        ],
+    }
+    anonymize_data(data)
+    names = [e['module'] for e in data['indirect_nodes_by_module']]
+    assert 'cisco.ios.ios_command' in names
+    assert 'acme.private_collection.some_module' not in names
+
+
+def test_anonymize_data_indirect_nodes_by_module_removes_no_module_sentinel():
+    """anonymize_data strips the _no_module sentinel from indirect_nodes_by_module."""
+    data = {
+        'indirect_nodes_by_module': [
+            {'module': '_no_module', 'host_count': 2},
+        ],
+    }
+    anonymize_data(data)
+    assert data['indirect_nodes_by_module'] == []

--- a/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_anonymized_rollups_module.py
@@ -63,20 +63,20 @@ def test_create_anonymized_object_unknown_name_raises():
 
 def test_anonymize_data_none_returns_none():
     """anonymize_data should return immediately (no error) when data is None."""
-    result = anonymize_data(None, 'salt')
+    result = anonymize_data(None)
     assert result is None
 
 
 def test_anonymize_data_non_dict_returns_none():
     """anonymize_data should return immediately when data is not a dict."""
-    result = anonymize_data(['not', 'a', 'dict'], 'salt')
+    result = anonymize_data(['not', 'a', 'dict'])
     assert result is None
 
 
 def test_anonymize_data_empty_dict_does_not_raise():
     """anonymize_data with an empty dict should be a no-op."""
     data = {}
-    anonymize_data(data, 'salt')
+    anonymize_data(data)
     assert data == {}
 
 
@@ -107,12 +107,12 @@ def test_anonymize_data_known_collection_unchanged():
             }
         ],
     }
-    anonymize_data(data, 'salt')
+    anonymize_data(data)
     assert data['jobs_by_installed_collections_versions'][0]['collection'] == 'ansible.posix'
     assert data['jobs_by_installed_collections_versions'][0]['version'] == '1.5.0'
 
 
-def test_anonymize_data_empty_collection_name_becomes_custom():
+def test_anonymize_data_unknown_installed_collection_removed():
     data = {
         'jobs_by_installed_collections_versions': [
             {
@@ -122,13 +122,11 @@ def test_anonymize_data_empty_collection_name_becomes_custom():
             }
         ],
     }
-    anonymize_data(data, 'salt')
-    row = data['jobs_by_installed_collections_versions'][0]
-    assert row['collection'] == 'Custom'
-    assert row['version'] == 'Custom'
+    anonymize_data(data)
+    assert data['jobs_by_installed_collections_versions'] == []
 
 
-def test_anonymize_data_pd_na_collection_does_not_raise():
+def test_anonymize_data_pd_na_collection_removed():
     data = {
         'jobs_by_installed_collections_versions': [
             {
@@ -138,10 +136,8 @@ def test_anonymize_data_pd_na_collection_does_not_raise():
             }
         ],
     }
-    anonymize_data(data, 'salt')
-    row = data['jobs_by_installed_collections_versions'][0]
-    assert row['collection'] == 'Custom'
-    assert row['version'] == 'Custom'
+    anonymize_data(data)
+    assert data['jobs_by_installed_collections_versions'] == []
 
 
 # ---------------------------------------------------------------------------

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -14,6 +14,7 @@ from metrics_utility.library.collectors.controller import (
     execution_environments,
     feature_flags_service,
     job_host_summary_service,
+    main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
     unified_jobs,
@@ -54,6 +55,9 @@ def _validate_top_level_structure(json_data):
     assert 'controller_versions' in json_data, "Missing 'controller_versions' at top level"
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
+    assert 'indirect_managed_nodes' not in json_data, (
+        'indirect_managed_nodes IDs must not appear at the top level — only the count goes in statistics'
+    )
 
 
 def _validate_statistics_structure(statistics):
@@ -86,6 +90,7 @@ def _validate_statistics_structure(statistics):
         'rollup_period_task_skipped_total',
         'rollup_period_task_unreachable_total',
         'rollup_period_task_ignored_total',
+        'rollup_period_indirect_managed_nodes_all_total',
     ]
     for field in required_fields:
         assert field in statistics, f"Missing '{field}' in statistics"
@@ -920,6 +925,22 @@ def _save_json_output(json_data, since, until):
         json.dump(json_data, f, indent=4)
 
 
+def _validate_indirect_managed_nodes(json_data, statistics):
+    """Validate indirect managed node count and confirm IDs are not in the output."""
+    print('--- Validating indirect_managed_nodes data values ---')
+    assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
+        'rollup_period_indirect_managed_nodes_all_total should be an integer'
+    )
+    # 10:00h window: host_ids 1, 2 (2 unique)
+    # 11:00h window: host_ids 2, 3 (2 is a duplicate, 3 is new)
+    # Unique across both windows: 1, 2, 3 = 3
+    assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
+        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated across windows), '
+        f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
+    )
+    assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
+
+
 def _validate_all_data(json_data, statistics):
     """Run all validation checks on the json_data."""
     # Validate structure
@@ -971,6 +992,7 @@ def _validate_all_data(json_data, statistics):
     _validate_controller_versions(json_data)
     _validate_jobs_by_controller_version(json_data, statistics)
     _validate_feature_flags(json_data)
+    _validate_indirect_managed_nodes(json_data, statistics)
 
     print('✅ All data value assertions passed!')
 
@@ -1014,6 +1036,10 @@ def test_from_gather_to_json(cleanup_glob):
             'func': feature_flags_service,
             'needs_since_until': False,  # snapshot collector
         },
+        'main_indirectmanagednodeaudit': {
+            'func': main_indirectmanagednodeaudit,
+            'needs_since_until': True,
+        },
     }
 
     # Define two hourly intervals: 10:00-11:00 and 11:00-12:00
@@ -1032,6 +1058,7 @@ def test_from_gather_to_json(cleanup_glob):
         'table_metadata': 'table_metadata',
         'controller_version_service': 'controller_version',
         'feature_flags_service': 'feature_flags',
+        'main_indirectmanagednodeaudit': 'indirect_managed_nodes',
     }
 
     # Collect data from all collectors

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -56,6 +56,7 @@ def _validate_top_level_structure(json_data):
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
     assert 'indirect_nodes_by_collection' in json_data, "Missing 'indirect_nodes_by_collection' at top level"
+    assert 'indirect_nodes_by_module' in json_data, "Missing 'indirect_nodes_by_module' at top level"
     assert 'indirect_managed_nodes' not in json_data, 'indirect_managed_nodes raw data must not appear at the top level'
 
 
@@ -947,6 +948,15 @@ def _validate_indirect_managed_nodes(json_data, statistics):
         assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
         assert 'collection_name' in group
         assert 'host_count' in group
+
+    by_m = json_data.get('indirect_nodes_by_module', [])
+    assert isinstance(by_m, list), 'indirect_nodes_by_module should be a list'
+
+    for entry in by_m:
+        assert 'host_names' not in entry, 'host_names must not appear in anonymized output (privacy)'
+        assert 'organization_name' not in entry, 'organization_name must not appear in anonymized output (privacy)'
+        assert 'module_name' in entry
+        assert 'host_count' in entry
 
 
 def _validate_all_data(json_data, statistics):

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -14,7 +14,6 @@ from metrics_utility.library.collectors.controller import (
     execution_environments,
     feature_flags_service,
     job_host_summary_service,
-    main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
     unified_jobs,
@@ -55,9 +54,6 @@ def _validate_top_level_structure(json_data):
     assert 'controller_versions' in json_data, "Missing 'controller_versions' at top level"
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
-    assert 'indirect_nodes_by_collection' in json_data, "Missing 'indirect_nodes_by_collection' at top level"
-    assert 'indirect_nodes_by_module' in json_data, "Missing 'indirect_nodes_by_module' at top level"
-    assert 'indirect_managed_nodes' not in json_data, 'indirect_managed_nodes raw data must not appear at the top level'
 
 
 def _validate_statistics_structure(statistics):
@@ -90,7 +86,6 @@ def _validate_statistics_structure(statistics):
         'rollup_period_task_skipped_total',
         'rollup_period_task_unreachable_total',
         'rollup_period_task_ignored_total',
-        'rollup_period_indirect_managed_nodes_all_total',
     ]
     for field in required_fields:
         assert field in statistics, f"Missing '{field}' in statistics"
@@ -240,21 +235,7 @@ def _validate_module_stats_values(json_data):
     module_stats_dict = {m['module_name']: m for m in json_data['module_stats']}
 
     anonymized_modules = [m for m in json_data['module_stats'] if m.get('collection_source') == 'Custom']
-    assert len(anonymized_modules) == 1, f'Should have 1 anonymized module (ansible.builtin.yum), got {len(anonymized_modules)}'
-    yum_module = anonymized_modules[0]
-    assert yum_module['jobs_total'] == 3, 'Should have 3 jobs using ansible.builtin.yum (anonymized)'
-    assert yum_module['unique_hosts_total'] == 2, 'Should have 2 hosts for ansible.builtin.yum (anonymized)'
-    assert yum_module['task_ok_total'] == 6, 'Should have 6 successful tasks for ansible.builtin.yum (3 jobs × 2 hosts)'
-    assert yum_module['task_ok_with_retries_total'] == 0, 'Should have 0 reruns for ansible.builtin.yum'
-    assert yum_module['task_failed_total'] == 0, 'Should have 0 failures for ansible.builtin.yum'
-    assert yum_module['processed_events_total'] == 6, 'Should have 6 processed events for ansible.builtin.yum (3 jobs × 2 hosts)'
-    assert 'ansible_versions' in yum_module, 'yum_module should have ansible_versions field'
-    assert isinstance(yum_module['ansible_versions'], list), 'ansible_versions should be a list'
-    assert len(yum_module['ansible_versions']) > 0, 'ansible_versions should not be empty'
-    for version in yum_module['ansible_versions']:
-        assert _is_valid_version(version), f'Version should contain numbers and dots, got {version}'
-    assert yum_module['module_name'] == 'Custom', f'Anonymized module name should be "Custom", got {yum_module["module_name"]}'
-    assert yum_module['collection_name'] == 'Custom', f'Anonymized collection name should be "Custom", got {yum_module.get("collection_name")}'
+    assert len(anonymized_modules) == 0, f'Should have 0 Custom modules (unknown collections removed by filter), got {len(anonymized_modules)}'
 
     a10_module = module_stats_dict.get('a10.acos_axapi.a10_slb_virtual_server')
     assert a10_module is not None, 'Should have a10.acos_axapi.a10_slb_virtual_server module'
@@ -290,21 +271,7 @@ def _validate_collection_stats_values(json_data):
     assert a10_collection['processed_events_total'] == 6, 'a10.acos_axapi collection should have 6 processed events (3 jobs × 2 hosts)'
 
     anonymized_collections = [c for c in json_data['collection_stats'] if c.get('collection_source') == 'Custom']
-    assert len(anonymized_collections) == 1, f'Should have 1 anonymized collection (ansible.builtin), got {len(anonymized_collections)}'
-    builtin_collection = anonymized_collections[0]
-    assert builtin_collection['collection_source'] == 'Custom', 'ansible.builtin collection should be Custom (not in collections.json)'
-    assert builtin_collection['jobs_total'] == 3, 'ansible.builtin collection should have 3 jobs'
-    assert 'ansible_versions' in builtin_collection, 'Each collection_stat should have ansible_versions field'
-    assert isinstance(builtin_collection['ansible_versions'], list), 'ansible_versions should be a list'
-    assert len(builtin_collection['ansible_versions']) > 0, 'ansible_versions should not be empty'
-    for version in builtin_collection['ansible_versions']:
-        assert _is_valid_version(version), f'Version should contain numbers and dots, got {version}'
-    assert builtin_collection['unique_hosts_total'] == 2, 'ansible.builtin collection should have 2 hosts'
-    assert builtin_collection['task_ok_total'] == 6, 'ansible.builtin collection should have 6 successful tasks'
-    assert builtin_collection['processed_events_total'] == 6, 'ansible.builtin collection should have 6 processed events (3 jobs × 2 hosts)'
-    assert builtin_collection['collection_name'] == 'Custom', (
-        f'Anonymized collection name should be "Custom", got {builtin_collection["collection_name"]}'
-    )
+    assert len(anonymized_collections) == 0, f'Should have 0 Custom collections (removed by filter), got {len(anonymized_collections)}'
 
 
 def _validate_role_stats(json_data):
@@ -330,10 +297,7 @@ def _validate_jobs_by_installed_collections_versions(json_data):
     assert isinstance(jobs_by_installed_collections_versions, list), 'jobs_by_installed_collections_versions should be a list'
     unknown_collections = [c for c in jobs_by_installed_collections_versions if c.get('collection') == 'Custom']
     known_collections = [c for c in jobs_by_installed_collections_versions if c.get('collection') != 'Custom']
-    assert len(unknown_collections) > 0, 'Should have at least one collection with "Custom" collection (ansible.builtin)'
-    for collection in unknown_collections:
-        assert collection['collection'] == 'Custom', f'Custom collection should have collection "Custom", got {collection.get("collection")}'
-        assert collection['version'] == 'Custom', f'Custom collection should have version "Custom", got {collection.get("version")}'
+    assert len(unknown_collections) == 0, f'Should have 0 Custom collections (removed by filter), got {len(unknown_collections)}'
     new_fields = [
         'jobs_never_started_total',
         'jobs_duration_total_seconds',
@@ -506,24 +470,7 @@ def _validate_module_stats_values_multi_hour(json_data):
     module_stats_dict = {m['module_name']: m for m in json_data['module_stats']}
 
     anonymized_modules = [m for m in json_data['module_stats'] if m.get('collection_source') == 'Custom']
-    assert len(anonymized_modules) == 1, f'Should have 1 anonymized module (ansible.builtin.yum), got {len(anonymized_modules)}'
-    yum_module = anonymized_modules[0]
-    # 6 jobs total (3 from 10:00 + 3 from 11:00)
-    assert yum_module['jobs_total'] == 6, 'Should have 6 jobs using ansible.builtin.yum (anonymized)'
-    assert yum_module['unique_hosts_total'] == 2, 'Should have 2 hosts for ansible.builtin.yum (anonymized)'
-    # 6 jobs × 2 hosts = 12 successful tasks
-    assert yum_module['task_ok_total'] == 12, 'Should have 12 successful tasks for ansible.builtin.yum (6 jobs × 2 hosts)'
-    assert yum_module['task_ok_with_retries_total'] == 0, 'Should have 0 reruns for ansible.builtin.yum'
-    assert yum_module['task_failed_total'] == 0, 'Should have 0 failures for ansible.builtin.yum'
-    # 6 jobs × 2 hosts = 12 processed events
-    assert yum_module['processed_events_total'] == 12, 'Should have 12 processed events for ansible.builtin.yum (6 jobs × 2 hosts)'
-    assert 'ansible_versions' in yum_module, 'yum_module should have ansible_versions field'
-    assert isinstance(yum_module['ansible_versions'], list), 'ansible_versions should be a list'
-    assert len(yum_module['ansible_versions']) > 0, 'ansible_versions should not be empty'
-    for version in yum_module['ansible_versions']:
-        assert _is_valid_version(version), f'Version should contain numbers and dots, got {version}'
-    assert yum_module['module_name'] == 'Custom', f'Anonymized module name should be "Custom", got {yum_module["module_name"]}'
-    assert yum_module['collection_name'] == 'Custom', f'Anonymized collection name should be "Custom", got {yum_module.get("collection_name")}'
+    assert len(anonymized_modules) == 0, f'Should have 0 Custom modules (unknown collections removed by filter), got {len(anonymized_modules)}'
 
     a10_module = module_stats_dict.get('a10.acos_axapi.a10_slb_virtual_server')
     assert a10_module is not None, 'Should have a10.acos_axapi.a10_slb_virtual_server module'
@@ -565,24 +512,7 @@ def _validate_collection_stats_values_multi_hour(json_data):
     assert a10_collection['processed_events_total'] == 12, 'a10.acos_axapi collection should have 12 processed events (6 jobs × 2 hosts)'
 
     anonymized_collections = [c for c in json_data['collection_stats'] if c.get('collection_source') == 'Custom']
-    assert len(anonymized_collections) == 1, f'Should have 1 anonymized collection (ansible.builtin), got {len(anonymized_collections)}'
-    builtin_collection = anonymized_collections[0]
-    assert builtin_collection['collection_source'] == 'Custom', 'ansible.builtin collection should be Custom (not in collections.json)'
-    # 6 jobs total
-    assert builtin_collection['jobs_total'] == 6, 'ansible.builtin collection should have 6 jobs'
-    assert 'ansible_versions' in builtin_collection, 'Each collection_stat should have ansible_versions field'
-    assert isinstance(builtin_collection['ansible_versions'], list), 'ansible_versions should be a list'
-    assert len(builtin_collection['ansible_versions']) > 0, 'ansible_versions should not be empty'
-    for version in builtin_collection['ansible_versions']:
-        assert _is_valid_version(version), f'Version should contain numbers and dots, got {version}'
-    assert builtin_collection['unique_hosts_total'] == 2, 'ansible.builtin collection should have 2 hosts'
-    # 6 jobs × 2 hosts = 12 successful tasks
-    assert builtin_collection['task_ok_total'] == 12, 'ansible.builtin collection should have 12 successful tasks'
-    # 6 jobs × 2 hosts = 12 processed events
-    assert builtin_collection['processed_events_total'] == 12, 'ansible.builtin collection should have 12 processed events (6 jobs × 2 hosts)'
-    assert builtin_collection['collection_name'] == 'Custom', (
-        f'Anonymized collection name should be "Custom", got {builtin_collection["collection_name"]}'
-    )
+    assert len(anonymized_collections) == 0, f'Should have 0 Custom collections (removed by filter), got {len(anonymized_collections)}'
 
 
 def _validate_jobs_by_launch_type_values(json_data):
@@ -925,40 +855,6 @@ def _save_json_output(json_data, since, until):
         json.dump(json_data, f, indent=4)
 
 
-def _validate_indirect_managed_nodes(json_data, statistics):
-    """Validate indirect managed node count and grouped output."""
-    print('--- Validating indirect_managed_nodes data values ---')
-    assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
-        'rollup_period_indirect_managed_nodes_all_total should be an integer'
-    )
-    # Daily collection of 4 records across 2 hourly intervals:
-    #   cisco-switch-01 -> cisco.ios (2 FQCNs)
-    #   cisco-switch-02 -> azure.azcollection, then cisco.ios in second interval
-    #   cisco-switch-03 -> azure.azcollection + cisco.ios (2 FQCNs)
-    # Total unique host_names: 3 (cisco-switch-01, -02, -03)
-    assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
-        f'Expected 3 unique indirect managed nodes (3 unique host_names), got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
-    )
-
-    by_c = json_data.get('indirect_nodes_by_collection', [])
-    assert isinstance(by_c, list), 'indirect_nodes_by_collection should be a list'
-
-    for group in by_c:
-        assert 'host_names' not in group, 'host_names must not appear in anonymized output (privacy)'
-        assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'collection' in group
-        assert 'host_count' in group
-
-    by_m = json_data.get('indirect_nodes_by_module', [])
-    assert isinstance(by_m, list), 'indirect_nodes_by_module should be a list'
-
-    for entry in by_m:
-        assert 'host_names' not in entry, 'host_names must not appear in anonymized output (privacy)'
-        assert 'organization_name' not in entry, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'module' in entry
-        assert 'host_count' in entry
-
-
 def _validate_all_data(json_data, statistics):
     """Run all validation checks on the json_data."""
     # Validate structure
@@ -1010,7 +906,6 @@ def _validate_all_data(json_data, statistics):
     _validate_controller_versions(json_data)
     _validate_jobs_by_controller_version(json_data, statistics)
     _validate_feature_flags(json_data)
-    _validate_indirect_managed_nodes(json_data, statistics)
 
     print('✅ All data value assertions passed!')
 
@@ -1054,10 +949,6 @@ def test_from_gather_to_json(cleanup_glob):
             'func': feature_flags_service,
             'needs_since_until': False,  # snapshot collector
         },
-        'main_indirectmanagednodeaudit': {
-            'func': main_indirectmanagednodeaudit,
-            'needs_since_until': True,
-        },
     }
 
     # Define two hourly intervals: 10:00-11:00 and 11:00-12:00
@@ -1076,7 +967,6 @@ def test_from_gather_to_json(cleanup_glob):
         'table_metadata': 'table_metadata',
         'controller_version_service': 'controller_version',
         'feature_flags_service': 'feature_flags',
-        'main_indirectmanagednodeaudit': 'indirect_managed_nodes',
     }
 
     # Collect data from all collectors
@@ -1086,9 +976,8 @@ def test_from_gather_to_json(cleanup_glob):
     input_data = _prepare_input_data(results, collector_to_input_key)
 
     # Compute anonymized rollup from raw data
-    salt = 'salt'
     print('Computing anonymized rollup from collected data...')
-    json_data = compute_anonymized_rollup_from_raw_data(input_data, salt)
+    json_data = compute_anonymized_rollup_from_raw_data(input_data)
     print('✓ Anonymized rollup computed successfully')
 
     # Save JSON output

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -931,11 +931,10 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
         'rollup_period_indirect_managed_nodes_all_total should be an integer'
     )
-    # 10:00h window: host_ids 1, 2 (2 unique)
-    # 11:00h window: host_ids 2, 3 (2 is a duplicate, 3 is new)
-    # Unique across both windows: 1, 2, 3 = 3
+    # Snapshot of full table: 4 records, host_ids 1, 2, 2, 3
+    # prepare() deduplicates within the snapshot to 3 unique host_ids (1, 2, 3)
     assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
-        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated across windows), '
+        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated in prepare()), '
         f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
     )
     assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
@@ -1038,7 +1037,7 @@ def test_from_gather_to_json(cleanup_glob):
         },
         'main_indirectmanagednodeaudit': {
             'func': main_indirectmanagednodeaudit,
-            'needs_since_until': True,
+            'needs_since_until': False,  # snapshot collector
         },
     }
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -55,9 +55,8 @@ def _validate_top_level_structure(json_data):
     assert 'controller_versions' in json_data, "Missing 'controller_versions' at top level"
     assert 'feature_flags' in json_data, "Missing 'feature_flags' at top level"
     assert 'observability_by_tasks' in json_data, "Missing 'observability_by_tasks' at top level"
-    assert 'indirect_managed_nodes' not in json_data, (
-        'indirect_managed_nodes IDs must not appear at the top level — only the count goes in statistics'
-    )
+    assert 'indirect_nodes_by_collection' in json_data, "Missing 'indirect_nodes_by_collection' at top level"
+    assert 'indirect_managed_nodes' not in json_data, 'indirect_managed_nodes raw data must not appear at the top level'
 
 
 def _validate_statistics_structure(statistics):
@@ -926,18 +925,28 @@ def _save_json_output(json_data, since, until):
 
 
 def _validate_indirect_managed_nodes(json_data, statistics):
-    """Validate indirect managed node count and confirm IDs are not in the output."""
+    """Validate indirect managed node count and grouped output."""
     print('--- Validating indirect_managed_nodes data values ---')
     assert isinstance(statistics['rollup_period_indirect_managed_nodes_all_total'], int), (
         'rollup_period_indirect_managed_nodes_all_total should be an integer'
     )
-    # Snapshot of full table: 4 records, host_ids 1, 2, 2, 3
-    # prepare() deduplicates within the snapshot to 3 unique host_ids (1, 2, 3)
+    # Daily collection of 4 records across 2 hourly intervals:
+    #   cisco-switch-01 -> cisco.ios (2 FQCNs)
+    #   cisco-switch-02 -> azure.azcollection, then cisco.ios in second interval
+    #   cisco-switch-03 -> azure.azcollection + cisco.ios (2 FQCNs)
+    # Total unique host_names: 3 (cisco-switch-01, -02, -03)
     assert statistics['rollup_period_indirect_managed_nodes_all_total'] == 3, (
-        f'Expected 3 unique indirect managed nodes (host_ids 1,2,3 deduplicated in prepare()), '
-        f'got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
+        f'Expected 3 unique indirect managed nodes (3 unique host_names), got {statistics["rollup_period_indirect_managed_nodes_all_total"]}'
     )
-    assert 'indirect_managed_nodes' not in json_data, 'Host IDs must not be included in the final JSON payload (privacy requirement)'
+
+    by_c = json_data.get('indirect_nodes_by_collection', [])
+    assert isinstance(by_c, list), 'indirect_nodes_by_collection should be a list'
+
+    for group in by_c:
+        assert 'host_names' not in group, 'host_names must not appear in anonymized output (privacy)'
+        assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
+        assert 'collection_name' in group
+        assert 'host_count' in group
 
 
 def _validate_all_data(json_data, statistics):
@@ -1037,7 +1046,7 @@ def test_from_gather_to_json(cleanup_glob):
         },
         'main_indirectmanagednodeaudit': {
             'func': main_indirectmanagednodeaudit,
-            'needs_since_until': False,  # snapshot collector
+            'needs_since_until': True,
         },
     }
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -946,7 +946,7 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     for group in by_c:
         assert 'host_names' not in group, 'host_names must not appear in anonymized output (privacy)'
         assert 'organization_name' not in group, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'collection_name' in group
+        assert 'collection' in group
         assert 'host_count' in group
 
     by_m = json_data.get('indirect_nodes_by_module', [])
@@ -955,7 +955,7 @@ def _validate_indirect_managed_nodes(json_data, statistics):
     for entry in by_m:
         assert 'host_names' not in entry, 'host_names must not appear in anonymized output (privacy)'
         assert 'organization_name' not in entry, 'organization_name must not appear in anonymized output (privacy)'
-        assert 'module_name' in entry
+        assert 'module' in entry
         assert 'host_count' in entry
 
 

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -146,7 +146,7 @@ def test_merge_unions_host_names():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -158,7 +158,7 @@ def test_merge_unions_host_names():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -181,7 +181,7 @@ def test_merge_with_none_data_all():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -202,7 +202,7 @@ def test_base_strips_pii():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -229,19 +229,19 @@ def test_base_collapses_orgs_into_collection_totals():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
             'OrgB||cisco.ios': {
                 'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2'],
                 'host_count': 1,
             },
             'OrgA||azure.azcollection': {
                 'organization_name': 'OrgA',
-                'collection_name': 'azure.azcollection',
+                'collection': 'azure.azcollection',
                 'host_names': ['host3'],
                 'host_count': 1,
             },
@@ -254,9 +254,9 @@ def test_base_collapses_orgs_into_collection_totals():
     assert result['json']['indirect_nodes_total'] == 3
     by_c = result['json']['by_collection']
     assert len(by_c) == 2
-    assert by_c[0]['collection_name'] == 'azure.azcollection'
+    assert by_c[0]['collection'] == 'azure.azcollection'
     assert by_c[0]['host_count'] == 1
-    assert by_c[1]['collection_name'] == 'cisco.ios'
+    assert by_c[1]['collection'] == 'cisco.ios'
     assert by_c[1]['host_count'] == 2
 
 
@@ -268,13 +268,13 @@ def test_base_deduplicates_hosts_across_orgs():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgB||cisco.ios': {
                 'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -285,7 +285,7 @@ def test_base_deduplicates_hosts_across_orgs():
     result = rollup.base(data)
 
     cisco_group = result['json']['by_collection'][0]
-    assert cisco_group['collection_name'] == 'cisco.ios'
+    assert cisco_group['collection'] == 'cisco.ios'
     assert cisco_group['host_count'] == 3
 
 
@@ -371,7 +371,7 @@ def test_merge_with_none_data_new():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -523,7 +523,7 @@ def test_merge_unions_module_group_host_names():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
@@ -536,7 +536,7 @@ def test_merge_unions_module_group_host_names():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -560,13 +560,13 @@ def test_base_produces_by_module():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgA||cisco.ios.ios_config': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_config',
+                'module': 'cisco.ios.ios_config',
                 'host_names': ['host3'],
                 'host_count': 1,
             },
@@ -578,8 +578,8 @@ def test_base_produces_by_module():
 
     by_module = result['json']['by_module']
     assert len(by_module) == 2
-    assert by_module[0] == {'module_name': 'cisco.ios.ios_command', 'host_count': 2}
-    assert by_module[1] == {'module_name': 'cisco.ios.ios_config', 'host_count': 1}
+    assert by_module[0] == {'module': 'cisco.ios.ios_command', 'host_count': 2}
+    assert by_module[1] == {'module': 'cisco.ios.ios_config', 'host_count': 1}
     for entry in by_module:
         assert 'host_names' not in entry
         assert 'organization_name' not in entry
@@ -594,13 +594,13 @@ def test_base_deduplicates_module_hosts_across_orgs():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1', 'host2'],
                 'host_count': 2,
             },
             'OrgB||cisco.ios.ios_command': {
                 'organization_name': 'OrgB',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host2', 'host3'],
                 'host_count': 2,
             },
@@ -612,11 +612,11 @@ def test_base_deduplicates_module_hosts_across_orgs():
 
     by_module = result['json']['by_module']
     assert len(by_module) == 1
-    assert by_module[0]['module_name'] == 'cisco.ios.ios_command'
+    assert by_module[0]['module'] == 'cisco.ios.ios_command'
     assert by_module[0]['host_count'] == 3
 
 
-def test_base_by_module_sorted_by_module_name():
+def test_base_by_module_sorted_by_module():
     """base() sorts by_module entries by module name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
@@ -625,13 +625,13 @@ def test_base_by_module_sorted_by_module_name():
         'module_groups': {
             'OrgA||cisco.ios.ios_config': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_config',
+                'module': 'cisco.ios.ios_config',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
             'OrgA||azure.azcollection.azure_rm_vm': {
                 'organization_name': 'OrgA',
-                'module_name': 'azure.azcollection.azure_rm_vm',
+                'module': 'azure.azcollection.azure_rm_vm',
                 'host_names': ['host2'],
                 'host_count': 1,
             },
@@ -641,7 +641,7 @@ def test_base_by_module_sorted_by_module_name():
 
     result = rollup.base(data)
 
-    names = [e['module_name'] for e in result['json']['by_module']]
+    names = [e['module'] for e in result['json']['by_module']]
     assert names == sorted(names)
 
 
@@ -653,7 +653,7 @@ def test_base_by_collection_unchanged_with_module_data():
         'groups': {
             'OrgA||cisco.ios': {
                 'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
+                'collection': 'cisco.ios',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -661,7 +661,7 @@ def test_base_by_collection_unchanged_with_module_data():
         'module_groups': {
             'OrgA||cisco.ios.ios_command': {
                 'organization_name': 'OrgA',
-                'module_name': 'cisco.ios.ios_command',
+                'module': 'cisco.ios.ios_command',
                 'host_names': ['host1'],
                 'host_count': 1,
             },
@@ -671,5 +671,5 @@ def test_base_by_collection_unchanged_with_module_data():
 
     result = rollup.base(data)
 
-    assert result['json']['by_collection'] == [{'collection_name': 'cisco.ios', 'host_count': 1}]
-    assert result['json']['by_module'] == [{'module_name': 'cisco.ios.ios_command', 'host_count': 1}]
+    assert result['json']['by_collection'] == [{'collection': 'cisco.ios', 'host_count': 1}]
+    assert result['json']['by_module'] == [{'module': 'cisco.ios.ios_command', 'host_count': 1}]

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -1,0 +1,109 @@
+from datetime import UTC, datetime
+
+import pandas as pd
+
+from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
+    IndirectManagedNodesAnonymizedRollup,
+)
+from metrics_utility.metric_utils import INDIRECT
+
+
+def test_prepare_adds_managed_node_type_tag():
+    """Test that prepare() adds managed_node_type = INDIRECT to all records."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        {
+            'id': [1, 2, 3],
+            'host_name': ['host1', 'host2', 'host3'],
+            'host_remote_id': ['remote1', 'remote2', 'remote3'],
+            'created': [datetime(2024, 1, 1, tzinfo=UTC)] * 3,
+        }
+    )
+
+    result = rollup.prepare(data)
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all('managed_node_type' in record for record in result)
+    assert all(record['managed_node_type'] == INDIRECT for record in result)
+
+
+def test_prepare_handles_empty_dataframe():
+    """Test that prepare() handles empty DataFrames gracefully."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    empty_data = pd.DataFrame()
+
+    result = rollup.prepare(empty_data)
+
+    assert result == {}
+
+
+def test_prepare_converts_timestamps_to_iso():
+    """Test that prepare() converts pandas Timestamp objects to ISO strings."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        {
+            'id': [1],
+            'created': [pd.Timestamp('2024-01-01 12:00:00', tz='UTC')],
+        }
+    )
+
+    result = rollup.prepare(data)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0]['created'], str)
+    assert result[0]['created'] == '2024-01-01T12:00:00+00:00'
+
+
+def test_prepare_handles_nan_values():
+    """Test that prepare() converts NaN values to None."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        {
+            'id': [1],
+            'host_name': ['host1'],
+            'optional_field': [pd.NA],
+        }
+    )
+
+    result = rollup.prepare(data)
+
+    assert isinstance(result, list)
+    assert result[0]['optional_field'] is None
+
+
+def test_prepare_converts_id_columns_to_strings():
+    """Test that _convert_id_columns_to_strings is called."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        {
+            'id': [1, 2],
+            'job_id': [100, 200],
+            'host_id': [10, 20],
+        }
+    )
+
+    result = rollup.prepare(data)
+
+    assert isinstance(result, list)
+    assert all(isinstance(record['id'], str) for record in result)
+    assert all(isinstance(record['job_id'], str) for record in result)
+    assert all(isinstance(record['host_id'], str) for record in result)
+
+
+def test_rollup_name():
+    """Test that rollup has correct name."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+    assert rollup.rollup_name == 'indirect_managed_nodes'
+
+
+def test_collector_names():
+    """Test that collector_names is set correctly."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+    assert rollup.collector_names == ['main_indirectmanagednodeaudit']

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -1,82 +1,272 @@
+import json
+
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
     IndirectManagedNodesAnonymizedRollup,
+    _extract_collection_names,
 )
 
 
-def test_prepare_extracts_unique_host_ids():
-    """Test that prepare() extracts and deduplicates host_remote_ids."""
+def _make_dataframe(rows):
+    """Build a DataFrame from a list of dicts with sensible defaults."""
+    defaults = {
+        'id': None,
+        'host_name': None,
+        'host_remote_id': None,
+        'organization_name': 'DefaultOrg',
+        'events': '[]',
+    }
+    filled = []
+    for i, row in enumerate(rows):
+        r = {**defaults, 'id': i + 1, **row}
+        filled.append(r)
+    return pd.DataFrame(filled)
+
+
+def test_prepare_groups_by_org_and_collection():
+    """prepare() groups hosts by organization and collection name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    data = pd.DataFrame(
-        {
-            'id': [1, 2, 3],
-            'host_name': ['host1', 'host2', 'host3'],
-            'host_remote_id': ['remote1', 'remote2', 'remote3'],
-        }
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+        ]
     )
 
     result = rollup.prepare(data)
 
-    assert isinstance(result, dict)
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
     assert result['indirect_nodes_total'] == 3
+    groups = result['groups']
+    assert 'OrgA||cisco.ios' in groups
+    assert 'OrgA||azure.azcollection' in groups
+    assert 'OrgB||cisco.ios' in groups
+    assert groups['OrgA||cisco.ios']['host_count'] == 1
+    assert groups['OrgA||azure.azcollection']['host_count'] == 1
+    assert groups['OrgB||cisco.ios']['host_count'] == 1
 
 
 def test_prepare_handles_empty_dataframe():
-    """Test that prepare() handles empty DataFrames gracefully."""
+    """prepare() handles empty DataFrames gracefully."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    empty_data = pd.DataFrame()
+    result = rollup.prepare(pd.DataFrame())
 
-    result = rollup.prepare(empty_data)
-
-    assert result == {'indirect_node_ids': [], 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
 
 
-def test_prepare_deduplicates_host_ids():
-    """Test that prepare() deduplicates duplicate host_remote_ids."""
+def test_prepare_deduplicates_hosts_within_group():
+    """prepare() deduplicates hosts that appear multiple times in the same group."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
-    data = pd.DataFrame(
-        {
-            'id': [1, 2, 3, 4],
-            'host_name': ['host1', 'host2', 'host1', 'host3'],
-            'host_remote_id': ['remote1', 'remote2', 'remote1', 'remote3'],
-        }
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_config"]'},
+        ]
     )
 
     result = rollup.prepare(data)
 
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
+    assert result['indirect_nodes_total'] == 1
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+    assert result['groups']['OrgA||cisco.ios']['host_names'] == ['host1']
+
+
+def test_prepare_handles_empty_events():
+    """prepare() handles rows with empty or null events arrays."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '[]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': None},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 2
+    no_collection_key = 'OrgA||_no_collection'
+    assert no_collection_key in result['groups']
+    assert result['groups'][no_collection_key]['host_count'] == 2
+
+
+def test_prepare_handles_multiple_collections_per_host():
+    """A host with events from multiple collections appears in each group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': json.dumps(['cisco.ios.ios_command', 'azure.azcollection.azure_rm_vm']),
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert 'OrgA||cisco.ios' in result['groups']
+    assert 'OrgA||azure.azcollection' in result['groups']
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+    assert result['groups']['OrgA||azure.azcollection']['host_count'] == 1
+
+
+def test_prepare_handles_events_as_list():
+    """prepare() handles events column already parsed as a Python list."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': ['cisco.ios.ios_command'],
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert 'OrgA||cisco.ios' in result['groups']
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
+
+
+def test_prepare_by_organizations_summary():
+    """prepare() includes by_organizations list with deduplicated host counts."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    by_orgs = result['by_organizations']
+    assert by_orgs == [
+        {'organization_name': 'OrgA', 'host_count': 1},
+        {'organization_name': 'OrgB', 'host_count': 1},
+    ]
+
+
+def test_prepare_by_collections_summary():
+    """prepare() includes by_collections list with deduplicated host counts."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    by_colls = result['by_collections']
+    assert by_colls == [
+        {'collection_name': 'azure.azcollection', 'host_count': 1},
+        {'collection_name': 'cisco.ios', 'host_count': 2},
+    ]
+
+
+def test_merge_includes_by_organizations_and_by_collections():
+    """merge() result includes by_organizations and by_collections summaries."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    data_new = {
+        'groups': {
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    assert result['by_organizations'] == [
+        {'organization_name': 'OrgA', 'host_count': 1},
+        {'organization_name': 'OrgB', 'host_count': 1},
+    ]
+    assert result['by_collections'] == [
+        {'collection_name': 'cisco.ios', 'host_count': 2},
+    ]
+
+
+def test_merge_unions_host_names():
+    """merge() unions host name sets across two batches."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    data_new = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    assert result['groups']['OrgA||cisco.ios']['host_count'] == 3
+    assert sorted(result['groups']['OrgA||cisco.ios']['host_names']) == ['host1', 'host2', 'host3']
     assert result['indirect_nodes_total'] == 3
 
 
-def test_prepare_handles_missing_host_remote_id():
-    """Test that prepare() handles DataFrames without host_remote_id column."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = pd.DataFrame(
-        {
-            'id': [1, 2],
-            'host_name': ['host1', 'host2'],
-        }
-    )
-
-    result = rollup.prepare(data)
-
-    assert result['indirect_node_ids'] == []
-    assert result['indirect_nodes_total'] == 0
-
-
-def test_merge_returns_data_new():
-    """Test that merge() passes through the snapshot batch unchanged."""
+def test_merge_with_none_data_all():
+    """merge(None, data_new) returns data_new unchanged."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data_new = {
-        'indirect_node_ids': ['remote1', 'remote2'],
-        'indirect_nodes_total': 2,
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
     }
 
     result = rollup.merge(None, data_new)
@@ -84,38 +274,210 @@ def test_merge_returns_data_new():
     assert result == data_new
 
 
-def test_base_returns_count_only_no_ids():
-    """Test that base() returns only the count, never host IDs."""
+def test_base_strips_pii():
+    """base() output does not contain host_names, organization_name, or by_organizations."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
-        'indirect_node_ids': ['remote1', 'remote2', 'remote3'],
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'by_organizations': [
+            {'organization_name': 'OrgA', 'host_count': 2},
+        ],
+        'by_collections': [
+            {'collection_name': 'cisco.ios', 'host_count': 2},
+        ],
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.base(data)
+
+    assert 'json' in result
+    output = result['json']
+    assert 'by_organizations' not in output
+    assert 'groups' not in output
+    assert 'host_names' not in output
+    for group in output['by_collection']:
+        assert 'host_names' not in group
+        assert 'organization_name' not in group
+
+
+def test_base_collapses_orgs_into_collection_totals():
+    """base() merges org-level groups into collection-level totals."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+            'OrgA||azure.azcollection': {
+                'organization_name': 'OrgA',
+                'collection_name': 'azure.azcollection',
+                'host_names': ['host3'],
+                'host_count': 1,
+            },
+        },
         'indirect_nodes_total': 3,
     }
 
     result = rollup.base(data)
 
-    assert result == {'json': {'indirect_nodes_total': 3}}
-    assert 'indirect_node_ids' not in result['json']
+    assert result['json']['indirect_nodes_total'] == 3
+    by_c = result['json']['by_collection']
+    assert len(by_c) == 2
+    assert by_c[0]['collection_name'] == 'azure.azcollection'
+    assert by_c[0]['host_count'] == 1
+    assert by_c[1]['collection_name'] == 'cisco.ios'
+    assert by_c[1]['host_count'] == 2
+
+
+def test_base_deduplicates_hosts_across_orgs():
+    """base() deduplicates hosts that appear under the same collection in different orgs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgB||cisco.ios': {
+                'organization_name': 'OrgB',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    cisco_group = result['json']['by_collection'][0]
+    assert cisco_group['collection_name'] == 'cisco.ios'
+    assert cisco_group['host_count'] == 3
 
 
 def test_base_handles_none():
-    """Test that base() returns zero count when no data."""
+    """base(None) returns zero count and empty array."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     result = rollup.base(None)
 
-    assert result == {'json': {'indirect_nodes_total': 0}}
-    assert 'indirect_node_ids' not in result['json']
+    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+
+
+def test_extract_collection_names_with_nan():
+    """_extract_collection_names returns empty set for NaN (float) input."""
+    assert _extract_collection_names(float('nan')) == set()
+
+
+def test_extract_collection_names_with_invalid_json():
+    """_extract_collection_names returns empty set for malformed JSON."""
+    assert _extract_collection_names('not valid json') == set()
+
+
+def test_extract_collection_names_with_unsupported_type():
+    """_extract_collection_names returns empty set for unsupported types."""
+    assert _extract_collection_names(42) == set()
+
+
+def test_extract_collection_names_skips_non_fqcn():
+    """_extract_collection_names skips entries that are not valid FQCNs."""
+    result = _extract_collection_names('["cisco.ios.ios_command", "builtin_module"]')
+    assert result == {'cisco.ios'}
+
+
+def test_prepare_skips_nan_host_name():
+    """prepare() skips rows where host_name is NaN."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+    data.loc[len(data)] = {
+        'id': 99,
+        'host_name': float('nan'),
+        'host_remote_id': None,
+        'organization_name': 'OrgA',
+        'events': '["cisco.ios.ios_config"]',
+    }
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert len(result['groups']) == 1
+
+
+def test_prepare_defaults_missing_organization_name():
+    """prepare() defaults to empty string when organization_name is missing."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = pd.DataFrame(
+        [
+            {
+                'id': 1,
+                'host_name': 'host1',
+                'host_remote_id': None,
+                'events': '["cisco.ios.ios_command"]',
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert '||cisco.ios' in result['groups']
+
+
+def test_merge_with_none_data_new():
+    """merge(data_all, None) returns data_all unchanged."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.merge(data_all, None)
+
+    assert result == data_all
 
 
 def test_rollup_name():
-    """Test that rollup has correct name."""
+    """Rollup has correct name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.rollup_name == 'indirect_managed_nodes'
 
 
 def test_collector_names():
-    """Test that collector_names is set correctly."""
+    """collector_names is set correctly."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.collector_names == ['main_indirectmanagednodeaudit']

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -1,15 +1,12 @@
-from datetime import UTC, datetime
-
 import pandas as pd
 
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
     IndirectManagedNodesAnonymizedRollup,
 )
-from metrics_utility.metric_utils import INDIRECT
 
 
-def test_prepare_adds_managed_node_type_tag():
-    """Test that prepare() adds managed_node_type = INDIRECT to all records."""
+def test_prepare_extracts_unique_host_ids():
+    """Test that prepare() extracts and deduplicates host_remote_ids."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = pd.DataFrame(
@@ -17,16 +14,14 @@ def test_prepare_adds_managed_node_type_tag():
             'id': [1, 2, 3],
             'host_name': ['host1', 'host2', 'host3'],
             'host_remote_id': ['remote1', 'remote2', 'remote3'],
-            'created': [datetime(2024, 1, 1, tzinfo=UTC)] * 3,
         }
     )
 
     result = rollup.prepare(data)
 
-    assert isinstance(result, list)
-    assert len(result) == 3
-    assert all('managed_node_type' in record for record in result)
-    assert all(record['managed_node_type'] == INDIRECT for record in result)
+    assert isinstance(result, dict)
+    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
+    assert result['indirect_nodes_total'] == 3
 
 
 def test_prepare_handles_empty_dataframe():
@@ -37,64 +32,76 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(empty_data)
 
-    assert result == {}
+    assert result == {'indirect_node_ids': [], 'indirect_nodes_total': 0}
 
 
-def test_prepare_converts_timestamps_to_iso():
-    """Test that prepare() converts pandas Timestamp objects to ISO strings."""
+def test_prepare_deduplicates_host_ids():
+    """Test that prepare() deduplicates duplicate host_remote_ids."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = pd.DataFrame(
         {
-            'id': [1],
-            'created': [pd.Timestamp('2024-01-01 12:00:00', tz='UTC')],
+            'id': [1, 2, 3, 4],
+            'host_name': ['host1', 'host2', 'host1', 'host3'],
+            'host_remote_id': ['remote1', 'remote2', 'remote1', 'remote3'],
         }
     )
 
     result = rollup.prepare(data)
 
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert isinstance(result[0]['created'], str)
-    assert result[0]['created'] == '2024-01-01T12:00:00+00:00'
+    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
+    assert result['indirect_nodes_total'] == 3
 
 
-def test_prepare_handles_nan_values():
-    """Test that prepare() converts NaN values to None."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = pd.DataFrame(
-        {
-            'id': [1],
-            'host_name': ['host1'],
-            'optional_field': [pd.NA],
-        }
-    )
-
-    result = rollup.prepare(data)
-
-    assert isinstance(result, list)
-    assert result[0]['optional_field'] is None
-
-
-def test_prepare_converts_id_columns_to_strings():
-    """Test that _convert_id_columns_to_strings is called."""
+def test_prepare_handles_missing_host_remote_id():
+    """Test that prepare() handles DataFrames without host_remote_id column."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = pd.DataFrame(
         {
             'id': [1, 2],
-            'job_id': [100, 200],
-            'host_id': [10, 20],
+            'host_name': ['host1', 'host2'],
         }
     )
 
     result = rollup.prepare(data)
 
-    assert isinstance(result, list)
-    assert all(isinstance(record['id'], str) for record in result)
-    assert all(isinstance(record['job_id'], str) for record in result)
-    assert all(isinstance(record['host_id'], str) for record in result)
+    assert result['indirect_node_ids'] == []
+    assert result['indirect_nodes_total'] == 0
+
+
+def test_merge_combines_host_ids():
+    """Test that merge() deduplicates host IDs across multiple hourly collections."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'indirect_node_ids': ['remote1', 'remote2'],
+        'indirect_nodes_total': 2,
+    }
+
+    data_new = {
+        'indirect_node_ids': ['remote2', 'remote3'],
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
+    assert result['indirect_nodes_total'] == 3
+
+
+def test_merge_handles_none():
+    """Test that merge() handles None for first merge."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_new = {
+        'indirect_node_ids': ['remote1', 'remote2'],
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(None, data_new)
+
+    assert result == data_new
 
 
 def test_rollup_name():

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -104,6 +104,31 @@ def test_merge_handles_none():
     assert result == data_new
 
 
+def test_base_returns_count_only_no_ids():
+    """Test that base() returns only the count, never host IDs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'indirect_node_ids': ['remote1', 'remote2', 'remote3'],
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    assert result == {'json': {'indirect_nodes_total': 3}}
+    assert 'indirect_node_ids' not in result['json']
+
+
+def test_base_handles_none():
+    """Test that base() returns zero count when no data."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    result = rollup.base(None)
+
+    assert result == {'json': {'indirect_nodes_total': 0}}
+    assert 'indirect_node_ids' not in result['json']
+
+
 def test_rollup_name():
     """Test that rollup has correct name."""
     rollup = IndirectManagedNodesAnonymizedRollup()

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -70,28 +70,8 @@ def test_prepare_handles_missing_host_remote_id():
     assert result['indirect_nodes_total'] == 0
 
 
-def test_merge_combines_host_ids():
-    """Test that merge() deduplicates host IDs across multiple hourly collections."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data_all = {
-        'indirect_node_ids': ['remote1', 'remote2'],
-        'indirect_nodes_total': 2,
-    }
-
-    data_new = {
-        'indirect_node_ids': ['remote2', 'remote3'],
-        'indirect_nodes_total': 2,
-    }
-
-    result = rollup.merge(data_all, data_new)
-
-    assert result['indirect_node_ids'] == ['remote1', 'remote2', 'remote3']
-    assert result['indirect_nodes_total'] == 3
-
-
-def test_merge_handles_none():
-    """Test that merge() handles None for first merge."""
+def test_merge_returns_data_new():
+    """Test that merge() passes through the snapshot batch unchanged."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data_new = {

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -5,6 +5,7 @@ import pandas as pd
 from metrics_utility.anonymized_rollups.indirect_managed_nodes_anonymized_rollup import (
     IndirectManagedNodesAnonymizedRollup,
     _extract_collection_names,
+    _extract_module_names,
 )
 
 
@@ -54,7 +55,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'module_groups': {}, 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -294,7 +295,7 @@ def test_base_handles_none():
 
     result = rollup.base(None)
 
-    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': []}}
+    assert result == {'json': {'indirect_nodes_total': 0, 'by_collection': [], 'by_module': []}}
 
 
 def test_extract_collection_names_with_nan():
@@ -393,3 +394,282 @@ def test_collector_names():
     """collector_names is set correctly."""
     rollup = IndirectManagedNodesAnonymizedRollup()
     assert rollup.collector_names == ['main_indirectmanagednodeaudit']
+
+
+# --- module-level tests ---
+
+
+def test_extract_module_names_returns_full_fqcn():
+    """_extract_module_names returns the full FQCN, not just the collection prefix."""
+    result = _extract_module_names('["cisco.ios.ios_command", "azure.azcollection.azure_rm_vm"]')
+    assert result == {'cisco.ios.ios_command', 'azure.azcollection.azure_rm_vm'}
+
+
+def test_extract_module_names_skips_non_fqcn():
+    """_extract_module_names skips entries without a valid namespace.collection prefix."""
+    result = _extract_module_names('["cisco.ios.ios_command", "builtin_module"]')
+    assert result == {'cisco.ios.ios_command'}
+
+
+def test_extract_module_names_with_nan():
+    """_extract_module_names returns empty set for NaN input."""
+    assert _extract_module_names(float('nan')) == set()
+
+
+def test_extract_module_names_with_invalid_json():
+    """_extract_module_names returns empty set for malformed JSON."""
+    assert _extract_module_names('not valid json') == set()
+
+
+def test_extract_collection_names_with_non_list_json():
+    """_extract_collection_names returns empty set when JSON decodes to a non-list (null, number, object)."""
+    assert _extract_collection_names('null') == set()
+    assert _extract_collection_names('42') == set()
+    assert _extract_collection_names('{}') == set()
+
+
+def test_extract_module_names_with_non_list_json():
+    """_extract_module_names returns empty set when JSON decodes to a non-list (null, number, object)."""
+    assert _extract_module_names('null') == set()
+    assert _extract_module_names('42') == set()
+    assert _extract_module_names('{}') == set()
+
+
+def test_prepare_groups_by_module():
+    """prepare() populates module_groups keyed by org and full FQCN."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host2', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_config"]'},
+            {'host_name': 'host3', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    module_groups = result['module_groups']
+    assert 'OrgA||cisco.ios.ios_command' in module_groups
+    assert 'OrgA||cisco.ios.ios_config' in module_groups
+    assert 'OrgB||cisco.ios.ios_command' in module_groups
+    assert module_groups['OrgA||cisco.ios.ios_command']['host_count'] == 1
+    assert module_groups['OrgA||cisco.ios.ios_config']['host_count'] == 1
+    assert module_groups['OrgB||cisco.ios.ios_command']['host_count'] == 1
+
+
+def test_prepare_deduplicates_hosts_within_module_group():
+    """prepare() deduplicates hosts within the same module group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['module_groups']['OrgA||cisco.ios.ios_command']['host_count'] == 1
+    assert result['module_groups']['OrgA||cisco.ios.ios_command']['host_names'] == ['host1']
+
+
+def test_prepare_host_appears_in_multiple_module_groups():
+    """A host touched by multiple modules appears in each module group."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {
+                'host_name': 'host1',
+                'organization_name': 'OrgA',
+                'events': json.dumps(['azure.azcollection.azure_rm_vm', 'azure.azcollection.azure_rm_network_interface']),
+            },
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert result['indirect_nodes_total'] == 1
+    assert 'OrgA||azure.azcollection.azure_rm_vm' in result['module_groups']
+    assert 'OrgA||azure.azcollection.azure_rm_network_interface' in result['module_groups']
+    assert result['module_groups']['OrgA||azure.azcollection.azure_rm_vm']['host_count'] == 1
+    assert result['module_groups']['OrgA||azure.azcollection.azure_rm_network_interface']['host_count'] == 1
+
+
+def test_prepare_no_events_uses_no_module_fallback():
+    """prepare() buckets hosts with no events under _no_module in module_groups."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = _make_dataframe(
+        [
+            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '[]'},
+        ]
+    )
+
+    result = rollup.prepare(data)
+
+    assert 'OrgA||_no_module' in result['module_groups']
+    assert result['module_groups']['OrgA||_no_module']['host_count'] == 1
+
+
+def test_merge_unions_module_group_host_names():
+    """merge() unions host name sets in module_groups across two batches."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data_all = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    data_new = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.merge(data_all, data_new)
+
+    merged = result['module_groups']['OrgA||cisco.ios.ios_command']
+    assert merged['host_count'] == 3
+    assert sorted(merged['host_names']) == ['host1', 'host2', 'host3']
+
+
+def test_base_produces_by_module():
+    """base() outputs a by_module list stripped of PII."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgA||cisco.ios.ios_config': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_config',
+                'host_names': ['host3'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    by_module = result['json']['by_module']
+    assert len(by_module) == 2
+    assert by_module[0] == {'module_name': 'cisco.ios.ios_command', 'host_count': 2}
+    assert by_module[1] == {'module_name': 'cisco.ios.ios_config', 'host_count': 1}
+    for entry in by_module:
+        assert 'host_names' not in entry
+        assert 'organization_name' not in entry
+
+
+def test_base_deduplicates_module_hosts_across_orgs():
+    """base() deduplicates hosts under the same module across different orgs."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1', 'host2'],
+                'host_count': 2,
+            },
+            'OrgB||cisco.ios.ios_command': {
+                'organization_name': 'OrgB',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host2', 'host3'],
+                'host_count': 2,
+            },
+        },
+        'indirect_nodes_total': 3,
+    }
+
+    result = rollup.base(data)
+
+    by_module = result['json']['by_module']
+    assert len(by_module) == 1
+    assert by_module[0]['module_name'] == 'cisco.ios.ios_command'
+    assert by_module[0]['host_count'] == 3
+
+
+def test_base_by_module_sorted_by_module_name():
+    """base() sorts by_module entries by module name."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {},
+        'module_groups': {
+            'OrgA||cisco.ios.ios_config': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_config',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+            'OrgA||azure.azcollection.azure_rm_vm': {
+                'organization_name': 'OrgA',
+                'module_name': 'azure.azcollection.azure_rm_vm',
+                'host_names': ['host2'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 2,
+    }
+
+    result = rollup.base(data)
+
+    names = [e['module_name'] for e in result['json']['by_module']]
+    assert names == sorted(names)
+
+
+def test_base_by_collection_unchanged_with_module_data():
+    """Adding module_groups does not affect by_collection output."""
+    rollup = IndirectManagedNodesAnonymizedRollup()
+
+    data = {
+        'groups': {
+            'OrgA||cisco.ios': {
+                'organization_name': 'OrgA',
+                'collection_name': 'cisco.ios',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'module_groups': {
+            'OrgA||cisco.ios.ios_command': {
+                'organization_name': 'OrgA',
+                'module_name': 'cisco.ios.ios_command',
+                'host_names': ['host1'],
+                'host_count': 1,
+            },
+        },
+        'indirect_nodes_total': 1,
+    }
+
+    result = rollup.base(data)
+
+    assert result['json']['by_collection'] == [{'collection_name': 'cisco.ios', 'host_count': 1}]
+    assert result['json']['by_module'] == [{'module_name': 'cisco.ios.ios_command', 'host_count': 1}]

--- a/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_indirect_managed_nodes_anonymized_rollup.py
@@ -54,7 +54,7 @@ def test_prepare_handles_empty_dataframe():
 
     result = rollup.prepare(pd.DataFrame())
 
-    assert result == {'groups': {}, 'by_organizations': [], 'by_collections': [], 'indirect_nodes_total': 0}
+    assert result == {'groups': {}, 'indirect_nodes_total': 0}
 
 
 def test_prepare_deduplicates_hosts_within_group():
@@ -137,87 +137,6 @@ def test_prepare_handles_events_as_list():
     assert result['groups']['OrgA||cisco.ios']['host_count'] == 1
 
 
-def test_prepare_by_organizations_summary():
-    """prepare() includes by_organizations list with deduplicated host counts."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = _make_dataframe(
-        [
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
-            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
-        ]
-    )
-
-    result = rollup.prepare(data)
-
-    by_orgs = result['by_organizations']
-    assert by_orgs == [
-        {'organization_name': 'OrgA', 'host_count': 1},
-        {'organization_name': 'OrgB', 'host_count': 1},
-    ]
-
-
-def test_prepare_by_collections_summary():
-    """prepare() includes by_collections list with deduplicated host counts."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data = _make_dataframe(
-        [
-            {'host_name': 'host1', 'organization_name': 'OrgA', 'events': '["cisco.ios.ios_command"]'},
-            {'host_name': 'host2', 'organization_name': 'OrgB', 'events': '["cisco.ios.ios_config"]'},
-            {'host_name': 'host3', 'organization_name': 'OrgA', 'events': '["azure.azcollection.azure_rm_vm"]'},
-        ]
-    )
-
-    result = rollup.prepare(data)
-
-    by_colls = result['by_collections']
-    assert by_colls == [
-        {'collection_name': 'azure.azcollection', 'host_count': 1},
-        {'collection_name': 'cisco.ios', 'host_count': 2},
-    ]
-
-
-def test_merge_includes_by_organizations_and_by_collections():
-    """merge() result includes by_organizations and by_collections summaries."""
-    rollup = IndirectManagedNodesAnonymizedRollup()
-
-    data_all = {
-        'groups': {
-            'OrgA||cisco.ios': {
-                'organization_name': 'OrgA',
-                'collection_name': 'cisco.ios',
-                'host_names': ['host1'],
-                'host_count': 1,
-            },
-        },
-        'indirect_nodes_total': 1,
-    }
-
-    data_new = {
-        'groups': {
-            'OrgB||cisco.ios': {
-                'organization_name': 'OrgB',
-                'collection_name': 'cisco.ios',
-                'host_names': ['host2'],
-                'host_count': 1,
-            },
-        },
-        'indirect_nodes_total': 1,
-    }
-
-    result = rollup.merge(data_all, data_new)
-
-    assert result['by_organizations'] == [
-        {'organization_name': 'OrgA', 'host_count': 1},
-        {'organization_name': 'OrgB', 'host_count': 1},
-    ]
-    assert result['by_collections'] == [
-        {'collection_name': 'cisco.ios', 'host_count': 2},
-    ]
-
-
 def test_merge_unions_host_names():
     """merge() unions host name sets across two batches."""
     rollup = IndirectManagedNodesAnonymizedRollup()
@@ -275,7 +194,7 @@ def test_merge_with_none_data_all():
 
 
 def test_base_strips_pii():
-    """base() output does not contain host_names, organization_name, or by_organizations."""
+    """base() output does not contain host_names or organization_name."""
     rollup = IndirectManagedNodesAnonymizedRollup()
 
     data = {
@@ -287,12 +206,6 @@ def test_base_strips_pii():
                 'host_count': 2,
             },
         },
-        'by_organizations': [
-            {'organization_name': 'OrgA', 'host_count': 2},
-        ],
-        'by_collections': [
-            {'collection_name': 'cisco.ios', 'host_count': 2},
-        ],
         'indirect_nodes_total': 2,
     }
 
@@ -300,7 +213,6 @@ def test_base_strips_pii():
 
     assert 'json' in result
     output = result['json']
-    assert 'by_organizations' not in output
     assert 'groups' not in output
     assert 'host_names' not in output
     for group in output['by_collection']:

--- a/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_jobs_anonymized_rollups.py
@@ -1461,7 +1461,7 @@ def test_jobs_anonymized_rollups_statistics_ansible_versions():
         'credentials': [cred_csv] if cred_csv else [],
     }
 
-    result = compute_anonymized_rollup_from_raw_data(input_data=input_data, salt='test_salt')
+    result = compute_anonymized_rollup_from_raw_data(input_data=input_data)
 
     # Validate result has ansible_versions at top level
     assert 'statistics' in result, 'Should have statistics in result'

--- a/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_multiple_files.py
@@ -281,7 +281,7 @@ def _validate_events_modules(result):
 
     module_stats = result['module_stats']
     assert isinstance(module_stats, list), 'module_stats should be a list'
-    assert len(module_stats) == 7, 'Should have stats for all 7 modules'
+    assert len(module_stats) == 6, 'Should have stats for all 6 non-Custom modules'
 
     win_copy_stats = [m for m in module_stats if m.get('module_name') == 'ansible.windows.win_copy']
     assert len(win_copy_stats) == 1, 'Should have exactly one entry for ansible.windows.win_copy'
@@ -308,7 +308,7 @@ def _validate_events_modules(result):
 
     collection_stats = result['collection_stats']
     assert isinstance(collection_stats, list), 'collection_stats should be a list'
-    assert len(collection_stats) == 7, 'Should have stats for all 7 collections'
+    assert len(collection_stats) == 6, 'Should have stats for all 6 non-Custom collections'
 
     windows_collection = [c for c in collection_stats if c.get('collection_name') == 'ansible.windows']
     assert len(windows_collection) == 1, 'Should have exactly one entry for ansible.windows collection'
@@ -326,16 +326,19 @@ def _validate_events_modules(result):
 def _validate_jobs_by_installed_collections_versions(result):
     """Validate collections versions section.
 
-    Uses same job fixture data as test_jobs_anonymized_rollups.py.  ansible.builtin is unknown →
-    anonymised to Custom/Custom.  All timing/template/inventory/ansible_version stats should match
-    the per-collection rollup values calculated from jobs 1-4 and 6 (job 5 filtered – no finished).
+    Uses same job fixture data as test_jobs_anonymized_rollups.py.  ansible.builtin is a known
+    certified collection kept as-is.  All timing/template/inventory/ansible_version stats should
+    match the per-collection rollup values calculated from jobs 1-4 and 6 (job 5 filtered – no
+    finished).
     """
     jobs_by_installed_collections_versions = result['jobs_by_installed_collections_versions']
     assert isinstance(jobs_by_installed_collections_versions, list), 'jobs_by_installed_collections_versions should be a list'
     cv = {(c['collection'], c['version']): c for c in jobs_by_installed_collections_versions}
 
     # --- jobs_total counts (unchanged from before) ---
-    assert cv.get(('Custom', 'Custom'))['jobs_total'] == 5, f'Expected Custom Custom (ansible.builtin) in 5 jobs, got {cv.get(("Custom", "Custom"))}'
+    assert cv.get(('ansible.builtin', '2.9.10'))['jobs_total'] == 5, (
+        f'Expected ansible.builtin 2.9.10 in 5 jobs, got {cv.get(("ansible.builtin", "2.9.10"))}'
+    )
     assert cv.get(('community.general', '1.0.0'))['jobs_total'] == 2
     assert cv.get(('community.general', '2.0.0'))['jobs_total'] == 2
     assert cv.get(('community.general', '3.0.0'))['jobs_total'] == 1
@@ -343,12 +346,12 @@ def _validate_jobs_by_installed_collections_versions(result):
     assert cv.get(('community.aws', '1.5.0'))['jobs_total'] == 1
 
     assert len(jobs_by_installed_collections_versions) == 6, (
-        f'Expected 6 unique collection-version pairs, got {len(jobs_by_installed_collections_versions)}'
+        f'Expected 6 unique collection-version pairs (ansible.builtin now kept), got {len(jobs_by_installed_collections_versions)}'
     )
 
-    # --- Custom/Custom (ansible.builtin 2.9.10, 5 jobs) ---
+    # --- ansible.builtin 2.9.10 (5 jobs) ---
     # jobs 1(s,3s,0s) 2(f,5s,2s) 3(s,7s,4s) 4(s,2s,1s) 6(f,NaN,NaN,never-started)
-    custom = cv[('Custom', 'Custom')]
+    custom = cv[('ansible.builtin', '2.9.10')]
     assert custom['jobs_failed_total'] == 2
     assert custom['jobs_successful_total'] == 3
     assert custom['jobs_never_started_total'] == 1
@@ -679,7 +682,7 @@ def test_multiple_csv_files_concatenation(cleanup_test_data):
     # ========== Split and create CSV files for each collector ==========
     input_data = _create_csv_files_from_split_data(data_dir, jobs, events, execution_environments, jobhostsummary, credentials)
 
-    result = compute_anonymized_rollup_from_raw_data(input_data=input_data, salt='test_salt')
+    result = compute_anonymized_rollup_from_raw_data(input_data=input_data)
 
     # print the result with pretty json
     import json
@@ -784,7 +787,7 @@ def test_empty_csv_files_handling(cleanup_test_data):
     }
 
     # Should not crash, but return empty/default results
-    result = compute_anonymized_rollup_from_raw_data(input_data=input_data, salt='test_salt')
+    result = compute_anonymized_rollup_from_raw_data(input_data=input_data)
 
     # Print the result for debugging
     import json

--- a/metrics_utility/test/test_collectors.py
+++ b/metrics_utility/test/test_collectors.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, Mock, patch
 
-from django.db.utils import ProgrammingError
+import pytest
+
+from django.db.utils import OperationalError, ProgrammingError
 
 from metrics_utility.automation_controller_billing.collectors import (
     cli_main_indirectmanagednodeaudit,
@@ -114,3 +116,27 @@ class TestMainIndirectManagedNodeAuditTable:
             ' Falling back to behavior without indirect managed node audit data.',
             specific_error,
         )
+
+    @patch('metrics_utility.automation_controller_billing.collectors.main_indirectmanagednodeaudit')
+    @patch('metrics_utility.automation_controller_billing.collectors.get_optional_collectors')
+    @patch('metrics_utility.automation_controller_billing.collectors.connection')
+    def test_main_indirectmanagednodeaudit_operational_error_propagates(
+        self,
+        mock_connection,
+        mock_get_optional_collectors,
+        mock_main_indirectmanagednodeaudit,
+    ):
+        """OperationalError (e.g. connection refused) is not caught and propagates up.
+
+        This is distinct from ProgrammingError (missing table), which is caught and logged.
+        """
+        mock_get_optional_collectors.return_value = {'main_indirectmanagednodeaudit'}
+        mock_main_indirectmanagednodeaudit.side_effect = OperationalError('connection refused')
+
+        since = Mock()
+        since.isoformat.return_value = '2024-01-01T00:00:00'
+        until = Mock()
+        until.isoformat.return_value = '2024-01-02T00:00:00'
+
+        with pytest.raises(OperationalError):
+            cli_main_indirectmanagednodeaudit(since=since, until=until, output=None)

--- a/metrics_utility/test/test_collectors.py
+++ b/metrics_utility/test/test_collectors.py
@@ -34,7 +34,7 @@ class TestMainIndirectManagedNodeAuditTable:
 
         # Assert
         assert result == ['test_file.csv']
-        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection, since=since, until=until)
+        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection)
         mock_output.as_files.assert_called_once_with(mock_collector)
 
     @patch('metrics_utility.automation_controller_billing.collectors.get_optional_collectors')

--- a/metrics_utility/test/test_collectors.py
+++ b/metrics_utility/test/test_collectors.py
@@ -36,7 +36,7 @@ class TestMainIndirectManagedNodeAuditTable:
 
         # Assert
         assert result == ['test_file.csv']
-        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection)
+        mock_main_indirectmanagednodeaudit.assert_called_once_with(db=mock_connection, since=since, until=until)
         mock_output.as_files.assert_called_once_with(mock_collector)
 
     @patch('metrics_utility.automation_controller_billing.collectors.get_optional_collectors')

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - ./main_instance.sql:/docker-entrypoint-initdb.d/init-5-main_instance.sql
       - ./main_jobhostsummary.sql:/docker-entrypoint-initdb.d/init-6-main_jobhostsummary.sql
       - ./dab_feature_flags.sql:/docker-entrypoint-initdb.d/init-7-dab_feature_flags.sql
+      - ./main_indirectmanagednodeaudit.sql:/docker-entrypoint-initdb.d/init-8-main_indirectmanagednodeaudit.sql
 
   postgres-wait:
     image: "mirror.gcr.io/postgres"

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,4 +1,5 @@
--- 10:00-11:00 window: host_ids 1 and 2 (2 distinct indirect hosts).
+-- Snapshot test data: 4 records, host_ids 1, 2, 2, 3.
+-- prepare() deduplicates to 3 unique hosts (host_ids 1, 2, 3).
 -- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
@@ -38,8 +39,7 @@ WHERE j.name = 'default_unified_job_2025-06-13'
 ORDER BY j.id
 LIMIT 1;
 
--- 11:00-12:00 window: host_id 2 again (dedup test) and host_id 3 (new).
--- Expected unique count across both windows: 3 (host_ids 1, 2, 3).
+-- host_id 2 again and host_id 3 (new): deduplication in prepare() keeps 3 unique hosts.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
 )

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,5 +1,9 @@
--- Snapshot test data: 4 records, host_ids 1, 2, 2, 3.
--- prepare() deduplicates to 3 unique hosts (host_ids 1, 2, 3).
+-- Daily collection test data: 4 records across 2 jobs, host_ids 1, 2, 2, 3.
+-- prepare() groups by (organization_name, collection_name) and deduplicates host_names.
+-- Expected groups:
+--   cisco.ios: cisco-switch-01, cisco-switch-02, cisco-switch-03 = 3 unique hosts
+--   azure.azcollection: cisco-switch-02, cisco-switch-03 = 2 unique hosts
+-- Total unique hosts across all groups: 3
 -- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
 INSERT INTO public.main_indirectmanagednodeaudit (
     created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
@@ -9,7 +13,7 @@ SELECT
     'cisco-switch-01',
     '{"fqdn": "cisco-switch-01.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["cisco.ios.ios_command", "cisco.ios.ios_config"]'::jsonb,
     3,
     1,
     NULL,
@@ -28,7 +32,7 @@ SELECT
     'cisco-switch-02',
     '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["azure.azcollection.azure_rm_storageaccount"]'::jsonb,
     5,
     2,
     NULL,
@@ -48,7 +52,7 @@ SELECT
     'cisco-switch-02',
     '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["cisco.ios.ios_command"]'::jsonb,
     2,
     2,
     NULL,
@@ -67,7 +71,7 @@ SELECT
     'cisco-switch-03',
     '{"fqdn": "cisco-switch-03.example.com"}'::jsonb,
     '{}'::jsonb,
-    '[]'::jsonb,
+    '["azure.azcollection.azure_rm_virtualmachine", "cisco.ios.ios_facts"]'::jsonb,
     1,
     3,
     NULL,

--- a/tools/docker/main_indirectmanagednodeaudit.sql
+++ b/tools/docker/main_indirectmanagednodeaudit.sql
@@ -1,0 +1,79 @@
+-- 10:00-11:00 window: host_ids 1 and 2 (2 distinct indirect hosts).
+-- Looks up job_id and organization_id from the job created by main_jobhostsummary.sql.
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 10:30:00+00',
+    'cisco-switch-01',
+    '{"fqdn": "cisco-switch-01.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    3,
+    1,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 10:30:00+00',
+    'cisco-switch-02',
+    '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    5,
+    2,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+-- 11:00-12:00 window: host_id 2 again (dedup test) and host_id 3 (new).
+-- Expected unique count across both windows: 3 (host_ids 1, 2, 3).
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 11:30:00+00',
+    'cisco-switch-02',
+    '{"fqdn": "cisco-switch-02.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    2,
+    2,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_11_2025-06-13'
+ORDER BY j.id
+LIMIT 1;
+
+INSERT INTO public.main_indirectmanagednodeaudit (
+    created, name, canonical_facts, facts, events, count, host_id, inventory_id, job_id, organization_id
+)
+SELECT
+    TIMESTAMP WITH TIME ZONE '2025-06-13 11:30:00+00',
+    'cisco-switch-03',
+    '{"fqdn": "cisco-switch-03.example.com"}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    1,
+    3,
+    NULL,
+    j.id,
+    j.organization_id
+FROM public.main_unifiedjob j
+WHERE j.name = 'default_unified_job_11_2025-06-13'
+ORDER BY j.id
+LIMIT 1;


### PR DESCRIPTION
## Summary

Backport of the indirect managed nodes feature to stable-0.7.

Cherry-picks 12 commits from devel (PRs #446, #453, #457, #464, #465, #475, #477, #478, #479, #482, #484, #496) plus one fixup commit.

The fixup commit covers things not in the cherry-picks:
- `salt`/`hash` dead code removal (devel #399 was not cherry-picked; #496 requires salt to already be gone)
- `ansible.builtin` added to `collections.json` (already in devel)
- Test assertion updates for the private-collection filter behaviour change (#496 removes unknown entries rather than renaming them to 'Custom') — affects `test_from_gather_to_json.py`, `test_anonymized_rollups_module.py`, `test_multiple_files.py`, and `big_test1/test_all.py`

Note: ruff `pr-checks` will fail on pre-existing violations in unchanged files — these are caught by a newer ruff version and are independent of this PR.

## Test plan

- [x] `uv run pytest` — 453 passed