### PR TITLE
[stable-0.7] CI: use uv run ruff (0.15) instead of uvx ruff (0.16)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,11 +29,11 @@ jobs:
 
       - name: "Run ruff check"
         run: |
-          uvx ruff check --output-format=github .
+          uv run ruff check --output-format=github .
 
       - name: "Check ruff format"
         run: |
-          uvx ruff format --check
+          uv run ruff format --check
 
       - name: "One logger to rule them all"
         run: |


### PR DESCRIPTION
## Summary

- Use `uv run ruff` (project-locked version) instead of `uvx ruff` (latest PyPI) in CI checks
- Prevents CI from breaking when a new ruff release changes defaults or adds rules

Backport of the CI change from #506.