### PR TITLE
AAP-75313 | feat: segment size up + calculate header size

### DIFF
--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -190,9 +190,10 @@ class StorageSegment:
             'context': {},
         }
         properties = self._build_properties(artifact_name, {}, 0, 0, 0)
+        serializable_meta = {k: v.isoformat() if isinstance(v, datetime.datetime) else v for k, v in segment_meta.items()}
         header = {
             **segment_envelope,
-            **segment_meta,
+            **serializable_meta,
             'properties': properties,
             'anonymousId': anonymous_id,
             'event': event_name,

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -49,6 +49,18 @@ class StorageSegment:
         if not self.write_key:
             logger.info('StorageSegment: write_key not set. Analytics will be disabled.')
 
+    def _build_properties(self, artifact_name, data, chunk_number, total_chunks, chunk_size):
+        return {
+            'artifact_name': artifact_name,
+            'data': data,
+            'upload_timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
+            'chunk_info': {
+                'chunk_number': chunk_number,
+                'total_chunks': total_chunks,
+                'chunk_size': chunk_size,
+            },
+        }
+
     def _calculate_size(self, data):
         """Calculate the size of data in bytes."""
         return len(json.dumps(data).encode('utf-8'))
@@ -170,21 +182,17 @@ class StorageSegment:
             segment_meta = {}
         message_id = segment_meta.get('message_id')
 
-        header = {
+        segment_envelope = {
             'anonymousId': anonymous_id,
             'type': 'track',
             'event': event_name,
             'messageId': 'a' * 64 if message_id else str(uuid.uuid4()),
             'timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
-            'integrations': segment_meta.get('integrations', {}),
-            'context': segment_meta.get('context', {}),
-            'properties': {
-                'artifact_name': artifact_name,
-                'data': {},
-                'upload_timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
-                'chunk_info': {'chunk_number': 0, 'total_chunks': 0, 'chunk_size': 0},
-            },
+            'integrations': {},
+            'context': {},
         }
+        properties = self._build_properties(artifact_name, {}, 0, 0, 0)
+        header = {**segment_envelope, 'properties': properties, **segment_meta}
         overhead = self._calculate_size(header)
         max_size = self.REGULAR_MESSAGE_LIMIT - overhead
         chunks = self._split_into_chunks(dict, max_size)
@@ -212,16 +220,9 @@ class StorageSegment:
             analytics.track(
                 anonymous_id=anonymous_id,
                 event=event_name,
-                properties={
-                    'artifact_name': artifact_name,
-                    'data': chunk,
-                    'upload_timestamp': (datetime.datetime.now(tz=datetime.UTC).isoformat()),
-                    'chunk_info': {
-                        'chunk_number': i,
-                        'total_chunks': total_chunks,
-                        'chunk_size': chunk_size,
-                    },
-                },
+                properties=self._build_properties(
+                    artifact_name, chunk, i, total_chunks, chunk_size,
+                ),
                 **segment_meta,
             )
 

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -26,8 +26,9 @@ class StorageSegment:
     per-message size limit.
     """
 
-    # Max JSON size of each `data` chunk. Segment enforces ~32KB per `track` message
-    # including `properties` wrapper, event name, and segment_meta; keep this conservative.
+    # Total budget for each Segment track message (JSON bytes). The SDK enforces a
+    # hard 32KB limit; in the `put` in this file, we subtract the header (and all
+    # other properties in the packet) from this number, and chunk accordingly
     REGULAR_MESSAGE_LIMIT = 32 * 1024
 
     def __init__(self, **settings):
@@ -156,12 +157,21 @@ class StorageSegment:
         analytics.host = self.host or None
 
         header = {
-            'artifact_name': artifact_name,
-            'data': {},
-            'upload_timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
-            'chunk_info': {'chunk_number': 0, 'total_chunks': 0, 'chunk_size': 0},
+            'anonymousId': anonymous_id,
+            'type': 'track',
+            'event': event_name,
+            'messageId': str(uuid.uuid4()),
+            'timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
+            'integrations': {},
+            'context': {},
+            'properties': {
+                'artifact_name': artifact_name,
+                'data': {},
+                'upload_timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
+                'chunk_info': {'chunk_number': 0, 'total_chunks': 0, 'chunk_size': 0},
+            },
         }
-        overhead = self._calculate_size({**header, **(segment_meta or {})})
+        overhead = self._calculate_size(header)
         max_size = self.REGULAR_MESSAGE_LIMIT - overhead
         chunks = self._split_into_chunks(dict, max_size)
 

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -28,7 +28,7 @@ class StorageSegment:
 
     # Max JSON size of each `data` chunk. Segment enforces ~32KB per `track` message
     # including `properties` wrapper, event name, and segment_meta; keep this conservative.
-    REGULAR_MESSAGE_LIMIT = 24 * 1024
+    REGULAR_MESSAGE_LIMIT = 32 * 1024
 
     def __init__(self, **settings):
         """Initialise the Segment storage backend.
@@ -155,7 +155,14 @@ class StorageSegment:
         # Setting to None restores the SDK default (https://api.segment.io).
         analytics.host = self.host or None
 
-        max_size = self.REGULAR_MESSAGE_LIMIT
+        header = {
+            'artifact_name': artifact_name,
+            'data': {},
+            'upload_timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
+            'chunk_info': {'chunk_number': 0, 'total_chunks': 0, 'chunk_size': 0},
+        }
+        overhead = self._calculate_size({**header, **(segment_meta or {})})
+        max_size = self.REGULAR_MESSAGE_LIMIT - overhead
         chunks = self._split_into_chunks(dict, max_size)
 
         total_chunks = len(chunks)

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -61,7 +61,7 @@ class StorageSegment:
         If a top-level key's value is a list, it is split in order: the next item is
         considered appended to the current chunk; if ``json.dumps`` of that chunk
         would exceed max_size, the current chunk is finalized and a new one is started
-        (or a single oversize item is emitted alone).
+        (or a single oversize item is emitted alone with a warning).
 
         Args:
             data: Dictionary to split, dictionary contains key : value pairs
@@ -72,7 +72,14 @@ class StorageSegment:
 
         Returns:
             List of data chunks
+
+        Raises:
+            ValueError: If max_size is not positive.
         """
+        if max_size <= 0:
+            msg = f'max_size must be positive, got {max_size}'
+            raise ValueError(msg)
+
         chunks = []
 
         if data is not None and not isinstance(data, dict):
@@ -81,8 +88,11 @@ class StorageSegment:
 
         for key, value in data.items():
             if isinstance(value, dict):
-                # always add to chunks, each key in main dict is a separate chunk
-                chunks.append({key: value})
+                chunk = {key: value}
+                chunk_size = self._calculate_size(chunk)
+                if chunk_size > max_size:
+                    logger.warning('Oversized dict chunk for key %r: %d bytes exceeds %d limit', key, chunk_size, max_size)
+                chunks.append(chunk)
 
             elif isinstance(value, list):
                 active_chunk = {key: []}
@@ -94,7 +104,7 @@ class StorageSegment:
                             chunks.append(active_chunk)
                             active_chunk = {key: [item]}
                         else:
-                            # single item does not fit max_size; emit it alone
+                            logger.warning('Single list item in key %r exceeds %d byte limit', key, max_size)
                             chunks.append({key: [item]})
                     else:
                         active_chunk[key].append(item)
@@ -156,14 +166,18 @@ class StorageSegment:
         # Setting to None restores the SDK default (https://api.segment.io).
         analytics.host = self.host or None
 
+        if not segment_meta:
+            segment_meta = {}
+        message_id = segment_meta.get('message_id')
+
         header = {
             'anonymousId': anonymous_id,
             'type': 'track',
             'event': event_name,
-            'messageId': str(uuid.uuid4()),
+            'messageId': 'a' * 64 if message_id else str(uuid.uuid4()),
             'timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
-            'integrations': {},
-            'context': {},
+            'integrations': segment_meta.get('integrations', {}),
+            'context': segment_meta.get('context', {}),
             'properties': {
                 'artifact_name': artifact_name,
                 'data': {},
@@ -180,10 +194,6 @@ class StorageSegment:
         if self.debug:
             msg = f'Split data into {total_chunks} chunks'
             print(msg, file=sys.stderr)
-
-        if not segment_meta:
-            segment_meta = {}
-        message_id = segment_meta.get('message_id')
 
         # Send each chunk
         for i, chunk in enumerate(chunks, 1):

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -221,7 +221,11 @@ class StorageSegment:
                 anonymous_id=anonymous_id,
                 event=event_name,
                 properties=self._build_properties(
-                    artifact_name, chunk, i, total_chunks, chunk_size,
+                    artifact_name,
+                    chunk,
+                    i,
+                    total_chunks,
+                    chunk_size,
                 ),
                 **segment_meta,
             )

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -192,7 +192,7 @@ class StorageSegment:
             'context': {},
         }
         properties = self._build_properties(artifact_name, {}, 0, 0, 0)
-        header = {**segment_envelope, 'properties': properties, **segment_meta}
+        header = {**segment_envelope, 'properties': properties}
         overhead = self._calculate_size(header)
         max_size = self.REGULAR_MESSAGE_LIMIT - overhead
         chunks = self._split_into_chunks(dict, max_size)

--- a/metrics_utility/library/storage/segment.py
+++ b/metrics_utility/library/storage/segment.py
@@ -183,16 +183,20 @@ class StorageSegment:
         message_id = segment_meta.get('message_id')
 
         segment_envelope = {
-            'anonymousId': anonymous_id,
             'type': 'track',
-            'event': event_name,
             'messageId': 'a' * 64 if message_id else str(uuid.uuid4()),
             'timestamp': datetime.datetime.now(tz=datetime.UTC).isoformat(),
             'integrations': {},
             'context': {},
         }
         properties = self._build_properties(artifact_name, {}, 0, 0, 0)
-        header = {**segment_envelope, 'properties': properties}
+        header = {
+            **segment_envelope,
+            **segment_meta,
+            'properties': properties,
+            'anonymousId': anonymous_id,
+            'event': event_name,
+        }
         overhead = self._calculate_size(header)
         max_size = self.REGULAR_MESSAGE_LIMIT - overhead
         chunks = self._split_into_chunks(dict, max_size)

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from metrics_utility.library.storage.segment import StorageSegment
 from metrics_utility.test.library.testing_data_for_segment import segment_data, segment_data_large
 
@@ -129,6 +131,55 @@ class TestStorageSegmentAvailable:
             chunk_info = call_kwargs['properties']['chunk_info']
             assert chunk_info['chunk_number'] == i
             assert chunk_info['total_chunks'] == 7
+
+    def test_split_into_chunks_rejects_non_positive_max_size(self):
+        storage_segment = StorageSegment()
+        with pytest.raises(ValueError, match='max_size must be positive'):
+            storage_segment._split_into_chunks({'key': [1, 2, 3]}, 0)
+        with pytest.raises(ValueError, match='max_size must be positive'):
+            storage_segment._split_into_chunks({'key': [1, 2, 3]}, -100)
+
+    def test_split_into_chunks_warns_on_oversized_dict(self, caplog):
+        storage_segment = StorageSegment()
+        data = {'big': {'a': 'x' * 500}}
+        chunks = storage_segment._split_into_chunks(data, 50)
+        assert len(chunks) == 1
+        assert chunks[0] == data
+        assert 'Oversized dict chunk' in caplog.text
+
+    def test_split_into_chunks_warns_on_oversized_single_list_item(self, caplog):
+        storage_segment = StorageSegment()
+        data = {'items': ['x' * 500]}
+        chunks = storage_segment._split_into_chunks(data, 50)
+        assert len(chunks) == 1
+        assert chunks[0]['items'] == ['x' * 500]
+        assert 'Single list item' in caplog.text
+
+    @patch('metrics_utility.library.storage.segment.analytics')
+    @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)
+    def test_put_overhead_includes_segment_meta(self, mock_analytics):
+        """put() accounts for segment_meta (including hashed message_id) in overhead."""
+        mock_analytics.track = Mock()
+        mock_analytics.flush = Mock()
+
+        storage_segment = StorageSegment(write_key='test_write_key')
+        meta = {'message_id': 'original-id-value'}
+        chunks_with_meta = storage_segment.put(
+            artifact_name='test',
+            dict={'items': [f'item{i}' for i in range(3000)]},
+            event_name='Test',
+            segment_meta=meta,
+        )
+
+        chunks_without_meta = storage_segment.put(
+            artifact_name='test',
+            dict={'items': [f'item{i}' for i in range(3000)]},
+            event_name='Test',
+        )
+
+        # A 64-char hashed message_id is larger than a 36-char UUID,
+        # so with meta the overhead is higher and chunks hold fewer items
+        assert len(chunks_with_meta) >= len(chunks_without_meta)
 
     @patch('metrics_utility.library.storage.segment.analytics')
     @patch('metrics_utility.library.storage.segment.SEGMENT_AVAILABLE', True)

--- a/metrics_utility/test/library/test_storage_segment.py
+++ b/metrics_utility/test/library/test_storage_segment.py
@@ -36,9 +36,9 @@ class TestStorageSegmentAvailable:
         assert 'jobs_by_job_type' in chunks[5]
         assert 'job_host_summary' in chunks[6]
 
-        assert len(chunks[1]['module_stats']) == 38
-        assert len(chunks[2]['module_stats']) == 38
-        assert len(chunks[3]['module_stats']) == 36
+        assert len(chunks[1]['module_stats']) == 50
+        assert len(chunks[2]['module_stats']) == 50
+        assert len(chunks[3]['module_stats']) == 12
 
     def test_simple_list_data(self):
         data = {'test_list': ['item1', 'item2']}
@@ -58,8 +58,8 @@ class TestStorageSegmentAvailable:
         assert len(chunks) == 2
         assert 'test_list' in chunks[0]
         assert 'test_list' in chunks[1]
-        assert len(chunks[0]['test_list']) == 2139
-        assert len(chunks[1]['test_list']) == 861
+        assert len(chunks[0]['test_list']) == 2821
+        assert len(chunks[1]['test_list']) == 179
 
     def test_rollup_period_string_arrays(self):
         """Test that arrays of strings (like rollup_period_controller_versions) are split correctly."""


### PR DESCRIPTION
[AAP-75313]
Dont forget to link back issue to PR.

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?

1. Segment max size from 24KB -> 32KB
2. Take the header/entire packet size into account with chunking (right now, we only take the content itself into account. This results in inefficient chunking. Whereas, if we subtract the size of everything except the content from the max message size, we get a more accurate chunking of the data)

- Why is this change needed?

Ticket justification: `we’re arbitrarily limiting chunk contents to 24kB to account for the possibility of 8kB of per-chunk overhead, while the overhead is often much smaller, but, also, allowed to grow larger and could still fail.`

- How does this change address the issue?

It both increases the limit to 32KB (which was one ask of the ticket, which is the max data size for the Segment SDK), as well as attempts to properly calculate the right # of bytes we can take advantage of, by subtracting the header/envelope size from the max. Then, we use this new max when chunking the actual data so it is properly sized

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [ ] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [X] Code is properly linted and formatted.
- [X] All tests (existing and new) pass successfully.
- [X] Tests are added or updated as needed.
- [X] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.

## AI Assistance

Used Claude to go over CodeRabbit's comments and make changes where seen fit. The core of this was written by myself, as well as the tests were manually updated by myself