### PR TITLE
group dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,38 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'
 
   - package-ecosystem: 'uv'
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directories:
+      - '/tools/mock-segment-server'
+      - '/tools/mock-prometheus-server'
+    schedule:
+      interval: 'monthly'
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'docker'
+    directories:
+      - '/tools/mock-segment-server'
+      - '/tools/mock-prometheus-server'
+    schedule:
+      interval: 'monthly'
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'

--- a/tools/mock-prometheus-server/Dockerfile
+++ b/tools/mock-prometheus-server/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:alpine AS builder
+FROM mirror.gcr.io/golang:alpine AS builder
 WORKDIR /build
 COPY go.mod main.go ./
 RUN CGO_ENABLED=0 go build -o mock-prometheus-server .
 
-FROM alpine:3
+FROM mirror.gcr.io/alpine:3
 RUN addgroup -S app && adduser -S -G app app
 COPY --from=builder /build/mock-prometheus-server /usr/local/bin/mock-prometheus-server
 USER app

--- a/tools/mock-segment-server/Dockerfile
+++ b/tools/mock-segment-server/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:alpine AS builder
+FROM mirror.gcr.io/golang:alpine AS builder
 WORKDIR /build
 COPY go.mod main.go ./
 RUN CGO_ENABLED=0 go build -o mock-segment-server .
 
-FROM alpine:3
+FROM mirror.gcr.io/alpine:3
 RUN addgroup -S app && adduser -S -G app app
 COPY --from=builder /build/mock-segment-server /usr/local/bin/mock-segment-server
 USER app


### PR DESCRIPTION
Based on https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/

Turns out, dependabot can we convinced to do one big update PR .. trying that..

(Not adding an explicit cooldown block — the default 3-day cooldown (`cooldown.default-days: 3`) is already the built-in behavior.)

Also adds `go.mod` update for the mock tools,
and fixes the containers to use hub mirrors too.

+ https://github.com/ansible/metrics-service/pull/376