### PR TITLE
[stable-0.7] [AAP-74848][stable-0.7] fix: exclude workflow child jobs from dashboard job collection

### DIFF
--- a/metrics_utility/library/collectors/dashboard/queries.py
+++ b/metrics_utility/library/collectors/dashboard/queries.py
@@ -38,7 +38,12 @@ def get_min_max_job_id_query(since: datetime, until: datetime, date_field: str =
 def get_where_clause(since: datetime, until: datetime, date_field: str = 'modified') -> tuple[str, list]:
     """
     Generate SQL WHERE clause for filtering jobs by a date range.
-    Excludes sync jobs and includes only jobs with status 'failed' or 'successful'.
+    Excludes sync and workflow jobs and includes only jobs with status 'failed' or 'successful'.
+
+    Workflow child jobs (``launch_type = 'workflow'``) are excluded because they have no
+    reliable user attribution (``launched_by_id`` is NULL for them in ``_JOBS_BASE_SQL``),
+    which caused the Successful/Failed totals to be inflated relative to the Top 5 Users
+    breakdown (AAP-74848 / AAP-85129).
 
     Args:
         since: Start of date range (inclusive)
@@ -53,12 +58,12 @@ def get_where_clause(since: datetime, until: datetime, date_field: str = 'modifi
     """
     _validate_date_field(date_field)
     where_clause = f"""
-    WHERE uj.launch_type != %s
+    WHERE uj.launch_type NOT IN (%s, %s)
     AND (uj.status= %s OR uj.status = %s)
     AND uj.{date_field} >= %s
     AND uj.{date_field} < %s
     """
-    params = ['sync', 'failed', 'successful', since.isoformat(), until.isoformat()]
+    params = ['sync', 'workflow', 'failed', 'successful', since.isoformat(), until.isoformat()]
     return where_clause, params
 
 

--- a/metrics_utility/test/library/dashboard/test_queries_dashboard.py
+++ b/metrics_utility/test/library/dashboard/test_queries_dashboard.py
@@ -19,11 +19,11 @@ class TestQueriesDashboard:
     def test_where_clause_defaults_to_modified(self):
         result, params = get_where_clause(self.since, self.until)
         assert 'WHERE' in result
-        assert 'uj.launch_type != %s' in result
+        assert 'uj.launch_type NOT IN (%s, %s)' in result
         assert 'AND (uj.status= %s OR uj.status = %s)' in result
         assert 'AND uj.modified >= %s' in result
         assert 'AND uj.modified < %s' in result
-        expected_params = ['sync', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
+        expected_params = ['sync', 'workflow', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
         assert params == expected_params
 
     def test_where_clause_finished(self):
@@ -97,10 +97,10 @@ class TestQueriesDashboard:
         # Must join main_job so bounds match the INNER JOIN in get_jobs_batch_query
         assert 'JOIN main_job mj ON mj.unifiedjob_ptr_id = uj.id' in result
         # Same base filter as get_where_clause
-        assert 'uj.launch_type != %s' in result
+        assert 'uj.launch_type NOT IN (%s, %s)' in result
         assert 'uj.status' in result
         assert 'uj.modified' in result
-        expected_params = ['sync', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
+        expected_params = ['sync', 'workflow', 'failed', 'successful', '2024-01-01T00:00:00+00:00', '2024-02-01T23:59:59+00:00']
         assert params == expected_params
 
     def test_get_jobs_batch_query(self):
@@ -117,7 +117,7 @@ class TestQueriesDashboard:
         assert 'uj.status' in result
         assert 'mj.project_id' in result
         # Same base filter
-        assert 'uj.launch_type != %s' in result
+        assert 'uj.launch_type NOT IN (%s, %s)' in result
 
     def test_get_jobs_batch_query_zero_after_id(self):
         result, params = get_jobs_batch_query(self.since, self.until, after_id=0, batch_size=500)


### PR DESCRIPTION
Backport of #525 to stable-0.7.

[AAP-74848]

## Description

Workflow child jobs (`launch_type='workflow'`) were counted in the Successful/Failed totals but excluded from Top 5 Users because `launched_by_id` is NULL for non-manual/relaunch jobs. This caused the two dashboard totals to mismatch (AAP-74848), the same root cause as the job-count inflation in AAP-85129.

Excludes `launch_type 'workflow'` alongside `'sync'` in `get_where_clause()` so the collected jobs only include ones Top 5 Users can attribute to a user.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.