### PR TITLE
[stable-0.7] chore: bump version to 0.7.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.7.3
+version = 0.7.7
 
 [options]
 packages = find:


### PR DESCRIPTION
## Description

- **What is being changed?**
  Bump `setup.cfg` version from `0.7.3` to `0.7.7` to align with the upcoming `0.7.7` release tag.

- **Why is this change needed?**
  The version in `setup.cfg` has drifted from the actual release tags (`0.7.3` vs `0.7.6`). Aligning it before tagging `0.7.7` keeps the package metadata consistent with the git tag.

- **How does this change address the issue?**
  Updates the single version field in `setup.cfg` to `0.7.7`.

## Testing

### Prerequisites

- None

### Steps to Test

1. `python setup.py --version` should report `0.7.7`

### Expected Results

- Version string matches the intended release tag

## Required Actions

- [ ] Requires downstream repository changes
  - After merge: tag `0.7.7` on stable-0.7, then bump the metrics-utility submodule in automation-metrics-service-container

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.