### PR TITLE
chore: relax exact pip pins to compatible-release constraints in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,18 @@ name = "metrics-utility"
 dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
-    "boto3==1.35.96",
+    "boto3~=1.35",
     "cryptography>=44.0.1",
-    "botocore==1.35.96",
-    "distro==1.9.0",
-    "django==5.2.7",
+    "botocore~=1.35",
+    "distro~=1.8",
+    "django~=5.2",
     "kubernetes>=33.1.0",
-    "openpyxl~=3.1.5",
+    "openpyxl~=3.1",
     "pandas~=3.0",
-    "psycopg==3.3.4",
-    "requests==2.34.2",
+    "psycopg~=3.1",
+    "requests~=2.28",
     "segment-analytics-python>=2.3.6",
-    "setuptools==80.9.0",
+    "setuptools>=65",
 ]
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `boto3==1.35.96` → `boto3~=1.35` (any 1.35+)
- `botocore==1.35.96` → `botocore~=1.35` (any 1.35+)
- `distro==1.9.0` → `distro~=1.8` (any 1.8+)
- `django==5.2.7` → `django~=5.2` (any 5.x)
- `openpyxl~=3.1.5` → `openpyxl~=3.1` (any 3.1.x was too tight, open to any 3.1+)
- `psycopg==3.3.4` → `psycopg~=3.1` (any 3.1+)
- `requests==2.34.2` → `requests~=2.28` (any 2.28+)
- `setuptools==80.9.0` → `setuptools>=65` (any modern version; `~=` not suitable for single-int version scheme)

## Why

Exact `==` pins in a library `pyproject.toml` prevent installation in any environment that already has a different patch version of the same package. This causes failures when `metrics-utility` is used alongside other packages with their own `boto3`, `requests`, or `django` requirements.

The **container repo** (`automation-metrics-service-container`) is the authoritative source of the production lock file: `requirements.txt` is generated by `uv pip compile` and pins every package to an exact version with hashes. `pyproject.toml` only needs to express minimum compatibility — the container lock file handles production pinning.

No behaviour change in production container builds; the generated `requirements.txt` already pinned these at the exact versions.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.