### PR TITLE
move host_metric SQL into a library collector

### DIFF
--- a/docs/collectors-and-partitions.md
+++ b/docs/collectors-and-partitions.md
@@ -453,6 +453,43 @@ WHERE main_indirectmanagednodeaudit.created >= 'since'
 
 ---
 
+### 11. `main_hostmetric`
+
+**File**: `metrics_utility/library/collectors/controller/main_hostmetric.py`
+
+**Purpose**: Collects host metric data (automation history, deletion status) joined with host facts. Used by the Renewal Guidance report.
+
+**Tables Accessed**:
+- `main_hostmetric` (READ) - Filtered by `last_automation` timestamp
+- `main_host` (READ) - LEFT JOIN for host variables and ansible facts
+
+**Partition Information**:
+- ❌ **Not partitioned** (all tables are non-partitioned)
+
+**Query Pattern**:
+```sql
+SELECT main_hostmetric.hostname, COALESCE(main_host.id, 0) AS host_id,
+       main_hostmetric.first_automation, main_hostmetric.last_automation,
+       main_hostmetric.automated_counter, main_hostmetric.deleted_counter,
+       main_hostmetric.last_deleted, main_hostmetric.deleted, ...
+FROM main_hostmetric
+LEFT JOIN main_host ON main_host.name = main_hostmetric.hostname
+WHERE main_hostmetric.last_automation >= 'since'
+ORDER BY main_hostmetric.hostname ASC, COALESCE(main_host.id, 0) ASC
+```
+
+**Time Range Support**:
+- ✅ **Supports `since`/`until` parameters**
+- Filters by `last_automation` timestamp (the Renewal Guidance report passes `since` only)
+
+**Pagination**:
+- Keyset pagination on `(hostname, host_id)` when materialised into a DataFrame; COPY-based (CSV) output streams the whole result set in one query
+
+**Frequency**:
+- Run per collection window (typically daily)
+
+---
+
 ## Partition Pruning Strategies
 
 ### How Partition Pruning Works

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -19,6 +19,7 @@ from metrics_utility.library.collectors.controller import (
     job_host_summary_service,
     main_host,
     main_host_daily,
+    main_hostmetric,
     main_indirectmanagednodeaudit,
     main_jobevent,
     main_jobevent_service,
@@ -161,6 +162,15 @@ def cli_main_host_daily(since, until, output):
         return None
 
     collector = main_host_daily(db=connection, since=since, until=until)
+    return output.as_files(collector)
+
+
+@register('main_hostmetric', '1.0', format='csv', fnc_slicing=daily_slicing)
+def cli_main_hostmetric(since, until, output):
+    if 'main_hostmetric' not in get_optional_collectors():
+        return None
+
+    collector = main_hostmetric(db=connection, since=since, until=until)
     return output.as_files(collector)
 
 

--- a/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
+++ b/metrics_utility/automation_controller_billing/extract/extractor_controller_db.py
@@ -2,16 +2,17 @@
 
 import datetime
 
-import pandas as pd
-
 from django.db import connection
+
+from metrics_utility.library.collectors.controller.main_hostmetric import main_hostmetric
 
 
 class ExtractorControllerDB:
     """Extracts host_metric data from the AWX/Controller PostgreSQL database.
 
-    Uses marker-based keyset pagination to stream large result sets in batches
-    of :attr:`limit` rows.
+    Thin adapter over the :func:`~metrics_utility.library.collectors.controller.main_hostmetric.main_hostmetric`
+    library collector, which owns the SQL, the custom PostgreSQL helper functions,
+    and the keyset pagination.
     """
 
     def __init__(self, extra_params):
@@ -25,160 +26,19 @@ class ExtractorControllerDB:
         self.extra_params = extra_params
 
     def iter_batches(self):
-        """Yield host_metric batches from the Controller database.
+        """Yield the host_metric batch from the Controller database.
 
-        Uses keyset pagination on ``hostname + host_id`` to iterate large result
-        sets without repeated full scans.
+        Delegates fetching (and keyset pagination) to the ``main_hostmetric``
+        collector, which returns the full result set as a single DataFrame.
 
         Yields:
-            Dict ``{'host_metric': pandas.DataFrame}`` for each non-empty batch.
+            Dict ``{'host_metric': pandas.DataFrame}`` when there is data.
         """
-        with connection.cursor() as cursor:
-            cursor.execute(self.pg_functions())
+        since = self.extra_params['opt_since']
+        if since.tzinfo is None:
+            since = since.replace(tzinfo=datetime.UTC)
 
-            since = self.extra_params['opt_since']
-            if since.tzinfo is None:
-                since = since.replace(tzinfo=datetime.UTC)
+        host_metric = main_hostmetric(db=connection, since=since).gather()
 
-            marker = None
-            while True:
-                query, params = self.host_metric_query(since, marker)
-                cursor.execute(query, params)
-                host_metric = self.dict_fetchall(cursor)
-
-                # Marker based pagination
-                if len(host_metric) <= 0:
-                    break
-
-                # Advance the keyset marker to the last row of this batch. Values are
-                # carried as query parameters (never interpolated) on the next iteration.
-                last_row = host_metric[-1]
-                marker = (last_row['hostname'], last_row['host_id'])
-
-                host_metric = pd.DataFrame(host_metric)
-
-                yield {'host_metric': host_metric}
-
-    def dict_fetchall(self, cursor):
-        """
-        Return all rows from a cursor as a dict.
-        Assume the column names are unique.
-        """
-        columns = [col[0] for col in cursor.description]
-        return [dict(zip(columns, row)) for row in cursor.fetchall()]
-
-    def pg_functions(self):
-        """Return SQL that creates or replaces the custom PostgreSQL helper functions.
-
-        Returns:
-            SQL string defining ``metrics_utility_parse_yaml_field`` and
-            ``metrics_utility_is_valid_json``.
-        """
-        query = """
-            -- Define function for parsing field out of yaml encoded as text
-            CREATE OR REPLACE FUNCTION metrics_utility_parse_yaml_field(
-                str text,
-                field text
-            )
-            RETURNS text AS
-            $$
-            DECLARE
-                line_re text;
-                field_re text;
-            BEGIN
-                field_re := ' *[:=] *(.+?) *$';
-                line_re := '(?n)^' || field || field_re;
-                RETURN trim(both '"' from substring(str from line_re) );
-            END;
-            $$
-            LANGUAGE plpgsql;
-
-            -- Define function to check if field is a valid json
-            CREATE OR REPLACE FUNCTION metrics_utility_is_valid_json(p_json text)
-                returns boolean
-            AS
-            $$
-            BEGIN
-                RETURN (p_json::json is not null);
-            EXCEPTION
-                WHEN others THEN
-                    RETURN false;
-            END;
-            $$
-            LANGUAGE plpgsql;
-        """
-        return query
-
-    def host_metric_query(self, since, marker=None):
-        """Build the host_metric SQL query and bind parameters, with optional keyset pagination.
-
-        All caller-influenced values (``since``, the pagination marker, and the row
-        limit) are passed as query parameters rather than interpolated into the SQL
-        text, so the returned query is safe to hand to ``cursor.execute(query, params)``.
-
-        Args:
-            since: Inclusive lower bound timestamp (timezone-aware datetime).
-            marker: Optional ``(hostname, host_id)`` tuple from the last row of the
-                previous batch. When provided, only rows ordered strictly after the
-                marker are returned (keyset pagination). ``None`` returns from the start.
-
-        Returns:
-            Tuple ``(query, params)`` suitable for ``cursor.execute``.
-        """
-        params = [since]
-
-        marker_cond = ''
-        if marker is not None:
-            # Multi-column keyset comparison matching the ORDER BY below. Expanded
-            # explicitly (rather than a row-value comparison) because the second
-            # sort key is COALESCE(main_host.id, 0), not a bare column.
-            marker_cond = """
-                AND (main_hostmetric.hostname > %s
-                     OR (main_hostmetric.hostname = %s
-                         AND COALESCE(main_host.id, 0) > %s))
-            """
-            last_hostname, last_host_id = marker
-            params.extend([last_hostname, last_hostname, last_host_id])
-
-        # marker_cond contains only static SQL with %s placeholders (no interpolated
-        # values); the surrounding f-string only injects that fixed fragment.
-        query = f"""
-            SELECT main_hostmetric.hostname,
-                   COALESCE(main_host.id, 0) AS host_id,
-                   main_hostmetric.first_automation,
-                   main_hostmetric.last_automation,
-                   main_hostmetric.automated_counter,
-                   main_hostmetric.deleted_counter,
-                   main_hostmetric.last_deleted,
-                   main_hostmetric.deleted,
-                   main_host.ansible_facts->>'ansible_product_serial'::TEXT AS ansible_product_serial,
-                   main_host.ansible_facts->>'ansible_machine_id'::TEXT AS ansible_machine_id,
-                   CASE
-                       WHEN (metrics_utility_is_valid_json(main_host.variables))
-                           THEN main_host.variables::jsonb->>'ansible_host'
-                       ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
-                   END AS ansible_host_variable,
-                   CASE
-                       WHEN (metrics_utility_is_valid_json(main_host.variables))
-                           THEN main_host.variables::jsonb->>'ansible_connection'
-                       ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
-                   END AS ansible_connection_variable
-
-            FROM main_hostmetric
-            LEFT JOIN main_host ON main_host.name = main_hostmetric.hostname
-            WHERE (main_hostmetric.last_automation >= %s {marker_cond})
-            ORDER BY main_hostmetric.hostname ASC, COALESCE(main_host.id, 0) ASC
-            LIMIT %s
-        """
-        params.append(self.limit())
-
-        return query, params
-
-    @staticmethod
-    def limit():
-        """Return the maximum number of rows fetched per page.
-
-        Returns:
-            int row-count limit.
-        """
-        return 10000
+        if host_metric is not None and not host_metric.empty:
+            yield {'host_metric': host_metric}

--- a/metrics_utility/library/README.md
+++ b/metrics_utility/library/README.md
@@ -33,6 +33,7 @@ Controller collectors (in `metrics_utility.library.collectors.controller`):
 * `job_host_summary_service(db, since, until).gather() -> DataFrame`
 * `main_host(db).gather() -> DataFrame`
 * `main_host_daily(db, since, until).gather() -> DataFrame`
+* `main_hostmetric(db, since, until).gather() -> DataFrame`
 * `main_indirectmanagednodeaudit(db, since, until).gather() -> DataFrame`
 * `main_jobevent(db, since, until).gather() -> DataFrame`
 * `main_jobevent_service(db, since, until).gather() -> DataFrame`

--- a/metrics_utility/library/collectors/controller/__init__.py
+++ b/metrics_utility/library/collectors/controller/__init__.py
@@ -7,6 +7,7 @@ from .feature_flags_service import feature_flags_service
 from .job_host_summary import job_host_summary
 from .job_host_summary_service import job_host_summary_service
 from .main_host import main_host, main_host_daily
+from .main_hostmetric import main_hostmetric
 from .main_indirectmanagednodeaudit import main_indirectmanagednodeaudit
 from .main_jobevent import main_jobevent
 from .main_jobevent_service import main_jobevent_service
@@ -26,6 +27,7 @@ __all__ = [
     'job_host_summary_service',
     'main_host',
     'main_host_daily',
+    'main_hostmetric',
     'main_indirectmanagednodeaudit',
     'main_jobevent',
     'main_jobevent_service',

--- a/metrics_utility/library/collectors/controller/main_hostmetric.py
+++ b/metrics_utility/library/collectors/controller/main_hostmetric.py
@@ -1,0 +1,113 @@
+"""Collector for host metric data from the Controller database."""
+
+from ..util import DataframeOutput, collector, date_where, ensure_functions
+
+
+# Rows fetched per keyset page when materialising into a DataFrame. COPY-based
+# outputs stream the whole result set and ignore this.
+PAGE_SIZE = 10000
+
+
+def _host_metric_query(*, since=None, until=None, marker=None, limit=None):
+    """Build the host_metric SQL query and its bound parameters.
+
+    The ``since``/``until`` window is applied via :func:`~..util.date_where` (which
+    safely interpolates tz-aware datetimes). The keyset marker and row limit are
+    passed as bound ``%s`` parameters -- the marker in particular carries a hostname
+    read from a previous row, so it must never be interpolated.
+
+    Args:
+        since: Optional inclusive lower bound for ``last_automation`` (tz-aware datetime).
+        until: Optional exclusive upper bound for ``last_automation`` (tz-aware datetime).
+        marker: Optional ``(hostname, host_id)`` tuple from the last row of the
+            previous page. When set, only rows ordered strictly after it are returned
+            (keyset pagination).
+        limit: Optional maximum number of rows to return (``LIMIT``). ``None`` returns
+            all matching rows.
+
+    Returns:
+        Tuple ``(query, params)`` suitable for ``cursor.execute``.
+    """
+    params = []
+    conditions = [date_where('main_hostmetric.last_automation', since, until)]
+
+    if marker is not None:
+        # Multi-column keyset comparison matching the ORDER BY below. Expanded
+        # explicitly (rather than a row-value comparison) because the second sort
+        # key is COALESCE(main_host.id, 0), not a bare column.
+        conditions.append('(main_hostmetric.hostname > %s OR (main_hostmetric.hostname = %s AND COALESCE(main_host.id, 0) > %s))')
+        last_hostname, last_host_id = marker
+        params.extend([last_hostname, last_hostname, last_host_id])
+
+    where_sql = ' AND '.join(conditions)
+
+    limit_sql = ''
+    if limit is not None:
+        limit_sql = 'LIMIT %s'
+        params.append(limit)
+
+    query = f"""
+        SELECT
+            main_hostmetric.hostname,
+            COALESCE(main_host.id, 0) AS host_id,
+            main_hostmetric.first_automation,
+            main_hostmetric.last_automation,
+            main_hostmetric.automated_counter,
+            main_hostmetric.deleted_counter,
+            main_hostmetric.last_deleted,
+            main_hostmetric.deleted,
+            main_host.ansible_facts->>'ansible_product_serial'::TEXT AS ansible_product_serial,
+            main_host.ansible_facts->>'ansible_machine_id'::TEXT AS ansible_machine_id,
+            CASE
+                WHEN (metrics_utility_is_valid_json(main_host.variables))
+                    THEN main_host.variables::jsonb->>'ansible_host'
+                ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_host' )
+            END AS ansible_host_variable,
+            CASE
+                WHEN (metrics_utility_is_valid_json(main_host.variables))
+                    THEN main_host.variables::jsonb->>'ansible_connection'
+                ELSE metrics_utility_parse_yaml_field(main_host.variables, 'ansible_connection' )
+            END AS ansible_connection_variable
+
+        FROM main_hostmetric
+        LEFT JOIN main_host ON main_host.name = main_hostmetric.hostname
+        WHERE {where_sql}
+        ORDER BY main_hostmetric.hostname ASC, COALESCE(main_host.id, 0) ASC
+        {limit_sql}
+    """
+
+    return query, params
+
+
+def _next_marker(row):
+    """Return the keyset marker (``(hostname, host_id)``) for the given result row."""
+    return (row['hostname'], row['host_id'])
+
+
+@collector
+def main_hostmetric(*, db=None, since=None, until=None, output=DataframeOutput()):
+    """Collect host metric records from the Controller database.
+
+    Reads ``main_hostmetric`` LEFT JOIN ``main_host``, filtered by
+    ``last_automation``. Used by the Renewal Guidance report.
+
+    Uses keyset pagination on ``(hostname, host_id)`` when materialising into a
+    DataFrame; COPY-based outputs stream the whole result set in one query.
+
+    Args:
+        db: Django database connection.
+        since: Inclusive start datetime for the ``last_automation`` filter.
+        until: Exclusive end datetime for the ``last_automation`` filter (pass None
+            to avoid an upper bound, as the Renewal Guidance report does).
+        output: Output adapter (defaults to :class:`~..util.DataframeOutput`).
+
+    Returns:
+        pandas DataFrame with host metric fields, or list of CSV paths.
+    """
+
+    def build_page(marker, limit):
+        return _host_metric_query(since=since, until=until, marker=marker, limit=limit)
+
+    # ensure_functions writes to DB, cannot be used in service (readonly DB)
+    ensure_functions(db)
+    return output.sql_keyset(db, build_page, _next_marker, page_size=PAGE_SIZE)

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -12,17 +12,51 @@ from ..csv_file_splitter import CsvFileSplitter
 class DataframeOutput:
     """Output adapter used by DB-backed library collectors to return a pandas DataFrame."""
 
-    def sql(self, db, query):
+    def sql(self, db, query, params=None):
         """Execute *query* and return a pandas DataFrame.
 
         Args:
             db: Django database connection.
             query: SQL query string.
+            params: Optional sequence of bound query parameters.
 
         Returns:
             pandas DataFrame with the query results.
         """
-        return _copy_table_pandas(db, query)
+        return _copy_table_pandas(db, query, params)
+
+    def sql_keyset(self, db, build_page, next_marker, page_size=10000):
+        """Fetch a keyset-paginated result set and return it as a single DataFrame.
+
+        Pages of at most *page_size* rows are fetched in order, advancing a marker to
+        the last row of each page, until a short (or empty) page is reached. This
+        streams large result sets without a single giant query/sort.
+
+        Args:
+            db: Django database connection.
+            build_page: Callable ``(marker, limit) -> (query, params)`` building the
+                query for one page. Must apply ``limit`` and, when *marker* is not
+                None, only return rows ordered strictly after it.
+            next_marker: Callable ``(row) -> marker`` extracting the keyset marker
+                from the last row of a page (a pandas Series).
+            page_size: Maximum number of rows fetched per page.
+
+        Returns:
+            pandas DataFrame with all pages concatenated (empty with columns if no rows).
+        """
+        import pandas as pd
+
+        marker = None
+        frames = []
+        while True:
+            query, params = build_page(marker, page_size)
+            df = _copy_table_pandas(db, query, params)
+            frames.append(df)
+            if len(df) < page_size:
+                break
+            marker = next_marker(df.iloc[-1])
+
+        return frames[0] if len(frames) == 1 else pd.concat(frames, ignore_index=True)
 
 
 # default in dict collectors
@@ -114,9 +148,31 @@ class CollectionOutput(DictOutput):
         """
         return self.files(collector.gather(output=self))
 
-    def sql(self, db, query):
+    def sql(self, db, query, params=None):
         filespec = tempfile.mktemp(dir=self.full_path)  # NOT mkstemp - this is a prefix, can't have it get created
-        return _copy_table_files(db, query, filespec)
+        return _copy_table_files(db, query, filespec, params)
+
+    def sql_keyset(self, db, build_page, next_marker, page_size=10000):
+        """Stream the full result set to CSV files via a single COPY.
+
+        COPY streams rows server-side without materialising them, so keyset
+        pagination is unnecessary here: the whole result set is requested in one
+        query (no marker, no LIMIT). *next_marker* and *page_size* are accepted for
+        interface parity with :meth:`DataframeOutput.sql_keyset` and ignored.
+
+        Args:
+            db: Django database connection.
+            build_page: Callable ``(marker, limit) -> (query, params)``; called once
+                as ``build_page(None, None)`` for the full result set.
+            next_marker: Unused (accepted for interface parity).
+            page_size: Unused (accepted for interface parity).
+
+        Returns:
+            List of CSV file paths.
+        """
+        query, params = build_page(None, None)
+        filespec = tempfile.mktemp(dir=self.full_path)  # NOT mkstemp - this is a prefix, can't have it get created
+        return _copy_table_files(db, query, filespec, params)
 
 
 def date_where(field, since, until):
@@ -186,13 +242,13 @@ def ensure_functions(db):
         cursor.execute(_yaml_json_functions())
 
 
-def _copy_table_files(db, query, filespec):
+def _copy_table_files(db, query, filespec, params=None):
     file = CsvFileSplitter(filespec=filespec)
 
     with db.cursor() as cursor:
         copy_query = f'COPY ({query}) TO STDOUT WITH CSV HEADER'
 
-        with cursor.copy(copy_query) as copy:
+        with cursor.copy(copy_query, params) as copy:
             while data := copy.read():
                 byte_data = bytes(data)
                 file.write(byte_data.decode())
@@ -200,13 +256,13 @@ def _copy_table_files(db, query, filespec):
     return file.file_list(keep_empty=True)
 
 
-def _copy_table_pandas(db, query):
+def _copy_table_pandas(db, query, params=None):
     import pandas as pd
 
     # Execute query and create DataFrame from results
     # Using cursor approach since pd.read_sql doesn't work well with psycopg3
     with db.cursor() as cursor:
-        cursor.execute(query)
+        cursor.execute(query, params)
 
         # Get column names from cursor description
         columns = [desc[0] for desc in cursor.description]

--- a/metrics_utility/library/collectors/util.py
+++ b/metrics_utility/library/collectors/util.py
@@ -51,11 +51,18 @@ class DataframeOutput:
         while True:
             query, params = build_page(marker, page_size)
             df = _copy_table_pandas(db, query, params)
-            frames.append(df)
+            # Skip empty pages: concatenating an all-object empty frame would
+            # downgrade every column's dtype to object. A trailing empty page
+            # happens whenever the row count is an exact multiple of page_size.
+            if not df.empty:
+                frames.append(df)
             if len(df) < page_size:
                 break
             marker = next_marker(df.iloc[-1])
 
+        if not frames:
+            # No rows at all: return the last (empty) frame so callers still get the columns.
+            return df
         return frames[0] if len(frames) == 1 else pd.concat(frames, ignore_index=True)
 
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -71,6 +71,7 @@ VALID_COLLECTORS = {
     # job_host_summary is on by default
     'main_host',
     'main_host_daily',
+    'main_hostmetric',
     'main_indirectmanagednodeaudit',
     'main_jobevent',
     ## vcpu

--- a/metrics_utility/test/library/test_collectors_main_hostmetric.py
+++ b/metrics_utility/test/library/test_collectors_main_hostmetric.py
@@ -1,0 +1,138 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from metrics_utility.library.collectors.controller.main_hostmetric import _host_metric_query, main_hostmetric
+from metrics_utility.library.collectors.util import CollectionOutput
+
+
+SINCE = datetime(2025, 6, 13, 0, 0, 0, tzinfo=UTC)
+UNTIL = datetime(2025, 6, 14, 0, 0, 0, tzinfo=UTC)
+
+
+def test_main_hostmetric_basic():
+    """The collector exposes the standard gather()/kwargs interface."""
+    mock_db = MagicMock()
+
+    instance = main_hostmetric(db=mock_db, since=SINCE)
+
+    assert hasattr(instance, 'gather')
+    assert instance.kwargs['db'] == mock_db
+    assert instance.kwargs['since'] == SINCE
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_hostmetric_calls_copy_table(mock_copy_pandas):
+    """gather() fetches via _copy_table_pandas and returns a DataFrame."""
+    mock_db = MagicMock()
+    mock_copy_pandas.return_value = pd.DataFrame({'hostname': ['a'], 'host_id': [0]})
+
+    result = main_hostmetric(db=mock_db, since=SINCE).gather()
+
+    mock_copy_pandas.assert_called_once()
+    db_arg, query, params = mock_copy_pandas.call_args[0]
+    assert db_arg == mock_db
+    assert 'main_hostmetric' in query
+    assert 'LEFT JOIN main_host' in query
+    assert 'LIMIT %s' in query
+    assert SINCE.isoformat() in query  # since interpolated via date_where
+    assert params == [10000]  # only the page-size LIMIT is bound
+    assert isinstance(result, pd.DataFrame)
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_hostmetric_query_columns(mock_copy_pandas):
+    """The SQL selects all expected host_metric/host columns."""
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    main_hostmetric(db=MagicMock(), since=SINCE).gather()
+
+    query = mock_copy_pandas.call_args[0][1]
+    for column in [
+        'hostname',
+        'host_id',
+        'first_automation',
+        'last_automation',
+        'automated_counter',
+        'deleted_counter',
+        'last_deleted',
+        'deleted',
+        'ansible_product_serial',
+        'ansible_machine_id',
+        'ansible_host_variable',
+        'ansible_connection_variable',
+    ]:
+        assert column in query
+
+
+@patch('metrics_utility.library.collectors.controller.main_hostmetric.PAGE_SIZE', 2)
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_hostmetric_keyset_pagination(mock_copy_pandas):
+    """A full page triggers another query carrying the last row as a keyset marker."""
+    page1 = pd.DataFrame({'hostname': ['a', 'b'], 'host_id': [1, 2]})
+    page2 = pd.DataFrame({'hostname': ['c'], 'host_id': [3]})
+    mock_copy_pandas.side_effect = [page1, page2]
+
+    result = main_hostmetric(db=MagicMock(), since=SINCE).gather()
+
+    assert list(result['hostname']) == ['a', 'b', 'c']
+    assert mock_copy_pandas.call_count == 2
+
+    # first page: no marker, only the page-size LIMIT is bound
+    first_params = mock_copy_pandas.call_args_list[0][0][2]
+    assert first_params == [2]
+
+    # second page: keyset marker from last row of page1 (hostname='b', host_id=2)
+    second_query = mock_copy_pandas.call_args_list[1][0][1]
+    second_params = mock_copy_pandas.call_args_list[1][0][2]
+    assert 'main_hostmetric.hostname > %s' in second_query
+    assert second_params == ['b', 'b', 2, 2]
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_files')
+def test_main_hostmetric_csv_output_single_copy(mock_copy_files, tmp_path):
+    """The CSV (gather) path streams via a single COPY: no LIMIT, no keyset marker."""
+    mock_copy_files.return_value = ['host_metric.csv']
+
+    output = CollectionOutput(str(tmp_path))
+    result = main_hostmetric(db=MagicMock(), since=SINCE, until=UNTIL, output=output).gather()
+
+    assert result == ['host_metric.csv']
+    mock_copy_files.assert_called_once()
+
+    _db, query, _filespec, params = mock_copy_files.call_args[0]
+    assert 'LIMIT' not in query
+    assert 'hostname > %s' not in query
+    assert SINCE.isoformat() in query
+    assert UNTIL.isoformat() in query
+    assert params == []
+
+
+def test_host_metric_query_since_only():
+    """since-only filter (via date_where), as used by the Renewal Guidance report."""
+    query, params = _host_metric_query(since=SINCE)
+
+    assert f"main_hostmetric.last_automation >= '{SINCE.isoformat()}'" in query
+    assert 'main_hostmetric.last_automation <' not in query
+    assert 'LIMIT' not in query
+    assert params == []
+
+
+def test_host_metric_query_full_params_order():
+    """since/until interpolated via date_where; marker and limit bound in placeholder order."""
+    query, params = _host_metric_query(since=SINCE, until=UNTIL, marker=('host9', 5), limit=10000)
+
+    assert SINCE.isoformat() in query
+    assert UNTIL.isoformat() in query
+    assert 'main_hostmetric.hostname > %s' in query
+    assert 'LIMIT %s' in query
+    assert params == ['host9', 'host9', 5, 10000]
+
+
+def test_host_metric_query_no_filters():
+    """No bounds produces WHERE true and no bound params."""
+    query, params = _host_metric_query()
+
+    assert 'WHERE true' in query
+    assert params == []

--- a/metrics_utility/test/library/test_collectors_main_hostmetric.py
+++ b/metrics_utility/test/library/test_collectors_main_hostmetric.py
@@ -90,6 +90,23 @@ def test_main_hostmetric_keyset_pagination(mock_copy_pandas):
     assert second_params == ['b', 'b', 2, 2]
 
 
+@patch('metrics_utility.library.collectors.controller.main_hostmetric.PAGE_SIZE', 2)
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_hostmetric_exact_multiple_preserves_dtypes(mock_copy_pandas):
+    """A row count that is an exact multiple of the page size fetches a trailing empty
+    page; it must be skipped so concatenation does not downgrade column dtypes to object."""
+    page1 = pd.DataFrame({'hostname': ['a', 'b'], 'host_id': [1, 2], 'deleted': [True, False]})
+    # trailing empty page (all-object dtypes) - must not corrupt the result
+    empty = pd.DataFrame({'hostname': [], 'host_id': [], 'deleted': []}, dtype=object)
+    mock_copy_pandas.side_effect = [page1, empty]
+
+    result = main_hostmetric(db=MagicMock(), since=SINCE).gather()
+
+    assert list(result['hostname']) == ['a', 'b']
+    assert result['host_id'].dtype == page1['host_id'].dtype
+    assert result['deleted'].dtype == page1['deleted'].dtype
+
+
 @patch('metrics_utility.library.collectors.util._copy_table_files')
 def test_main_hostmetric_csv_output_single_copy(mock_copy_files, tmp_path):
     """The CSV (gather) path streams via a single COPY: no LIMIT, no keyset marker."""

--- a/metrics_utility/test/library/test_collectors_util_output.py
+++ b/metrics_utility/test/library/test_collectors_util_output.py
@@ -81,7 +81,7 @@ class TestDataframeOutput:
         query = 'SELECT id FROM users'
         output.sql(mock_db, query)
 
-        mock_cursor.execute.assert_called_once_with(query)
+        mock_cursor.execute.assert_called_once_with(query, None)
 
     def test_sql_returns_correct_columns(self):
         """Test that DataFrame has correct columns from cursor description."""

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -2,8 +2,12 @@ import tempfile
 
 import pytest
 
+import metrics_utility.automation_controller_billing.collectors as controller_collectors
+
+from metrics_utility.base import Collector
 from metrics_utility.exceptions import MissingRequiredEnvVar
 from metrics_utility.management.validation import (
+    VALID_COLLECTORS,
     handle_directory_ship_target,
     handle_env_validation,
     handle_s3_ship_target,
@@ -18,6 +22,23 @@ from metrics_utility.management.validation import (
 
 # Error message constants
 MAX_GATHER_DAYS_ERROR_MSG = 'Value must be number between 0 to 3650'
+
+# Collectors that are always gathered and so are not toggled via
+# METRICS_UTILITY_OPTIONAL_COLLECTORS (hence intentionally absent from VALID_COLLECTORS).
+ALWAYS_ON_COLLECTORS = {'config', 'job_host_summary'}
+
+
+def test_valid_collectors_matches_registered_optional_collectors():
+    """Every optional (togglable) registered collector must be in VALID_COLLECTORS.
+
+    Guards against registering a collector gated on METRICS_UTILITY_OPTIONAL_COLLECTORS
+    without allowlisting it -- which would make it impossible to enable (validation
+    rejects it), and against stale allowlist entries for collectors that no longer exist.
+    """
+    registered = set(Collector.registered_collectors(controller_collectors))
+    optional = registered - ALWAYS_ON_COLLECTORS
+
+    assert optional == VALID_COLLECTORS
 
 
 @pytest.fixture(autouse=True)

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -6,7 +6,7 @@ export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="directory"
 
 # FIXME: total_workers_vcpu needs more setup
-export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"
+export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_hostmetric,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"
 
 if ! pg_isready -h localhost; then
   echo "run-s3-gather-build: DB not ready, run make compose first"


### PR DESCRIPTION
Issue: AAP-89148

Extract the host_metric query from ExtractorControllerDB into a proper main_hostmetric library collector, keeping the parameterized SQL and keyset pagination from #530. The keyset marker and LIMIT are bound params; since/until use date_where, matching the other collectors.

The collector paginates via a new generic sql_keyset() on the output adapters: DataframeOutput loops keyset pages and concatenates, while CollectionOutput streams the whole result via a single COPY (used by the new main_hostmetric gather collector). ExtractorControllerDB becomes a thin adapter delegating to the collector for the Renewal Guidance report.

---

this allows us to make the source data for renewal guidance report available to metrics-service, cc @D4D3VD4V3
(pending the resolution of `ensure_functions` - relevant to more collectors, https://github.com/ansible/metrics-utility/pull/536#discussion_r3749968250 )