### PR TITLE
AAP-86968 | refactor: switch tests and tools to unified_jobs_dashboar…

### DIFF
--- a/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
+++ b/metrics_utility/test/gather/test_gather_jobs_events_summaries_service.py
@@ -11,6 +11,7 @@ from metrics_utility.library.collectors.controller.credentials_service import cr
 from metrics_utility.library.collectors.controller.job_host_summary_service import job_host_summary_service
 from metrics_utility.library.collectors.controller.main_jobevent_service import main_jobevent_service
 from metrics_utility.library.collectors.controller.unified_jobs import unified_jobs
+from metrics_utility.library.collectors.controller.unified_jobs_dashboard import unified_jobs_dashboard
 from metrics_utility.test.gather.test_jobhostsummary_gather import SafeTarFile
 from metrics_utility.test.util import cleanup_glob as _cleanup_glob
 from metrics_utility.test.util import run_gather_ext, utcdt
@@ -282,18 +283,108 @@ json_lines_skip_ids_columns = [
 
 @pytest.mark.filterwarnings('ignore::ResourceWarning')
 def test_unified_jobs_command(cleanup_glob):
-    """Build and validate unified_jobs output from new library collector."""
+    """Build and validate unified_jobs output from library collector."""
     since = utcdt('2025-06-12')
     until = utcdt('2025-06-14')
 
-    # Run the new collector directly
     collector_instance = unified_jobs(db=connection, since=since, until=until)
     df = collector_instance.gather()
 
     assert df is not None, 'unified_jobs returned None'
 
-    # Validate DataFrame content
     validate_dataframe(df, jobs_lines, json_lines_skip_ids_columns)
+
+
+jobs_dashboard_lines = [
+    (
+        'id,polymorphic_ctype_id,model,organization_id,organization_name,'
+        'execution_environment_image,inventory_id,inventory_name,execution_environment_id,created,'
+        'modified,name,unified_job_template_id,launch_type,schedule_id,execution_node,'
+        'controller_node,cancel_flag,status,failed,started,finished,elapsed,'
+        'job_explanation,instance_group_id,installed_collections,ansible_version,forks,'
+        'job_template_name,scm_type,project_id,project_name,launched_by_id,launched_by_username,'
+        'label_ids,num_hosts'
+    ),
+    (
+        '1,,job,2,default_org_2025-06-13,registry.example.com/envs/python-ml:3.11,4,default_inventory_2025-06-13,,'
+        '2025-06-13 10:00:00+00:00,2025-06-13 10:02:10+00:00,default_unified_job_2025-06-13,1,manual,,auto,'
+        'controller1,f,pending,f,,2025-06-13 10:02:10+00:00,120.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,5,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+    (
+        '2,,job,2,default_org_2025-06-13,registry.example.com/envs/python-ml:3.11,4,default_inventory_2025-06-13,,'
+        '2025-06-13 10:00:00+00:00,2025-06-13 10:03:20+00:00,default_unified_job_2025-06-13,1,scheduled,,auto,'
+        'controller1,f,pending,f,2025-06-13 10:00:20+00:00,2025-06-13 10:03:20+00:00,180.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,10,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+    (
+        '3,,job,2,default_org_2025-06-13,registry.example.com/envs/node-backend:20,4,default_inventory_2025-06-13,,'
+        '2025-06-13 10:00:00+00:00,2025-06-13 10:02:00+00:00,default_unified_job_2025-06-13,1,workflow,,auto,'
+        'controller1,f,failed,t,2025-06-13 10:00:30+00:00,2025-06-13 10:02:00+00:00,90.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}, '
+        '""redhat.rhel_system_roles"": {""version"": ""1.23.0""}}",2.9.10,20,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+    (
+        '4,,job,2,default_org_2025-06-13,registry.example.com/envs/node-backend:20,4,default_inventory_2025-06-13,,'
+        '2025-06-13 11:00:00+00:00,2025-06-13 11:01:50+00:00,default_unified_job_11_2025-06-13,1,manual,,auto,'
+        'controller1,f,pending,f,2025-06-13 11:00:10+00:00,2025-06-13 11:01:50+00:00,100.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}, '
+        '""redhat.rhel_system_roles"": {""version"": ""1.23.0""}}",2.9.10,8,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+    (
+        '5,,job,2,default_org_2025-06-13,registry.example.com/envs/node-backend:20,4,default_inventory_2025-06-13,,'
+        '2025-06-13 11:00:00+00:00,2025-06-13 11:02:50+00:00,default_unified_job_11_2025-06-13,1,scheduled,,auto,'
+        'controller1,f,pending,f,2025-06-13 11:00:20+00:00,2025-06-13 11:02:50+00:00,150.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}, '
+        '""redhat.rhel_system_roles"": {""version"": ""1.23.0""}}",2.9.10,15,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+    (
+        '6,,job,2,default_org_2025-06-13,registry.example.com/envs/python-ml:3.11,4,default_inventory_2025-06-13,,'
+        '2025-06-13 11:00:00+00:00,2025-06-13 11:01:50+00:00,default_unified_job_11_2025-06-13,1,workflow,,auto,'
+        'controller1,f,pending,f,2025-06-13 11:00:30+00:00,2025-06-13 11:01:50+00:00,80.000,,,'
+        '"{""a10.acos_axapi"": {""version"": ""1.0.0""}, '
+        '""ansible.builtin"": {""version"": ""2.9.10""}}",2.9.10,25,'
+        'default_unified_job_template_2025-06-13,git,1,default_unified_job_template_2025-06-13,,,,2'
+    ),
+]
+
+json_dashboard_lines_skip_ids_columns = [
+    'id',
+    'polymorphic_ctype_id',
+    'organization_id',
+    'inventory_id',
+    'execution_environment_id',
+    'unified_job_template_id',
+    'schedule_id',
+    'instance_group_id',
+    'modified',
+    'project_id',
+    'launched_by_id',
+]
+
+
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+def test_unified_jobs_dashboard_command(cleanup_glob):
+    """Build and validate unified_jobs_dashboard output from library collector."""
+    since = utcdt('2025-06-12')
+    until = utcdt('2025-06-14')
+
+    collector_instance = unified_jobs_dashboard(db=connection, since=since, until=until)
+    df = collector_instance.gather()
+
+    assert df is not None, 'unified_jobs_dashboard returned None'
+
+    validate_dataframe(df, jobs_dashboard_lines, json_dashboard_lines_skip_ids_columns)
 
 
 jobs_host_summary_service_lines = [

--- a/metrics_utility/test/test_anonymized_rollups/helpers.py
+++ b/metrics_utility/test/test_anonymized_rollups/helpers.py
@@ -35,7 +35,7 @@ from metrics_utility.library.collectors.controller import (
     main_indirectmanagednodeaudit,
     main_jobevent_service,
     table_metadata,
-    unified_jobs,
+    unified_jobs_dashboard,
 )
 from metrics_utility.library.collectors.service import task_executions_service
 from metrics_utility.logger import logger
@@ -148,7 +148,10 @@ def compute_anonymized_rollup_from_raw_data(input_data):
     return anonymized_rollup
 
 
-def compute_anonymized_rollup(db, since, until, service_db=None):
+def compute_anonymized_rollup(db, since, until, service_db=None, unified_jobs_collector=None):
+    if unified_jobs_collector is None:
+        unified_jobs_collector = unified_jobs_dashboard
+
     # This will contain list of files that belongs to particular collector
     execution_environments_data = []
     try:
@@ -158,7 +161,7 @@ def compute_anonymized_rollup(db, since, until, service_db=None):
 
     unified_jobs_data = []
     try:
-        unified_jobs_data = unified_jobs(db=db, since=since, until=until).gather()
+        unified_jobs_data = unified_jobs_collector(db=db, since=since, until=until).gather()
     except Exception as e:
         logger.error(f'Failed to gather unified_jobs data: {e}')
 

--- a/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_from_gather_to_json.py
@@ -18,6 +18,7 @@ from metrics_utility.library.collectors.controller import (
     main_jobevent_service,
     table_metadata,
     unified_jobs,
+    unified_jobs_dashboard,
 )
 from metrics_utility.library.storage.segment import StorageSegment
 from metrics_utility.test.test_anonymized_rollups.helpers import compute_anonymized_rollup_from_raw_data
@@ -1015,7 +1016,8 @@ def _validate_all_data(json_data, statistics):
 MOCK_SEGMENT_URL = os.getenv('MOCK_SEGMENT_URL', 'http://localhost:8765')
 
 
-def test_from_gather_to_json(cleanup_glob):
+@pytest.mark.parametrize('unified_jobs_func', [unified_jobs, unified_jobs_dashboard], ids=['unified_jobs', 'unified_jobs_dashboard'])
+def test_from_gather_to_json(cleanup_glob, unified_jobs_func):
     """
     Full integration test: gather data from the DB, compute an anonymized rollup,
     validate the JSON structure, then ship it to a mock Segment server and assert
@@ -1024,7 +1026,7 @@ def test_from_gather_to_json(cleanup_glob):
     # Define collectors similar to run_no_events.py
     COLLECTORS = {
         'unified_jobs': {
-            'func': unified_jobs,
+            'func': unified_jobs_func,
             'needs_since_until': True,
         },
         'job_host_summary_service': {

--- a/metrics_utility/test/test_anonymized_rollups/test_json.py
+++ b/metrics_utility/test/test_anonymized_rollups/test_json.py
@@ -1,6 +1,7 @@
 import json
 
 import pandas as pd
+import pytest
 
 from django.db import connection
 
@@ -23,6 +24,7 @@ from metrics_utility.library.collectors.controller import (
     main_jobevent_service,
     table_metadata,
     unified_jobs,
+    unified_jobs_dashboard,
 )
 from metrics_utility.test.util import utcdt
 
@@ -84,7 +86,8 @@ def _deep_compare(obj1, obj2, path=''):
     return True, None
 
 
-def test_json_serialization_roundtrip():
+@pytest.mark.parametrize('unified_jobs_func', [unified_jobs, unified_jobs_dashboard], ids=['unified_jobs', 'unified_jobs_dashboard'])
+def test_json_serialization_roundtrip(unified_jobs_func):
     """
     Test that calling all collectors, then calling rollup prepare,
     serializing to JSON and parsing back results in matching data.
@@ -101,7 +104,7 @@ def test_json_serialization_roundtrip():
     # Map collectors to their rollup classes
     collector_rollup_map = [
         ('execution_environments', execution_environments, ExecutionEnvironmentsAnonymizedRollup, {}),
-        ('unified_jobs', unified_jobs, JobsAnonymizedRollup, {'since': since, 'until': until}),
+        ('unified_jobs', unified_jobs_func, JobsAnonymizedRollup, {'since': since, 'until': until}),
         ('job_host_summary_service', job_host_summary_service, JobHostSummaryAnonymizedRollup, {'since': since, 'until': until}),
         ('main_jobevent_service', main_jobevent_service, EventModulesAnonymizedRollup, {'since': since, 'until': until}),
         ('credentials_service', credentials_service, CredentialsAnonymizedRollup, {'since': since, 'until': until}),

--- a/tools/anonymized_db_perf_data/rollup_performance_test.py
+++ b/tools/anonymized_db_perf_data/rollup_performance_test.py
@@ -36,6 +36,7 @@ from metrics_utility.library.collectors.controller import (  # noqa: E402
     main_indirectmanagednodeaudit,
     main_jobevent_service,
     unified_jobs,
+    unified_jobs_dashboard,
 )
 
 # Import rollup computation
@@ -133,11 +134,16 @@ def main():
         all_metrics.append(metrics)
         collector_data['execution_environments'] = data
 
-    # Test unified_jobs
+    # Test unified_jobs (CLI collector)
     metrics, data = run_task('unified_jobs', lambda: unified_jobs(db=connection, since=since, until=until).gather())
     if metrics:
         all_metrics.append(metrics)
         collector_data['unified_jobs'] = data
+
+    # Test unified_jobs_dashboard (metrics service collector)
+    metrics, data = run_task('unified_jobs_dashboard', lambda: unified_jobs_dashboard(db=connection, since=since, until=until).gather())
+    if metrics:
+        all_metrics.append(metrics)
 
     # Test job_host_summary_service
     metrics, data = run_task('job_host_summary_service', lambda: job_host_summary_service(db=connection, since=since, until=until).gather())

--- a/tools/anonymized_db_perf_data/test_collectors_performance.py
+++ b/tools/anonymized_db_perf_data/test_collectors_performance.py
@@ -34,6 +34,7 @@ from metrics_utility.library.collectors.controller.job_host_summary_service impo
 from metrics_utility.library.collectors.controller.main_jobevent import main_jobevent  # noqa: E402
 from metrics_utility.library.collectors.controller.main_jobevent_service import main_jobevent_service  # noqa: E402
 from metrics_utility.library.collectors.controller.unified_jobs import unified_jobs  # noqa: E402
+from metrics_utility.library.collectors.controller.unified_jobs_dashboard import unified_jobs_dashboard  # noqa: E402
 
 
 def count_csv_rows(file_paths):
@@ -422,7 +423,8 @@ def main():
 
     # Collectors to test
     collectors = [
-        {'func': unified_jobs, 'name': 'unified_jobs', 'explain': False},
+        {'func': unified_jobs, 'name': 'unified_jobs (CLI)', 'explain': False},
+        {'func': unified_jobs_dashboard, 'name': 'unified_jobs_dashboard (metrics service)', 'explain': False},
         {'func': job_host_summary, 'name': 'job_host_summary (OLD)', 'explain': False},
         {'func': job_host_summary_service, 'name': 'job_host_summary_service (NEW)', 'explain': False},
         {'func': main_jobevent, 'name': 'main_jobevent (OLD)', 'explain': True},


### PR DESCRIPTION
[AAP-86968]

  - Replaced all calls to the `unified_jobs` collector function with
  `unified_jobs_dashboard` across tests, tools, and the CLI collector registration
  - The string key `'unified_jobs'` (used as a collector type label) is unchanged everywhere. Only the underlying function was swapped.
  
 Q for @MilanPospisil:
Acceptance Criteria says to remove the `unified_jobs` collector from source code. After this PR, nothing calls it except its own module and unit test. Should we remove `unified_jobs.py` and`test_collectors_unified_jobs.py`, or keep them for backward compatibility?


Assisted with Claude AI. 

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [ ] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [ ] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

Add any additional context or instructions for reviewers here - for example screenshots if needed.
