### PR TITLE
vcpu - local/mock Prometheus gather + run-vcpu

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -92,7 +92,7 @@ jobs:
           METRICS_UTILITY_DB_USER: "awx"
           METRICS_UTILITY_DB_PASSWORD: "awx"
           MOCK_SEGMENT_URL: "http://localhost:8765"
-          MOCK_PROMETHEUS_URL: "http://localhost:9090"
+          METRICS_UTILITY_PROMETHEUS_URL: "http://localhost:9090"
         run: |
           uv run pytest -s -v --cov=. --cov-branch --cov-report=xml
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -96,6 +96,8 @@ container
 * `METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS` - maximum lenght of collection interval in days, default 28; `get_max_gather_period_days`
 * `METRICS_UTILITY_OPTIONAL_COLLECTORS` - optional collectors, comma-separated list
 * `METRICS_UTILITY_PROMETHEUS_URL` - Prometheus base url
+* `METRICS_UTILITY_PROMETHEUS_TOKEN` - Prometheus bearer token, overrides the in-cluster service-account token (local testing, see `./run-vcpu`)
+* `METRICS_UTILITY_PROMETHEUS_CA_CERT_PATH` - CA cert for Prometheus TLS, overrides the in-cluster service CA; empty string skips verification
 * `METRICS_UTILITY_USAGE_BASED_METERING_ENABLED` - `total_workers_vcpu` collector toggle - skips kubernetes when disabled (=false, default)
 
 

--- a/docs/vcpu.md
+++ b/docs/vcpu.md
@@ -10,5 +10,8 @@
 
   - `METRICS_UTILITY_CLUSTER_NAME`: Contains the cluster name which is part of the collection payload.
   - `METRICS_UTILITY_USAGE_BASED_METERING_ENABLED`: [true/false] In case of true, the payload will contain the actual number of total vcpu accross all workers otherwise the total will be set to 1.
+  - `METRICS_UTILITY_PROMETHEUS_URL`: Prometheus base url (defaults to the in-cluster openshift-monitoring endpoint).
+  - `METRICS_UTILITY_PROMETHEUS_TOKEN`: Bearer token for Prometheus. Overrides the in-cluster service-account token, mainly for local testing (see `./run-vcpu`).
+  - `METRICS_UTILITY_PROMETHEUS_CA_CERT_PATH`: Path to the CA certificate used to verify Prometheus TLS. Overrides the in-cluster service CA; set to an empty string to skip verification (e.g. plain `http` mock).
 
 N.B.: The SaaS solution runs on ROSA HCP so all nodes are workers, if this collector is used for another solution then the filtering must be implemented.

--- a/metrics_utility/automation_controller_billing/collectors.py
+++ b/metrics_utility/automation_controller_billing/collectors.py
@@ -238,18 +238,28 @@ def cli_total_workers_vcpu(since, until, output):
     token = None
     ca_cert_path = None
     if metering_enabled:
+        # METRICS_UTILITY_PROMETHEUS_TOKEN / _CA_CERT_PATH override the in-cluster
+        # service-account paths, so we can gather against a local/mock Prometheus
+        # (see ./run-vcpu). Set _CA_CERT_PATH to an empty string to skip TLS verification.
+        token = os.getenv('METRICS_UTILITY_PROMETHEUS_TOKEN')
+        ca_cert_path = os.getenv('METRICS_UTILITY_PROMETHEUS_CA_CERT_PATH')
+
         token_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
-        if not os.path.exists(token_path):
+        if not token and not os.path.exists(token_path):
             raise MetricsException(f'Service account token not found at {token_path}')
 
-        ca_cert_path = '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
-        if not os.path.exists(ca_cert_path):
+        if ca_cert_path is None:
+            ca_cert_path = '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+            if not os.path.exists(ca_cert_path):
+                raise MetricsException(f'CA_CERT not found at {ca_cert_path}')
+        elif ca_cert_path and not os.path.exists(ca_cert_path):
             raise MetricsException(f'CA_CERT not found at {ca_cert_path}')
 
-        with open(token_path) as f:
-            token = f.read().strip()
         if not token:
-            raise MetricsException(f'Unable to retrieve the token for the current service account from {token_path}')
+            with open(token_path) as f:
+                token = f.read().strip()
+            if not token:
+                raise MetricsException(f'Unable to retrieve the token for the current service account from {token_path}')
 
     def log_info_data(info):
         # This message must always appear in the log regardless of the log level.

--- a/metrics_utility/test/gather/test_vcpu_gather_integration.py
+++ b/metrics_utility/test/gather/test_vcpu_gather_integration.py
@@ -16,7 +16,7 @@ import pytest
 from metrics_utility.test.util import run_gather_int
 
 
-MOCK_PROMETHEUS_URL = os.getenv('MOCK_PROMETHEUS_URL', 'http://localhost:9090')
+PROMETHEUS_URL = os.getenv('METRICS_UTILITY_PROMETHEUS_URL', 'http://localhost:9090')
 
 K8S_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 K8S_CERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
@@ -42,7 +42,7 @@ env_vars = {
     'METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR': 'true',
     'METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES': 'true',
     'METRICS_UTILITY_OPTIONAL_COLLECTORS': 'total_workers_vcpu',
-    'METRICS_UTILITY_PROMETHEUS_URL': MOCK_PROMETHEUS_URL,
+    'METRICS_UTILITY_PROMETHEUS_URL': PROMETHEUS_URL,
     'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
     'METRICS_UTILITY_SHIP_PATH': './metrics_utility/test/test_data',
     'METRICS_UTILITY_SHIP_TARGET': 'directory',
@@ -60,13 +60,13 @@ def _load_schema(filename):
 
 def _configure_mock(**kwargs):
     data = json.dumps(kwargs).encode()
-    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
+    req = urllib.request.Request(f'{PROMETHEUS_URL}/config', data=data, method='POST')
     req.add_header('Content-Type', 'application/json')
     urllib.request.urlopen(req)
 
 
 def _reset_mock():
-    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
+    req = urllib.request.Request(f'{PROMETHEUS_URL}/reset', method='POST')
     urllib.request.urlopen(req)
 
 
@@ -133,7 +133,7 @@ def test_vcpu_gather_validates_against_schema(mock_exists, mock_open, cleanup_gl
     assert 'total_workers_vcpu.json' in manifest_data
 
     # verify Prometheus was actually called (instant + range query)
-    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests') as resp:
+    with urllib.request.urlopen(f'{PROMETHEUS_URL}/requests') as resp:
         captured = json.loads(resp.read())
     paths = [r['path'] for r in captured]
     assert '/api/v1/query' in paths

--- a/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
+++ b/metrics_utility/test/library/test_collectors_prometheus_client_integration.py
@@ -13,23 +13,23 @@ from metrics_utility.library.collectors.others.total_workers_vcpu import (
 )
 
 
-MOCK_PROMETHEUS_URL = os.getenv('MOCK_PROMETHEUS_URL', 'http://localhost:9090')
+PROMETHEUS_URL = os.getenv('METRICS_UTILITY_PROMETHEUS_URL', 'http://localhost:9090')
 
 
 def reset_mock():
-    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/reset', method='POST')
+    req = urllib.request.Request(f'{PROMETHEUS_URL}/reset', method='POST')
     urllib.request.urlopen(req)
 
 
 def configure_mock(**kwargs):
     data = json.dumps(kwargs).encode()
-    req = urllib.request.Request(f'{MOCK_PROMETHEUS_URL}/config', data=data, method='POST')
+    req = urllib.request.Request(f'{PROMETHEUS_URL}/config', data=data, method='POST')
     req.add_header('Content-Type', 'application/json')
     urllib.request.urlopen(req)
 
 
 def get_captured_requests():
-    with urllib.request.urlopen(f'{MOCK_PROMETHEUS_URL}/requests') as resp:
+    with urllib.request.urlopen(f'{PROMETHEUS_URL}/requests') as resp:
         return json.loads(resp.read())
 
 
@@ -39,7 +39,7 @@ class TestPrometheusClientIntegration:
         configure_mock(cpu_value='16', empty_result=False)
 
     def test_instant_query(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         result = client.query('sum(machine_cpu_cores)')
 
         assert len(result) == 1
@@ -51,14 +51,14 @@ class TestPrometheusClientIntegration:
         assert captured[0]['params']['query'] == 'sum(machine_cpu_cores)'
 
     def test_instant_query_with_time_param(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         result = client.query('up', time_param=1700000000.0)
 
         assert len(result) == 1
         assert float(result[0]['value'][0]) == pytest.approx(1700000000.0)
 
     def test_range_query(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         start = 1700000000.0
         end = 1700003600.0  # 1 hour later
         result = client.query_range('sum(machine_cpu_cores)', start_time=start, end_time=end, step='5m')
@@ -76,7 +76,7 @@ class TestPrometheusClientIntegration:
         assert captured[0]['params']['step'] == '5m'
 
     def test_get_current_value(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         value = client.get_current_value('sum(machine_cpu_cores)')
 
         assert value == pytest.approx(16.0)
@@ -84,7 +84,7 @@ class TestPrometheusClientIntegration:
     def test_get_current_value_empty_result(self):
         configure_mock(empty_result=True)
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         value = client.get_current_value('sum(machine_cpu_cores)')
 
         assert value is None
@@ -96,7 +96,7 @@ class TestVcpuHelpersIntegration:
         configure_mock(cpu_value='16', empty_result=False)
 
     def test_get_total_workers_cpu(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         base_ts = 1700000000.0
         vcpu_val, query = get_total_workers_cpu(client, base_ts)
 
@@ -107,13 +107,13 @@ class TestVcpuHelpersIntegration:
     def test_get_total_workers_cpu_no_data(self):
         configure_mock(empty_result=True)
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         vcpu_val, _query = get_total_workers_cpu(client, 1700000000.0)
 
         assert vcpu_val is None
 
     def test_get_cpu_timeline(self):
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         start = 1700000000.0
         end = 1700003600.0
 
@@ -127,7 +127,7 @@ class TestVcpuHelpersIntegration:
     def test_get_cpu_timeline_empty(self):
         configure_mock(empty_result=True)
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         timeline = get_cpu_timeline(client, 1700000000.0, 1700003600.0)
 
         assert timeline == []
@@ -135,7 +135,7 @@ class TestVcpuHelpersIntegration:
     def test_dynamic_cpu_value(self):
         configure_mock(cpu_value='32')
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         value = client.get_current_value('sum(machine_cpu_cores)')
 
         assert value == pytest.approx(32.0)
@@ -143,7 +143,7 @@ class TestVcpuHelpersIntegration:
     def test_range_query_varying_values(self):
         configure_mock(cpu_value=['8', '16', '24'])
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         start = 1700000000.0
         end = 1700000600.0  # 10 minutes later
         result = client.query_range('sum(machine_cpu_cores)', start_time=start, end_time=end, step='5m')
@@ -157,7 +157,7 @@ class TestVcpuHelpersIntegration:
     def test_instant_query_returns_last_value_from_list(self):
         configure_mock(cpu_value=['8', '16', '24'])
 
-        client = PrometheusClient(url=MOCK_PROMETHEUS_URL)
+        client = PrometheusClient(url=PROMETHEUS_URL)
         value = client.get_current_value('sum(machine_cpu_cores)')
 
         assert value == pytest.approx(24.0)

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -9,7 +9,7 @@ export METRICS_UTILITY_SHIP_TARGET="directory"
 export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_hostmetric,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"
 
 if ! pg_isready -h localhost; then
-  echo "run-s3-gather-build: DB not ready, run make compose first"
+  echo "run-ccsp2-gather: DB not ready, run make compose first"
   exit 1
 fi
 

--- a/run-ccsp2-gather
+++ b/run-ccsp2-gather
@@ -5,7 +5,7 @@ cd "`dirname "$0"`"
 export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="directory"
 
-# FIXME: total_workers_vcpu needs more setup
+# total_workers_vcpu excluded - see ./run-vcpu
 export METRICS_UTILITY_OPTIONAL_COLLECTORS="execution_environments,job_host_summary_service,main_host,main_hostmetric,main_indirectmanagednodeaudit,main_jobevent,main_jobevent_service,unified_jobs"
 
 if ! pg_isready -h localhost; then

--- a/run-renewal
+++ b/run-renewal
@@ -7,7 +7,7 @@ export METRICS_UTILITY_SHIP_PATH="./out"
 export METRICS_UTILITY_SHIP_TARGET="controller_db"
 
 if ! pg_isready -h localhost; then
-  echo "run-s3-gather-build: DB not ready, run make compose first"
+  echo "run-renewal: DB not ready, run make compose first"
   exit 1
 fi
 

--- a/run-vcpu
+++ b/run-vcpu
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+cd "`dirname "$0"`"
+
+export METRICS_UTILITY_CLUSTER_NAME="aap-dev"
+export METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR="true"
+export METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES="true"
+export METRICS_UTILITY_OPTIONAL_COLLECTORS="total_workers_vcpu"
+export METRICS_UTILITY_SHIP_PATH="./out/vcpu"
+export METRICS_UTILITY_SHIP_TARGET="directory"
+export METRICS_UTILITY_USAGE_BASED_METERING_ENABLED="true"
+
+# talk to the mock-prometheus container from `make compose` (see tools/mock-prometheus-server)
+export METRICS_UTILITY_PROMETHEUS_URL="http://localhost:9090"
+export METRICS_UTILITY_PROMETHEUS_TOKEN="dev"        # override the in-cluster service-account token
+export METRICS_UTILITY_PROMETHEUS_CA_CERT_PATH=""     # skip TLS verification for the plain-http mock
+
+if ! pg_isready -h localhost; then
+  echo "run-vcpu: DB not ready, run make compose first"
+  exit 1
+fi
+
+if ! curl -sf "$METRICS_UTILITY_PROMETHEUS_URL/api/v1/query?query=up" >/dev/null; then
+  echo "run-vcpu: Prometheus not reachable at $METRICS_UTILITY_PROMETHEUS_URL, run make compose first"
+  exit 1
+fi
+
+TIME=`command -v gtime >/dev/null 2>&1 && echo 'gtime' || echo '/usr/bin/time'`
+$TIME --format='\n\nmemory %MK\ncpu %P\ntime %es\n\n' \
+uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force "$@"
+
+set -x
+ls -lR out/vcpu/data/`date +%Y`/

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
       METRICS_UTILITY_BUCKET_SECRET_KEY: "myusersecretkey"
       METRICS_UTILITY_DB_HOST: "postgres"
       MOCK_SEGMENT_URL: "http://mock-segment:8765"
-      MOCK_PROMETHEUS_URL: "http://mock-prometheus:9090"
+      METRICS_UTILITY_PROMETHEUS_URL: "http://mock-prometheus:9090"
     entrypoint: |
       sh -c '
         set -e


### PR DESCRIPTION
Replaces #316 

The `total_workers_vcpu` collector required in-cluster service-account files (`/var/run/secrets/...`), so it could only run inside the cluster — the reason `run-ccsp2-gather` carried a `# FIXME: total_workers_vcpu needs more setup`.

- Add `METRICS_UTILITY_PROMETHEUS_TOKEN` and `METRICS_UTILITY_PROMETHEUS_CA_CERT_PATH` overrides for the SA token/CA paths. An empty `_CA_CERT_PATH` skips TLS verification (for the plain-http mock). Existence-check ordering is preserved, so the token-handling tests are unchanged.

- Add a `run-vcpu` helper wired to the `mock-prometheus` service already started by `make compose` (`http://localhost:9090`), mirroring the other `run-*` scripts.

- Document the three prometheus env vars in `docs/vcpu.md` and `docs/environment.md`.

rename `MOCK_PROMETHEUS_URL` → `METRICS_UTILITY_PROMETHEUS_URL` - respected by the cli and the tests now
(metrics-service CI doesn't reference it, so not a compat issue)

And fixed `run-ccsp2-gather` / `run-renewal` printing `run-s3-gather-build` in their DB-not-ready messages (copy-paste leftover).

---

Making the collector a bit more runnable for ANSTRAT-1587.