### PR TITLE
[stable-0.7] bump version to 0.7.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = metrics_utility
 author = Red Hat
 author_email = info@ansible.com
-version = 0.7.7
+version = 0.7.8
 
 [options]
 packages = find:


### PR DESCRIPTION
[AAP-85808]
[AAP-85807]

Connected to https://github.com/ansible/metrics-utility/pull/544.

Version bump to trigger PyPI release after Django 5.2.17 cherry-pick (PR https://github.com/ansible/metrics-utility/pull/544). No code changes; version number only.

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

