### PR TITLE
[stable-0.7] AAP-88628 | feat: support implicit S3 credentials (cherry-pick of #547)

### DIFF
--- a/metrics_utility/automation_controller_billing/base/s3_handler.py
+++ b/metrics_utility/automation_controller_billing/base/s3_handler.py
@@ -15,6 +15,12 @@ class S3Handler:
         self.bucket_access_key = params.get('bucket_access_key')
         self.bucket_secret_key = params.get('bucket_secret_key')
 
+        if bool(self.bucket_access_key) != bool(self.bucket_secret_key):
+            raise ValueError(
+                'bucket_access_key and bucket_secret_key must both be provided or both be omitted'
+                ' (omit both to use implicit credentials such as IRSA or EC2 instance profiles)'
+            )
+
         self._session = None
 
     @property
@@ -22,11 +28,22 @@ class S3Handler:
         if self._session is not None:
             return self._session
 
-        self._session = boto3.Session(
-            aws_access_key_id=self.bucket_access_key,
-            aws_secret_access_key=self.bucket_secret_key,
-            region_name=self.bucket_region,
-        )
+        session_kwargs = {'region_name': self.bucket_region}
+        if self.bucket_access_key and self.bucket_secret_key:
+            session_kwargs['aws_access_key_id'] = self.bucket_access_key
+            session_kwargs['aws_secret_access_key'] = self.bucket_secret_key
+
+        session = boto3.Session(**session_kwargs)
+
+        if not self.bucket_access_key and session.get_credentials() is None:
+            raise ValueError(
+                'Unable to locate AWS credentials. '
+                'Set the METRICS_UTILITY_BUCKET_ACCESS_KEY and METRICS_UTILITY_BUCKET_SECRET_KEY '
+                'environment variables, or configure implicit credentials '
+                '(IRSA, EC2 instance profile, ~/.aws/credentials, etc.).'
+            )
+
+        self._session = session
         return self._session
 
     def get_s3_resource(self):

--- a/metrics_utility/library/storage/s3.py
+++ b/metrics_utility/library/storage/s3.py
@@ -17,6 +17,12 @@ class StorageS3:
         self.access_key = settings.get('access_key')
         self.secret_key = settings.get('secret_key')
 
+        if bool(self.access_key) != bool(self.secret_key):
+            raise ValueError(
+                'access_key and secret_key must both be provided or both be omitted'
+                ' (omit both to use implicit credentials such as IRSA or EC2 instance profiles)'
+            )
+
         if not self.bucket:
             raise Exception('StorageS3: bucket not set')
 
@@ -27,11 +33,22 @@ class StorageS3:
         if self._client is not None:
             return self._client
 
-        self._client = boto3.Session(
-            aws_access_key_id=self.access_key,
-            aws_secret_access_key=self.secret_key,
-            region_name=self.region,
-        ).client('s3', endpoint_url=self.endpoint)
+        session_kwargs = {'region_name': self.region}
+        if self.access_key and self.secret_key:
+            session_kwargs['aws_access_key_id'] = self.access_key
+            session_kwargs['aws_secret_access_key'] = self.secret_key
+
+        session = boto3.Session(**session_kwargs)
+
+        if not self.access_key and session.get_credentials() is None:
+            raise ValueError(
+                'Unable to locate AWS credentials. '
+                'Set the METRICS_UTILITY_BUCKET_ACCESS_KEY and METRICS_UTILITY_BUCKET_SECRET_KEY '
+                'environment variables, or configure implicit credentials '
+                '(IRSA, EC2 instance profile, ~/.aws/credentials, etc.).'
+            )
+
+        self._client = session.client('s3', endpoint_url=self.endpoint)
 
         return self._client
 

--- a/metrics_utility/management/validation.py
+++ b/metrics_utility/management/validation.py
@@ -102,13 +102,16 @@ def handle_s3_ship_target():
         missing += ['METRICS_UTILITY_BUCKET_NAME - name of S3 bucket']
     if not bucket_endpoint:
         missing += ['METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com']
-    if not bucket_access_key:
-        missing += ['METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key']
-    if not bucket_secret_key:
-        missing += ['METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key']
+    if bool(bucket_access_key) != bool(bucket_secret_key):
+        missing += [
+            (
+                'METRICS_UTILITY_BUCKET_ACCESS_KEY and METRICS_UTILITY_BUCKET_SECRET_KEY must both be set or both be omitted'
+                ' (omit both to use implicit credentials such as IRSA or EC2 instance profiles)'
+            )
+        ]
     if not ship_path:
         missing += [f'METRICS_UTILITY_SHIP_PATH - {ship_path_description}']
-    # bucket_region is optional
+    # bucket_region, bucket_access_key, bucket_secret_key are optional
 
     if missing:
         raise MissingRequiredEnvVar(f'Missing some required env variables for S3 configuration, namely: {", ".join(missing)}.')

--- a/metrics_utility/test/validation/test_s3_env.py
+++ b/metrics_utility/test/validation/test_s3_env.py
@@ -2,7 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
+from metrics_utility.automation_controller_billing.base.s3_handler import S3Handler
 from metrics_utility.exceptions import BadShipTarget, MissingRequiredEnvVar
+from metrics_utility.library.storage import StorageS3
 from metrics_utility.test.util import run_build_int, run_gather_int
 
 
@@ -155,14 +157,11 @@ def test_build_s3():
         },
         MissingRequiredEnvVar,
     )
-    assert (
-        e.name == 'Missing some required env variables for S3 configuration, namely: '
-        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
-        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
-        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
-        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
-        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
-    )
+    assert 'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket' in e.name
+    assert 'METRICS_UTILITY_BUCKET_ENDPOINT' in e.name
+    assert 'METRICS_UTILITY_SHIP_PATH' in e.name
+    assert 'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key' not in e.name
+    assert 'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key' not in e.name
 
     e = expect_build_error(
         {
@@ -190,6 +189,36 @@ def test_build_s3():
         MissingRequiredEnvVar,
     )
     assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+
+
+def test_build_s3_implicit_credentials():
+    """S3 without explicit credentials should pass validation (IRSA, instance profiles)."""
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert e.name == 'Missing required env variable METRICS_UTILITY_REPORT_TYPE.'
+
+
+def test_build_s3_mismatched_credentials():
+    """Setting only one of access_key/secret_key should fail."""
+    e = expect_build_error(
+        {
+            'METRICS_UTILITY_REPORT_TYPE': 'CCSPv2',
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_ACCESS_KEY': 'only-access-key',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert 'must both be set or both be omitted' in e.name
 
 
 def test_gather_s3():
@@ -199,14 +228,11 @@ def test_gather_s3():
         },
         MissingRequiredEnvVar,
     )
-    assert (
-        e.name == 'Missing some required env variables for S3 configuration, namely: '
-        'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket, '
-        'METRICS_UTILITY_BUCKET_ENDPOINT - S3 endpoint, eg. https://s3.us-east.example.com, '
-        'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key, '
-        'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key, '
-        'METRICS_UTILITY_SHIP_PATH - place for collected data and built reports.'
-    )
+    assert 'METRICS_UTILITY_BUCKET_NAME - name of S3 bucket' in e.name
+    assert 'METRICS_UTILITY_BUCKET_ENDPOINT' in e.name
+    assert 'METRICS_UTILITY_SHIP_PATH' in e.name
+    assert 'METRICS_UTILITY_BUCKET_ACCESS_KEY - S3 access key' not in e.name
+    assert 'METRICS_UTILITY_BUCKET_SECRET_KEY - S3 secret key' not in e.name
 
     run_gather_int(
         {
@@ -238,3 +264,134 @@ def test_gather_s3():
             'dry-run': True,
         },
     )
+
+
+def test_gather_s3_implicit_credentials():
+    """S3 without explicit credentials should pass validation (IRSA, instance profiles)."""
+    run_gather_int(
+        {
+            **unset,
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+        },
+        {
+            'dry-run': True,
+        },
+    )
+
+
+def test_gather_s3_mismatched_credentials():
+    """Setting only one of access_key/secret_key should fail."""
+    e = expect_gather_error(
+        {
+            'METRICS_UTILITY_SHIP_TARGET': 's3',
+            'METRICS_UTILITY_SHIP_PATH': 'wherever',
+            'METRICS_UTILITY_BUCKET_NAME': 'something',
+            'METRICS_UTILITY_BUCKET_ENDPOINT': 'https://s3.us-east.example.com',
+            'METRICS_UTILITY_BUCKET_SECRET_KEY': 'only-secret-key',
+        },
+        MissingRequiredEnvVar,
+    )
+    assert 'must both be set or both be omitted' in e.name
+
+
+@patch('metrics_utility.automation_controller_billing.base.s3_handler.boto3.Session')
+def test_s3handler_session_with_explicit_credentials(mock_session):
+    """S3Handler should pass credentials to boto3.Session when both are provided."""
+    handler = S3Handler(
+        {
+            'bucket_access_key': 'AKIA_TEST',
+            'bucket_secret_key': 'secret123',
+            'bucket_region': 'us-east-1',
+        }
+    )
+    _ = handler.session
+    mock_session.assert_called_once_with(
+        region_name='us-east-1',
+        aws_access_key_id='AKIA_TEST',
+        aws_secret_access_key='secret123',
+    )
+
+
+@patch('metrics_utility.automation_controller_billing.base.s3_handler.boto3.Session')
+def test_s3handler_session_with_implicit_credentials(mock_session):
+    """S3Handler should not pass credentials to boto3.Session when both are absent."""
+    handler = S3Handler(
+        {
+            'bucket_region': 'us-west-2',
+        }
+    )
+    _ = handler.session
+    mock_session.assert_called_once_with(region_name='us-west-2')
+
+
+@patch('metrics_utility.library.storage.s3.boto3.Session')
+def test_storage_s3_client_with_explicit_credentials(mock_session):
+    """StorageS3 should pass credentials to boto3.Session when both are provided."""
+    storage = StorageS3(
+        bucket='test-bucket',
+        endpoint='https://s3.example.com',
+        region='eu-west-1',
+        access_key='AKIA_TEST',
+        secret_key='secret123',
+    )
+    _ = storage.client
+    mock_session.assert_called_once_with(
+        region_name='eu-west-1',
+        aws_access_key_id='AKIA_TEST',
+        aws_secret_access_key='secret123',
+    )
+
+
+@patch('metrics_utility.library.storage.s3.boto3.Session')
+def test_storage_s3_client_with_implicit_credentials(mock_session):
+    """StorageS3 should not pass credentials to boto3.Session when both are absent."""
+    storage = StorageS3(
+        bucket='test-bucket',
+        endpoint='https://s3.example.com',
+        region='ap-southeast-2',
+    )
+    _ = storage.client
+    mock_session.assert_called_once_with(region_name='ap-southeast-2')
+
+
+def test_s3handler_rejects_mismatched_credentials():
+    """S3Handler should reject a one-sided credential pair at construction time."""
+    with pytest.raises(ValueError, match='must both be provided or both be omitted'):
+        S3Handler({'bucket_access_key': 'AKIA_TEST'})
+
+    with pytest.raises(ValueError, match='must both be provided or both be omitted'):
+        S3Handler({'bucket_secret_key': 'secret123'})
+
+
+def test_storage_s3_rejects_mismatched_credentials():
+    """StorageS3 should reject a one-sided credential pair at construction time."""
+    with pytest.raises(ValueError, match='must both be provided or both be omitted'):
+        StorageS3(bucket='test-bucket', access_key='AKIA_TEST')
+
+    with pytest.raises(ValueError, match='must both be provided or both be omitted'):
+        StorageS3(bucket='test-bucket', secret_key='secret123')
+
+
+@patch('metrics_utility.automation_controller_billing.base.s3_handler.boto3.Session')
+def test_s3handler_implicit_credentials_not_found(mock_session_cls):
+    """S3Handler should raise a clear error mentioning env vars when implicit credentials are absent."""
+    mock_session = mock_session_cls.return_value
+    mock_session.get_credentials.return_value = None
+
+    handler = S3Handler({'bucket_region': 'us-east-1'})
+    with pytest.raises(ValueError, match=r'METRICS_UTILITY_BUCKET_ACCESS_KEY.*METRICS_UTILITY_BUCKET_SECRET_KEY'):
+        _ = handler.session
+
+
+@patch('metrics_utility.library.storage.s3.boto3.Session')
+def test_storage_s3_implicit_credentials_not_found(mock_session_cls):
+    """StorageS3 should raise a clear error mentioning env vars when implicit credentials are absent."""
+    mock_session = mock_session_cls.return_value
+    mock_session.get_credentials.return_value = None
+
+    storage = StorageS3(bucket='test-bucket', endpoint='https://s3.example.com', region='us-east-1')
+    with pytest.raises(ValueError, match=r'METRICS_UTILITY_BUCKET_ACCESS_KEY.*METRICS_UTILITY_BUCKET_SECRET_KEY'):
+        _ = storage.client

--- a/metrics_utility/test/validation/test_validation.py
+++ b/metrics_utility/test/validation/test_validation.py
@@ -6,6 +6,7 @@ from metrics_utility.exceptions import MissingRequiredEnvVar
 from metrics_utility.management.validation import (
     handle_directory_ship_target,
     handle_env_validation,
+    handle_s3_ship_target,
     validate_ccsp_report_sheets,
     validate_collectors,
     validate_max_gather_period_days,
@@ -341,3 +342,43 @@ def test_report_type_ignored_in_gather(monkeypatch):
     monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', 'whatever')
     # Only "controller_db" is allowed for "RENEWAL_GUIDANCE" .. but only in build_report
     handle_env_validation('gather')
+
+
+def test_handle_s3_ship_target_implicit_credentials(monkeypatch):
+    """Omitting both access_key and secret_key should succeed (implicit credential chain)."""
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/tmp')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_NAME', 'my-bucket')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_ENDPOINT', 'https://s3.example.com')
+    monkeypatch.delenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', raising=False)
+    monkeypatch.delenv('METRICS_UTILITY_BUCKET_SECRET_KEY', raising=False)
+
+    result = handle_s3_ship_target()
+    assert result['bucket_name'] == 'my-bucket'
+    assert result['bucket_access_key'] is None
+    assert result['bucket_secret_key'] is None
+
+
+def test_handle_s3_ship_target_explicit_credentials(monkeypatch):
+    """Providing both access_key and secret_key should succeed."""
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/tmp')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_NAME', 'my-bucket')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_ENDPOINT', 'https://s3.example.com')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', 'AKIA_TEST')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_SECRET_KEY', 'secret123')
+
+    result = handle_s3_ship_target()
+    assert result['bucket_access_key'] == 'AKIA_TEST'
+    assert result['bucket_secret_key'] == 'secret123'
+
+
+def test_handle_s3_ship_target_mismatched_credentials(monkeypatch):
+    """Providing only access_key without secret_key should fail."""
+    monkeypatch.setenv('METRICS_UTILITY_SHIP_PATH', '/tmp')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_NAME', 'my-bucket')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_ENDPOINT', 'https://s3.example.com')
+    monkeypatch.setenv('METRICS_UTILITY_BUCKET_ACCESS_KEY', 'AKIA_TEST')
+    monkeypatch.delenv('METRICS_UTILITY_BUCKET_SECRET_KEY', raising=False)
+
+    with pytest.raises(MissingRequiredEnvVar) as excinfo:
+        handle_s3_ship_target()
+    assert 'must both be set or both be omitted' in str(excinfo.value)


### PR DESCRIPTION
[AAP-88628]

Backport for https://github.com/ansible/metrics-utility/pull/547.


### Code Quality

- [x] Code is properly linted and formatted.
- [x] All tests (existing and new) pass successfully.


