### PR TITLE
Relax setuptools runtime pin to >=80.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "psycopg==3.3.4",
     "requests==2.34.2",
     "segment-analytics-python>=2.3.6",
-    "setuptools==80.9.0",
+    "setuptools>=80.9.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -762,7 +762,7 @@ requires-dist = [
     { name = "psycopg", specifier = "==3.3.4" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "segment-analytics-python", specifier = ">=2.3.6" },
-    { name = "setuptools", specifier = "==80.9.0" },
+    { name = "setuptools", specifier = ">=80.9.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
`metrics-utility` pins `setuptools==80.9.0` as an exact runtime dependency in `pyproject.toml`. This collides with `django==5.2.17` (already a dependency here): Django 5.2.17's `[build-system]` requires `setuptools>=83`.

In hermetic/offline consumers that build Django from source — e.g. `ansible-automation-platform/automation-metrics-service-container` — the prefetch cache must include `setuptools>=83` for Django's wheel build. But the exact `==80.9.0` runtime pin then fails to resolve at the final `pip install --no-index` step:

```
ERROR: Could not find a version that satisfies the requirement setuptools==80.9.0 (from metrics-utility) (from versions: 71.1.0, 80.3.1, 81.0.0, 84.0.0)
ERROR: No matching distribution found for setuptools==80.9.0
```

## Change
Relax `setuptools==80.9.0` → `setuptools>=80.9.0`. This keeps the known-good floor while allowing the newer setuptools (84.0.0) that current Django requires. No functional change.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.