### PR TITLE
Loosen runtime dependency pins to compatible-release ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
       monthly-batch:
         patterns:
           - '*'
+    # Never propose major version bumps for Python deps. Runtime pins are
+    # compatible-release (~=) ranges and major upgrades are deliberate,
+    # human-driven changes (e.g. Django LTS bumps must stay in sync with
+    # metrics-service, which pins the same major).
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'gomod'
     directories:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,16 @@ name = "metrics-utility"
 dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
-    "boto3==1.35.96",
+    "boto3~=1.35",
     "cryptography>=44.0.1",
-    "botocore==1.35.96",
-    "distro==1.9.0",
-    "django==5.2.17",
+    "botocore~=1.35",
+    "distro~=1.9",
+    "django~=5.2",
     "kubernetes>=33.1.0",
-    "openpyxl~=3.1.5",
+    "openpyxl~=3.1",
     "pandas~=3.0",
-    "psycopg==3.3.4",
-    "requests==2.34.2",
+    "psycopg~=3.3",
+    "requests~=2.32",
     "segment-analytics-python>=2.3.6",
     "setuptools>=80.9.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -751,16 +751,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "==1.35.96" },
-    { name = "botocore", specifier = "==1.35.96" },
+    { name = "boto3", specifier = "~=1.35" },
+    { name = "botocore", specifier = "~=1.35" },
     { name = "cryptography", specifier = ">=44.0.1" },
-    { name = "distro", specifier = "==1.9.0" },
-    { name = "django", specifier = "==5.2.17" },
+    { name = "distro", specifier = "~=1.9" },
+    { name = "django", specifier = "~=5.2" },
     { name = "kubernetes", specifier = ">=33.1.0" },
-    { name = "openpyxl", specifier = "~=3.1.5" },
+    { name = "openpyxl", specifier = "~=3.1" },
     { name = "pandas", specifier = "~=3.0" },
-    { name = "psycopg", specifier = "==3.3.4" },
-    { name = "requests", specifier = "==2.34.2" },
+    { name = "psycopg", specifier = "~=3.3" },
+    { name = "requests", specifier = "~=2.32" },
     { name = "segment-analytics-python", specifier = ">=2.3.6" },
     { name = "setuptools", specifier = ">=80.9.0" },
 ]


### PR DESCRIPTION
## Summary

`metrics-utility` is bundled beneath `metrics-service` and pulled into the
`automation-metrics-service-container` build as a git submodule, where its
`pyproject.toml` is fed to `uv pip compile` alongside `metrics-service` and
`django-ansible-base`. Hard `==` pins on shared deps constrained that combined
resolution and risked forcing overrides/constraints downstream.

This converts the exact pins on shared deps to compatible-release (`~=major.minor`)
ranges so minor/patch upgrades flow through while major bumps stay capped, letting
`metrics-service`/DAB drive the resolved versions:

| Before | After |
|---|---|
| `boto3==1.35.96`, `botocore==1.35.96` | `~=1.35` |
| `distro==1.9.0` | `~=1.9` |
| `django==5.2.17` | `~=5.2` (stays on 5.2 LTS, blocks 6.x) |
| `psycopg==3.3.4` | `~=3.3` (stops fighting downstream `psycopg[c]`) |
| `requests==2.34.2` | `~=2.32` |
| `openpyxl~=3.1.5` | `~=3.1` |

`kubernetes` stays `>=33.1.0` — the downstream container resolves `kubernetes==35.0.0`
above that floor, and a `~=33.1` cap would break it.

## Notes

- `uv.lock` regenerated; **all resolved versions are unchanged** (only the specifier
  metadata differs), so standalone installs remain reproducible.
- Reproducibility for the standalone/service use case is unaffected because `uv.lock`
  still pins exact versions.

## Testing

- `uv lock` resolves cleanly; `uv run ruff check` passes.
- Test suite has pre-existing failures (Prometheus integration tests requiring a live
  mock server, plus a rollup snapshot test) that reproduce identically on `devel`;
  since resolved versions are unchanged, this change cannot affect test outcomes.

## AI Assistance

This change was developed with assistance from Claude Code (Claude Opus 4.8).
All generated code was reviewed, tested, and validated before merging.