### PR TITLE
[stable-0.7] Loosen runtime dependency pins to compatible-release ranges (backport #552)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ name = "metrics-utility"
 dynamic = ["version"] # from setup.cfg
 description = "A metrics utility for Ansible"
 dependencies = [
-    "boto3==1.35.96",
-    "botocore==1.35.96",
-    "distro==1.9.0",
-    "django==5.2.17",
+    "boto3~=1.35",
+    "botocore~=1.35",
+    "distro~=1.9",
+    "django~=5.2",
     "kubernetes>=33.1.0",
-    "openpyxl~=3.1.5",
+    "openpyxl~=3.1",
     "pandas~=3.0",
-    "psycopg==3.3.0",
-    "requests==2.32.5",
+    "psycopg~=3.3",
+    "requests~=2.32",
     "segment-analytics-python>=2.3.6",
     "setuptools>=80.9.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -335,15 +335,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "==1.35.96" },
-    { name = "botocore", specifier = "==1.35.96" },
-    { name = "distro", specifier = "==1.9.0" },
-    { name = "django", specifier = "==5.2.17" },
+    { name = "boto3", specifier = "~=1.35" },
+    { name = "botocore", specifier = "~=1.35" },
+    { name = "distro", specifier = "~=1.9" },
+    { name = "django", specifier = "~=5.2" },
     { name = "kubernetes", specifier = ">=33.1.0" },
-    { name = "openpyxl", specifier = "~=3.1.5" },
+    { name = "openpyxl", specifier = "~=3.1" },
     { name = "pandas", specifier = "~=3.0" },
-    { name = "psycopg", specifier = "==3.3.0" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "psycopg", specifier = "~=3.3" },
+    { name = "requests", specifier = "~=2.32" },
     { name = "segment-analytics-python", specifier = ">=2.3.6" },
     { name = "setuptools", specifier = ">=80.9.0" },
 ]


### PR DESCRIPTION
## Summary
Backport of #552 to `stable-0.7`.

`metrics-utility` is bundled beneath `metrics-service` and pulled into the `automation-metrics-service-container` build as a git submodule, where its `pyproject.toml` is fed to `uv pip compile` alongside `metrics-service` and `django-ansible-base`. Hard `==` pins on shared deps constrain that combined resolution and risk forcing overrides/constraints downstream.

This converts exact pins on shared deps to compatible-release (`~=major.minor`) ranges so minor/patch upgrades flow through while major bumps stay capped, letting `metrics-service`/DAB drive the resolved versions.

## Changes
| Before | After |
|---|---|
| `boto3==1.35.96`, `botocore==1.35.96` | `~=1.35` |
| `distro==1.9.0` | `~=1.9` |
| `django==5.2.17` | `~=5.2` (stays on 5.2 LTS, blocks 6.x) |
| `psycopg==3.3.0` | `~=3.3` (stops fighting downstream `psycopg[c]`) |
| `requests==2.32.5` | `~=2.32` |
| `openpyxl~=3.1.5` | `~=3.1` |

`kubernetes` stays `>=33.1.0` — downstream resolves `35.x` above that floor.

Also adds Dependabot ignore rule for semver-major bumps on the `uv` ecosystem, so major upgrades (e.g. Django 5.2 → 6.x) must be deliberate, human-driven changes kept in sync with metrics-service.

## Notes
- `uv.lock` specifiers updated; **resolved package versions unchanged** (only metadata differs).
- Standalone installs remain reproducible.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Haiku 4.5).
All generated code was reviewed, tested, and validated before merging.