### PR TITLE
Content usage - fix FQCN role regex for 4+ segment names

### DIFF
--- a/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
+++ b/metrics_utility/automation_controller_billing/dataframe_engine/dataframe_content_usage.py
@@ -97,7 +97,7 @@ class DataframeContentUsage(Base):
         Returns:
             Regex pattern string.
         """
-        return r'^(\w+)\.(\w+)\.((\w+)(\.|$))+'
+        return r'^(\w+)\.(\w+)\.(\w+)(?:\.\w+)*$'
 
     @staticmethod
     def standalone_role_regexp():

--- a/metrics_utility/test/test_dataframe_content_usage.py
+++ b/metrics_utility/test/test_dataframe_content_usage.py
@@ -52,10 +52,10 @@ class TestExtractRoleName:
         result = DataframeContentUsage.extract_role_name('community.general.git_config')
         assert result == 'community.general.git_config'
 
-    def test_four_part_fqcn_uses_last_segment(self):
-        """For a.b.c.d the regex captures the last repeated segment (d)."""
+    def test_four_part_fqcn_uses_role_segment(self):
+        """For a.b.c.d the role is the third segment (c), not the trailing one."""
         result = DataframeContentUsage.extract_role_name('ansible.builtin.copy.something')
-        assert result == 'ansible.builtin.something'
+        assert result == 'ansible.builtin.copy'
 
     def test_three_part_fqcn_correct(self):
         result = DataframeContentUsage.extract_role_name('ansible.builtin.copy')
@@ -79,6 +79,15 @@ class TestExtractRoleName:
     def test_redhat_namespace_role(self):
         result = DataframeContentUsage.extract_role_name('redhat.rhel_system_roles.selinux')
         assert result == 'redhat.rhel_system_roles.selinux'
+
+    def test_deeply_nested_fqcn_uses_role_segment(self):
+        """Extra trailing segments are ignored; the role stays the third segment."""
+        result = DataframeContentUsage.extract_role_name('a.b.c.d.e')
+        assert result == 'a.b.c'
+
+    def test_trailing_junk_returns_none(self):
+        """A malformed FQCN with non-word trailing junk no longer matches."""
+        assert DataframeContentUsage.extract_role_name('ansible.builtin.copy.more extra') is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
(Related to #540, saving fixes applied to unused library code and applying back to original code.)

Backports the reDOS-safe FQCN regex from #342 ("Added changes due to the Snyk Security Scan") to the CLI content-usage code.

## What

`DataframeContentUsage.collection_regexp()` used a nested-quantifier pattern:

```python
r'^(\w+)\.(\w+)\.((\w+)(\.|$))+'
```

This is replaced with the linear pattern from #342:

```python
r'^(\w+)\.(\w+)\.(\w+)(?:\.\w+)*$'
```

## Why it wasn't already fixed

#342 was a Snyk security fix that rewrote this exact regex, but it only touched the (since-removed) `library/` copy of the code — the duplicated CLI copy in `dataframe_engine/dataframe_content_usage.py` was never patched, so the vulnerable/buggy pattern is still live here.

## Why it matters

Two independent reasons:

1. **reDOS**: `((\w+)(\.|$))+` has nested quantifiers (catastrophic backtracking) — the pattern Snyk flagged. The replacement is linear.
2. **Correctness**: for a 4+ segment FQCN the old regex captured the *last* repeated segment as the role. `ansible.builtin.copy.something` yielded role `ansible.builtin.something` instead of the correct `ansible.builtin.copy` (`groups()[2]` was the trailing segment, not the third).

## Scope

- Affects the `main_jobevent` content-usage rollup in the **CCSP** and **CCSPv2** reports only (`role_name` column). RENEWAL_GUIDANCE is unaffected.
- **Collection** extraction (first two segments) is unchanged — both regexes agree there.
- Behavior change to flag: a malformed role string with trailing non-word junk (e.g. `ns.coll.role.more extra`) previously produced a bogus partial; it now falls back to `"No role used"`. This is more correct, but it is a visible output change if such dirty data exists.

Updates `test_four_part_fqcn_uses_last_segment` (which pinned the buggy behavior) to assert the correct third segment, and adds coverage for deeper nesting and the trailing-junk case.
