### PR TITLE
CI - fix SonarCloud reporting 0% new-code coverage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,9 @@ on:
     branches: ['devel']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -111,16 +111,24 @@ jobs:
           name: coverage-report
           path: coverage.xml
 
-      - name: "Save off PR number"
+      - name: "Save off PR number and analysed commit"
         if: github.event_name == 'pull_request'
-        run: echo "PR ${{ github.event.pull_request.number }}" > pr_number.txt
+        # HEAD here is the commit coverage.xml was generated against (on a
+        # pull_request event actions/checkout checks out the fake merge commit).
+        # sonar_checks.yml must analyse this exact commit, otherwise coverage
+        # line numbers won't match the source and the whole report is dropped.
+        run: |
+          echo "PR ${{ github.event.pull_request.number }}" > pr_number.txt
+          git rev-parse HEAD > coverage_sha.txt
 
-      - name: "Upload PR number"
+      - name: "Upload PR number and analysed commit"
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
-          path: pr_number.txt
+          path: |
+            pr_number.txt
+            coverage_sha.txt
 
       - name: "Send code coverage report to Sonar Cloud (on push)"
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -64,12 +64,22 @@ jobs:
           echo "PR_BASE=$PR_BASE" >> $GITHUB_ENV
           echo "PR_HEAD=$PR_HEAD" >> $GITHUB_ENV
 
-      - name: Checkout Code for PR
+      - name: Checkout the commit coverage was generated against
+        # Analyse the exact commit pytest measured coverage against (the fake
+        # merge commit, on a pull_request event). gh pr checkout would give the
+        # PR head instead; if devel has since changed a file's length, the
+        # coverage line numbers fall out of range and SonarCloud drops the
+        # ENTIRE coverage report -> new-code coverage wrongly reads 0%.
+        # Note: the merge commit is ephemeral - if devel moves before this job
+        # runs (e.g. a manual re-run much later), GitHub may have GC'd it and
+        # the fetch fails loudly. That is preferable to the silent 0% above.
         run: |
-          gh pr checkout "$PR_NUMBER"
+          COVERAGE_SHA=$(cat pr-artifact/coverage_sha.txt)
+          echo "Analysing coverage commit $COVERAGE_SHA"
+          git fetch origin "$COVERAGE_SHA"
+          git checkout "$COVERAGE_SHA"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -7,7 +7,10 @@ on:
     types:
       - completed
 
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
## Why

SonarCloud has been reporting **0% coverage on new-code lines** for PRs (e.g. #536), even though pytest measures those lines as fully covered and the `coverage.xml` artifact is correct.
(But only once devel has moved on from the shared commit.)

Root cause is a commit mismatch between the two workflows:

- `pytest.yml` runs on the `pull_request` event, so `actions/checkout` gives it the **fake merge commit** (PR merged with the current tip of devel). `coverage.xml` line numbers are relative to *that* tree.
- `sonar_checks.yml` runs on `workflow_run` and did `gh pr checkout`, analysing the **PR head** instead.

When devel changes a file's line count after the PR branched, the merge tree and the head tree disagree on that file's length. `coverage.xml` then references a line beyond the end of the file as Sonar sees it, e.g.:

```
Cannot read coverage report ... 'Line 124 is out of range in the file
.../s3_handler.py (lines: 122)'
```

The Cobertura sensor treats that as fatal and **discards the entire coverage report** - so *every* new-code line shows up as 0% covered, not just the file that grew.

## What

Make Sonar analyse the exact commit coverage was measured against:

- `pytest.yml` records `git rev-parse HEAD` (the merge commit) into `coverage_sha.txt` and uploads it alongside `pr_number.txt`.
- `sonar_checks.yml` fetches and checks out that SHA instead of `gh pr checkout`-ing the head.

`sonar.scm.revision` stays pinned to `workflow_run.head_sha` so GitHub PR decoration still points at the head commit.

## Trade-off

This keeps tests running **merged with devel** (so integration breakage is still caught) at the cost of relying on the merge commit still being fetchable. That commit is ephemeral - if devel moves before this job runs (e.g. a much-later manual re-run) GitHub may have GC'd it and the fetch fails *loudly*. That is strictly better than the current *silent* 0%.