### PR TITLE
AAP-89203 | feat: indirect nodes in `Usage by Collections`

### DIFF
--- a/metrics_utility/automation_controller_billing/report/base.py
+++ b/metrics_utility/automation_controller_billing/report/base.py
@@ -5,11 +5,14 @@
 ######################################
 import json
 
+import pandas as pd
+
 from openpyxl.styles import Alignment, Font
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 
 from metrics_utility.automation_controller_billing.dataframe_engine.base import merge_sets
+from metrics_utility.automation_controller_billing.dataframe_engine.dataframe_content_usage import DataframeContentUsage
 from metrics_utility.automation_controller_billing.helpers import merge_arrays, merge_json_sets
 from metrics_utility.metric_utils import INDIRECT
 
@@ -460,9 +463,77 @@ class Base:
 
         return current_row + row_counter
 
-    def _build_data_section_usage_by_collections(self, current_row, ws, dataframe):
+    # Columns used to merge direct and indirect collection usage into one frame
+    COLLECTIONS_LONG_COLUMNS = ['collection_name', 'host_name', 'host_composite_id', 'task_runs', 'duration']
+
+    def _build_indirect_collections_long(self, indirects):
+        """Normalize indirect managed node rows into per-collection "long" rows.
+
+        Each indirect job-host-summary row carries an ``events`` list of
+        fully-qualified content names (e.g. ``["cisco.ios.ios_command"]``). We
+        explode that list into one row per collection so indirect host counts
+        merge naturally with the direct content-usage frame in the
+        'Usage by collections' sheet.
+
+        Note: an indirect row's ``task_runs`` is attributed to every collection
+        in its ``events`` list (the audit data does not break task counts down
+        per collection). This is imprecise for task counts but preserves the
+        host counts, which is what this sheet is primarily about. Indirect rows
+        have no duration, so ``duration`` is set to 0.
+
+        Args:
+            indirects: DataFrame of INDIRECT job-host-summary rows, or None.
+
+        Returns:
+            A DataFrame with :attr:`COLLECTIONS_LONG_COLUMNS`, or None when
+            there is no indirect collection data to add.
+        """
+        if indirects is None or indirects.empty:
+            return None
+
+        records = []
+        for row in indirects.itertuples(index=False):
+            events = getattr(row, 'events', None)
+            if not events:
+                continue
+
+            collection_names = set()
+            for fqcn in events:
+                collection_name = DataframeContentUsage.extract_collection_name(fqcn)
+                if collection_name is not None:
+                    collection_names.add(collection_name)
+
+            if not collection_names:
+                continue
+
+            host_composite_id = f'{row.host_name}__{row.install_uuid}__{row.job_remote_id}'
+            for collection_name in collection_names:
+                records.append(
+                    {
+                        'collection_name': collection_name,
+                        'host_name': row.host_name,
+                        'host_composite_id': host_composite_id,
+                        'task_runs': row.task_runs,
+                        'duration': 0,
+                    }
+                )
+
+        if not records:
+            return None
+
+        return pd.DataFrame.from_records(records, columns=self.COLLECTIONS_LONG_COLUMNS)
+
+    def _build_data_section_usage_by_collections(self, current_row, ws, dataframe, indirects=None):
         header_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX, bold=True)
         value_font = Font(name=self.FONT, size=10, color=self.BLACK_COLOR_HEX)
+
+        # Merge indirect managed node usage into the direct content-usage frame so
+        # collection-level host counts include indirect nodes. No-op when there is
+        # no indirect data (default None), preserving the direct-only behavior.
+        indirect_long = self._build_indirect_collections_long(indirects)
+        if indirect_long is not None:
+            direct_long = dataframe[self.COLLECTIONS_LONG_COLUMNS]
+            dataframe = pd.concat([direct_long, indirect_long], ignore_index=True)
 
         # Take the content explorer dataframe and extract specific group by
         agg_dict = {

--- a/metrics_utility/automation_controller_billing/report/report_ccsp.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp.py
@@ -139,7 +139,10 @@ class ReportCCSP(Base):
             if 'usage_by_collections' in self.optional_report_sheets():
                 # Sheet with usage by collections
                 ws = self.add_sheet('Usage by collections', sheet_index, self.config['data_column_widths'])
-                self._build_data_section_usage_by_collections(1, ws, events_dataframe)
+                # Include indirect managed nodes only when indirect reporting is enabled,
+                # matching the 'Usage by organizations' sheet behavior.
+                collections_indirects = indirects if 'indirectly_managed_nodes' in self.optional_report_sheets() else None
+                self._build_data_section_usage_by_collections(1, ws, events_dataframe, indirects=collections_indirects)
                 sheet_index += 1
 
             if 'usage_by_roles' in self.optional_report_sheets():

--- a/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
+++ b/metrics_utility/automation_controller_billing/report/report_ccsp_v2.py
@@ -173,7 +173,10 @@ class ReportCCSPv2(Base):
             if 'usage_by_collections' in self.optional_report_sheets():
                 # Sheet with usage by collections
                 ws = self.add_sheet('Usage by collections', sheet_index, self.config['data_column_widths'])
-                self._build_data_section_usage_by_collections(1, ws, events_dataframe)
+                # Include indirect managed nodes only when indirect reporting is enabled,
+                # matching the 'Usage by organizations' sheet behavior.
+                collections_indirects = indirects if 'indirectly_managed_nodes' in self.optional_report_sheets() else None
+                self._build_data_section_usage_by_collections(1, ws, events_dataframe, indirects=collections_indirects)
                 sheet_index += 1
 
             if 'usage_by_roles' in self.optional_report_sheets():

--- a/metrics_utility/test/test_report_base.py
+++ b/metrics_utility/test/test_report_base.py
@@ -612,6 +612,29 @@ def _collections_df():
     )
 
 
+def _indirects_df(**extra):
+    # events is the merged, already-parsed list of fully-qualified content names per row
+    data = {
+        'host_name': ['h1', 'ind_h2'],
+        'install_uuid': ['u1', 'u1'],
+        'job_remote_id': ['j9', 'j10'],
+        'task_runs': [4, 6],
+        'events': [['col.a.some_module'], ['col.c.other_module', 'col.a.another_module']],
+    }
+    data.update(extra)
+    return pd.DataFrame(data)
+
+
+def _sheet_rows(ws, ncols):
+    """Read a built worksheet into a list of row tuples, until the first empty first-column cell."""
+    rows = []
+    r_idx = 1
+    while ws.cell(row=r_idx, column=1).value is not None:
+        rows.append(tuple(ws.cell(row=r_idx, column=c).value for c in range(1, ncols + 1)))
+        r_idx += 1
+    return rows
+
+
 class TestBuildDataSectionUsageByCollections:
     def test_returns_advanced_row_number(self):
         r = _report()
@@ -631,6 +654,75 @@ class TestBuildDataSectionUsageByCollections:
         r._build_data_section_usage_by_collections(1, ws, _collections_df())
         headers = [ws.cell(row=1, column=c).value for c in range(1, 6)]
         assert 'Collection name' in headers
+
+    def test_indirect_none_matches_direct_only(self):
+        r_direct = _report()
+        ws_direct = _make_ws(r_direct)
+        r_direct._build_data_section_usage_by_collections(1, ws_direct, _collections_df())
+
+        r_none = _report()
+        ws_none = _make_ws(r_none)
+        r_none._build_data_section_usage_by_collections(1, ws_none, _collections_df(), indirects=None)
+
+        assert _sheet_rows(ws_direct, 5) == _sheet_rows(ws_none, 5)
+
+    def test_indirect_empty_adds_no_collections(self):
+        r = _report()
+        ws = _make_ws(r)
+        r._build_data_section_usage_by_collections(1, ws, _collections_df(), indirects=_indirects_df().iloc[0:0])
+        collection_names = {row[0] for row in _sheet_rows(ws, 5)[1:]}
+        assert collection_names == {'col.a', 'col.b'}
+
+    def test_indirect_merges_and_adds_collections(self):
+        r = _report()
+        ws = _make_ws(r)
+        r._build_data_section_usage_by_collections(1, ws, _collections_df(), indirects=_indirects_df())
+
+        by_collection = {row[0]: row for row in _sheet_rows(ws, 5)[1:]}
+
+        # col.a gains indirect h1 (same name, new composite id) and ind_h2: unique host
+        # names {h1, h3, ind_h2}=3, non-unique composite ids=4, task_runs 10+8+4+6=28
+        assert by_collection['col.a'] == ('col.a', 3, 4, 28, 180.0)
+        assert by_collection['col.b'] == ('col.b', 1, 1, 5, 50.0)
+        # col.c is indirect-only (ind_h2), no duration recorded for indirect
+        assert by_collection['col.c'] == ('col.c', 1, 1, 6, 0.0)
+
+
+class TestBuildIndirectCollectionsLong:
+    def test_returns_none_when_indirects_none(self):
+        assert _report()._build_indirect_collections_long(None) is None
+
+    def test_returns_none_when_indirects_empty(self):
+        assert _report()._build_indirect_collections_long(_indirects_df().iloc[0:0]) is None
+
+    def test_returns_none_when_no_events_resolve_to_collections(self):
+        df = _indirects_df(events=[['not_a_fqcn'], []])
+        assert _report()._build_indirect_collections_long(df) is None
+
+    def test_returns_none_when_events_empty(self):
+        df = _indirects_df(events=[[], None])
+        assert _report()._build_indirect_collections_long(df) is None
+
+    def test_explodes_events_into_one_row_per_collection(self):
+        result = _report()._build_indirect_collections_long(_indirects_df())
+        # h1 -> col.a ; ind_h2 -> col.c, col.a
+        assert len(result) == 3
+        assert set(result['collection_name']) == {'col.a', 'col.c'}
+
+    def test_computes_composite_id_and_zero_duration(self):
+        df = _indirects_df(events=[['col.a.mod'], []])
+        result = _report()._build_indirect_collections_long(df)
+        assert list(result['host_composite_id']) == ['h1__u1__j9']
+        assert list(result['duration']) == [0]
+
+    def test_task_runs_attributed_to_each_collection_in_row(self):
+        df = _indirects_df(host_name=['ind_h2'], install_uuid=['u1'], job_remote_id=['j10'], task_runs=[6], events=[['col.a.m1', 'col.c.m2']])
+        result = _report()._build_indirect_collections_long(df)
+        assert sorted(zip(result['collection_name'], result['task_runs'])) == [('col.a', 6), ('col.c', 6)]
+
+    def test_output_columns_match_long_schema(self):
+        result = _report()._build_indirect_collections_long(_indirects_df())
+        assert list(result.columns) == Base.COLLECTIONS_LONG_COLUMNS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Assisted-by: Claude Code (claude-opus-4-8)

[AAP-89203]

> [!WARNING]
> **Failure to notify downstream stakeholders (such as the Analytics team) of schema or version changes can result in outages and loss of revenue.**
>
> Please notify stakeholders to disseminate the change correctly, most notably the **Analytics HCC service**.
> A critical ticket to track the change prior to promotion.
> The change should not be merged until dependencies have been updated.

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?

Includes Indirect Node data in the `Usage by Collections` report sheet (CCSPv2)

- Why is this change needed?

Since indirect node gathering is being GA'd for v2.7 of AAP, we should include indirect node data in the `Usage by Collections` sheet to give the user a summary of the metrics on indirect nodes, alongside other collections

- How does this change address the issue?

Introduces a function in `automation_controller_billing/report/base.py` which creates the string to include in the `Usage by Collections` sheet. Then, adds to the CCSPv2 report only when the `indirectly_managed_nodes` optional sheet is enabled. Finally it introduces tests for the new additions

With the GA of this feature, another PR will be covering enabling `indirectly_managed_nodes` by default. This PR purely adds indirect node data to `Usage by Collections`

## Required Actions

<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->

- [X] Requires documentation updates
<!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
<!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
<!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
<!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
<!-- Reference blocking PRs/MRs with brief context -->

## Self-Review Checklist

<!-- These items help ensure quality - they complement our automated CI checks -->

### Code Quality

- [X] Code is properly linted and formatted.
- [X] All tests (existing and new) pass successfully.
- [X] Tests are added or updated as needed.
- [X] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.  
       - If updates are required in the [handbook](https://github.com/ansible/handbook), create a separate PR for the handbook repo.

## Notes for Reviewers

I am still testing this, but the core of the requirements from the jira ticket are in this PR. Keeping as draft for now

[AAP-89203]: https://redhat.atlassian.net/browse/AAP-89203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ