### PR TITLE
CI - only run SonarCloud scan on upstream push

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -122,9 +122,9 @@ jobs:
           name: pr_number
           path: pr_number.txt
 
-      - name: "Send code coverage report to Sonar Cloud (on push)"
+      - name: "Send code coverage report to Sonar Cloud (on upstream push)"
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
-        if: ${{ ! github.base_ref }}
+        if: ${{ ! github.base_ref && github.repository == 'ansible/metrics-utility' }}
         env:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_ORGANIZATION: ansible


### PR DESCRIPTION
The SonarCloud scan step in `pytest.yml` runs on push to `devel` (`if: ${{ ! github.base_ref }}`). The downstream mirror also pushes to `devel` but doesn't set the `CICD_ORG_SONAR_TOKEN_CICD_BOT` secret, so the scan step fails there.

Gate the step on the canonical repo (`github.repository == 'ansible/metrics-utility'`) so downstream skips it entirely instead of failing on the missing token.

Should make the tests green there too :crossed_fingers: :)