### PR TITLE
docs: add architecture guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A `metrics-utility` CLI tool for collecting and reporting metrics from Controlle
 It can run either standalone (against a specified postgres instance),
 or inside the Controller's python virtual environment. The controller mode allows the `config` collector to collect more settings and takes DB connection details from there.
 
-It provides two subcommands:
+The billing workflow provides two primary commands:
   - `gather_automation_controller_billing_data`
     - collects data from controller, saves daily tarballs with `.csv` / `.json` inside
     - saves tarballs in specified storage
@@ -29,6 +29,8 @@ It provides two subcommands:
       - 3 report types - `CCSP`, `CCSPv2`, `RENEWAL_GUIDANCE`
       - the ccsp* reports use the collected tarballs as the source
       - the renewal* report reads from controller db
+
+The `candlepin_manage` command is an auxiliary management command for Candlepin consumer registration and certificate renewal; see `python manage.py candlepin_manage --help`.
 
 Example invocation:
 
@@ -65,7 +67,7 @@ The `metrics_utility.library` library provides a lower-level python API exposing
 * extractors - extracts these tarballs, loading specific data into dicts or Pandas dataframe
 * rollups - group and aggregate dataframes, compute stats and optionally save them
 * reports - builds a xlsx report from a set of dataframes
-* storage - unified storage backend for filesystem, s3, segment, crc and db
+* storage - unified storage backend for filesystem, S3, Segment, and CRC
 * instants - associated datetime-related helpers
 * tempdir & db locking helpers
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ls out/reports/`date +%Y/%m`/ # reports/<year>/<month>/<type>-<year>-<month>.xls
 See [docs/cli.md](./docs/cli.md) and [docs/old-readme.md](./docs/old-readme.md) for details on the usage,  
 See [docs/environment.md](./docs/environment.md) for a full list of environment variables,  
 See [docs/awx.md](./docs/awx.md) for more on running against an awx dev env.
+See [docs/architecture.md](./docs/architecture.md) for the system architecture and maintainer extension points.
 
 
 ### Python library

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,204 @@
+# Metrics Utility Architecture
+
+This document describes the current architecture of `metrics-utility` for maintainers and contributors. It focuses on the data paths, boundaries, extension points, and operational contracts that are easy to miss when reading one module in isolation.
+
+## System overview
+
+`metrics-utility` has two related interfaces:
+
+- The management commands provide the end-to-end gather and report workflows.
+- The `metrics_utility.library` package exposes reusable collectors, storage, dataframe, rollup, and report primitives.
+
+The main data path is:
+
+```mermaid
+flowchart LR
+    controller[(Automation Controller DB)]
+    prometheus[(Prometheus)]
+    cli[CLI / management commands]
+    collectors[Registered collectors]
+    packages[Packages\nCSV / JSON + metadata]
+    storage[(Directory / S3 / CRC)]
+    extractors[Extractors]
+    dataframes[Dataframe engines\nrollups]
+    dedup[Deduplication]
+    reports[Report builders]
+    xlsx[XLSX report]
+
+    controller --> cli
+    prometheus --> collectors
+    cli --> collectors
+    collectors --> packages
+    packages --> storage
+    storage --> extractors
+    extractors --> dataframes
+    dataframes --> dedup
+    dedup --> reports
+    reports --> xlsx
+    storage --> reports
+```
+
+The anonymized-data path is related but has a different output contract:
+
+```mermaid
+flowchart LR
+    raw[Collected CSV / JSON] --> prepare[Rollup prepare]
+    prepare --> merge[Merge hourly or partial rollups]
+    merge --> base[Daily base rollup]
+    base --> combine[Combine rollups]
+    combine --> anonymize[Filter and anonymize]
+    anonymize --> split[Split payloads]
+    split --> segment[(Segment)]
+```
+
+## Entry points and workflows
+
+### Gathering Controller data
+
+`gather_automation_controller_billing_data` validates command options and environment variables, creates `automation_controller_billing.collector.Collector`, and selects a shipping target: `directory`, `s3`, or `crc`.
+
+The billing collector extends `base.Collector` and performs the following sequence:
+
+```mermaid
+sequenceDiagram
+    participant Command as Gather command
+    participant Collector
+    participant DB as Controller DB
+    participant Package
+    participant Target as Storage target
+
+    Command->>Collector: gather(since, until, parameters)
+    Collector->>Collector: Acquire billing advisory lock
+    Collector->>Collector: Resolve interval and load checkpoints
+    Collector->>DB: Run config, JSON, and CSV collectors
+    Collector->>Package: Add collection outputs
+    Collector->>Package: Build tar.gz artifacts
+    Package->>Target: Ship artifacts when enabled
+    Collector->>DB: Save successful last-gathered timestamps
+    Collector-->>Command: Return artifact paths
+```
+
+The base collector discovers functions in the configured collector module by looking for metadata attached by `@register`. Each function becomes a `CollectionJSON` or `CollectionCSV` object. CSV collections may be sliced into multiple sub-collections so large or partition-aware queries can be processed and shipped incrementally.
+
+Collection intervals use an inclusive `since` boundary and an exclusive `until` boundary. When no explicit start is supplied, persisted last-gathered values determine the incremental range. The maximum interval is controlled by `METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS` and defaults to 28 days.
+
+Successful scheduled or manual collection updates the Controller setting used by the upstream analytics collector. Failed collection keys prevent their checkpoint from advancing. Dry runs gather into temporary files but do not ship artifacts or persist checkpoints.
+
+### Building reports
+
+`build_report` selects the input and output implementations from `METRICS_UTILITY_SHIP_TARGET`, then runs the reporting pipeline:
+
+```mermaid
+flowchart TD
+    command[build_report command] --> validate[Validate options and environment]
+    validate --> saver[ReportSaverFactory]
+    saver --> exists{Report exists?}
+    exists -->|yes, no --force| stop[Skip]
+    exists -->|no or --force| extractor[ExtractorFactory]
+    extractor --> factory[DataframeFactory]
+    factory --> dedup[DedupFactory]
+    dedup --> report[ReportFactory]
+    report --> save[ReportSaver]
+
+    controller[(Controller DB)] --> extractor
+    archive[(Directory / S3 tarballs)] --> extractor
+    save --> output[(Directory / S3 XLSX)]
+```
+
+CCSP and CCSPv2 reports read collected tarballs. Renewal guidance reads directly from the Controller database. Extractors load raw data into named dataframe engines; those engines combine and aggregate data before the selected deduplicator and report builder run.
+
+## Collection and artifact model
+
+### Collectors
+
+Collectors should be small, parameter-driven functions. They should not read environment variables or depend on hidden global state. Time-series collectors accept timezone-aware `since` and `until` values; snapshot collectors return the current state without a time range.
+
+The primary collector groups are:
+
+- Controller collectors in `metrics_utility/library/collectors/controller/`
+- Dashboard collectors in `metrics_utility/library/collectors/dashboard/`
+- Service collectors in `metrics_utility/library/collectors/service/`
+- Other external-input collectors in `metrics_utility/library/collectors/others/`
+
+The billing workflow uses the collector module in `metrics_utility/automation_controller_billing/collectors.py`. The database tables and partition behavior of the Controller collectors are documented in [collectors-and-partitions.md](collectors-and-partitions.md).
+
+### Packages
+
+The base `Package` groups collection outputs into `.tar.gz` artifacts. A package contains:
+
+- `config.json`, including collection and billing-provider context safe to persist
+- `manifest.json`, recording collector names and versions
+- `data_collection_status.csv`, recording start, finish, and success status
+- One or more collector-produced `.csv` or `.json` files
+
+Large collections can be divided across packages. A collection that produces sub-collections is shipped immediately so temporary files can be released and duplicate filenames remain isolated.
+
+### Storage
+
+Storage adapters provide a common `put`, `get`, `exists`, `remove`, and `glob` interface where the backend supports the operation. Current implementations are:
+
+- `StorageDirectory` for local files
+- `StorageS3` for S3-compatible object storage
+- `StorageCRC` and `StorageCRCMutual` for console.redhat.com ingress
+- `StorageSegment` for put-only analytics events
+
+The billing package classes select the appropriate adapter and are responsible for shipping collection artifacts. Report saver classes perform the analogous operation for generated XLSX files. See [the library guide](../metrics_utility/library/README.md) for callable-level examples.
+
+## Dataframes, rollups, and reports
+
+The reporting implementation separates data loading from aggregation and presentation:
+
+1. An extractor obtains tarball contents or queries the Controller database.
+2. A dataframe factory creates the dataframe engines needed by the selected report.
+3. Dataframe engines accept raw CSV or JSON data and produce grouped or rollup data.
+4. A deduplicator removes or reconciles duplicate usage according to the report type.
+5. A report builder converts the resulting dataframes into the requested XLSX format.
+6. A report saver writes the XLSX to a directory or S3-compatible target.
+
+The factory modules under `metrics_utility/automation_controller_billing/` are the selection boundaries. New implementations should normally be added behind the relevant factory rather than branching through the management command.
+
+## Anonymized rollups
+
+Anonymized rollups are implemented in `metrics_utility/anonymized_rollups/`. Each rollup corresponds to a collector or data category and typically exposes `prepare`, `merge`, and `base` stages.
+
+The intended processing model is hierarchical: raw hourly data is reduced to a small serializable partial rollup, partial rollups are merged through the day, and the completed daily rollup is combined with the other categories. The final structure is flattened, sanitized, and anonymized before it is split into Segment-compatible messages.
+
+Sensitive values such as customer-specific names and identifiers must not cross the anonymization boundary. Public collection metadata is allow-listed through `collections.json`; values outside the permitted set are filtered or replaced according to the rollup implementation. See [anonymized rollups](../metrics_utility/anonymized_rollups/anonymized_rollups.md) for the collector-to-rollup mapping and detailed processing notes.
+
+## Concurrency, checkpoints, and failure behavior
+
+- Gathering uses PostgreSQL advisory locks to prevent concurrent collection runs. The billing collector uses its own lock and coordinates checkpoint persistence with the upstream analytics lock.
+- Checkpoints advance only for successfully gathered collections after shipping is complete in manual or scheduled mode.
+- Temporary staging files are created under a per-run directory and removed during cleanup.
+- A failed collection is recorded in package status and does not advance its corresponding checkpoint.
+- Shipping backends raise or report failures rather than silently treating an upload as successful.
+- Existing reports are skipped unless `--force` is supplied.
+
+These behaviors are important when adding a collector or changing a storage implementation: retrying must not create an incorrect checkpoint, and a partially successful run must remain diagnosable from its status metadata and logs.
+
+## Extension guide
+
+### Add a collector
+
+1. Add a function in the appropriate collector module.
+2. Decorate it with `@register`, including a stable key, version, and output format.
+3. Follow the collector input contract and return an empty result when there is no data.
+4. Add focused tests under `metrics_utility/test/library/` or `metrics_utility/test/gather/`.
+5. If the collector is included in anonymized analytics, add its rollup and anonymization tests as well.
+
+### Add a storage or report implementation
+
+Implement the existing adapter/report-saver contract, add the implementation to its factory, and cover both successful output and failure behavior. Keep backend-specific configuration at the factory or adapter boundary; library collector functions should remain environment-independent.
+
+### Add an anonymized rollup
+
+Add a rollup class in `metrics_utility/anonymized_rollups/`, register it in the rollup selection code, define the serializable output contract, and test both aggregation and sensitive-value handling. Update the collector-to-rollup documentation when the mapping changes.
+
+## Related documentation
+
+- [CLI usage](cli.md)
+- [Environment variables](environment.md)
+- [Collectors and database partitions](collectors-and-partitions.md)
+- [Library abstractions](../metrics_utility/library/README.md)
+- [Anonymized rollups](../metrics_utility/anonymized_rollups/anonymized_rollups.md)
+- [Contributor guide](CONTRIBUTING.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ The standalone mode is currently used only for development & testing. It does no
 
 1. Use `--help` to see any other params
   - `build_report` also supports `--ephemeral`, `--force` and `--verbose`
-  - `gather_automation_controller_billing_data` also supports `--dry-run` and `--ship`
+  - `gather_automation_controller_billing_data` also supports `--dry-run`, `--ship`, and `--verbose`
 
 1. Set any other necessary environmental variable
   - see [`docs/environment.md`](./environment.md) for a full list of the environment variables
@@ -66,7 +66,7 @@ export METRICS_UTILITY_REPORT_SKU="MCT3752MO"
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
 
 # collect data
-uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m --force
+uv run ./manage.py gather_automation_controller_billing_data --ship --until=10m
 
 # collected tarballs somewhere here (by date and instance uuid)
 ls metrics_utility/test/test_data/data/2024/04/*

--- a/docs/collectors-and-partitions.md
+++ b/docs/collectors-and-partitions.md
@@ -1,10 +1,10 @@
 # Metrics Utility Collectors: Database Tables and Partition Analysis
 
-**Last Updated**: February 2026
+**Last Updated**: August 2026
 
 ## Overview
 
-This document provides comprehensive documentation on all collectors in the metrics-utility library, including:
+This document provides detailed documentation on the Controller collectors used by the billing workflow, including:
 - Which database tables each collector queries
 - Whether tables are partitioned
 - Partition key columns and structure
@@ -31,6 +31,8 @@ The following tables in Ansible Automation Platform Controller are partitioned b
 | `main_jobevent` | `job_created` (TIMESTAMPTZ) | RANGE (hourly) | `main_jobevent_YYYYMMDD_HH` |
 
 **Note**: While other event tables (`main_adhoccommandevent`, `main_inventoryupdateevent`, `main_projectupdateevent`, `main_systemjobevent`) are also partitioned in the Controller database, **metrics-utility collectors do not currently access these tables**, so they are not documented here.
+
+The library also contains dashboard, metrics-service, and Prometheus collectors. They are outside the scope of this database-partition analysis because they use different inputs or are not part of the billing collector's registered Controller dataset.
 
 ### Partition Structure
 
@@ -202,6 +204,7 @@ WHERE (e.job_created >= '2024-12-19 17:00:00+00' AND e.job_created < '2024-12-19
   - Using literal timestamp values (not joins) in WHERE clause
   - Grouping consecutive hours into ranges
   - Filtering by both `job_created` (partition key) and `job_id`
+- It prioritizes the densest `job_created` partitions and caps selection at 1,000 jobs and 200,000 event rows by default. These limits can affect completeness for very large windows.
 
 ---
 
@@ -209,10 +212,10 @@ WHERE (e.job_created >= '2024-12-19 17:00:00+00' AND e.job_created < '2024-12-19
 
 **File**: `metrics_utility/library/collectors/controller/unified_jobs.py`
 
-**Purpose**: Collects unified job data (jobs created or finished within a time window).
+**Purpose**: Collects unified job data for jobs finished within a time window.
 
 **Tables Accessed**:
-- `main_unifiedjob` (READ) - Filtered by `created` OR `finished` timestamp
+- `main_unifiedjob` (READ) - Filtered by `finished` timestamp
 - `main_unifiedjobtemplate` (READ) - LEFT JOIN
 - `django_content_type` (READ) - LEFT JOIN for polymorphic type
 - `main_job` (READ) - LEFT JOIN
@@ -228,18 +231,17 @@ WHERE (e.job_created >= '2024-12-19 17:00:00+00' AND e.job_created < '2024-12-19
 ```sql
 SELECT main_unifiedjob.*, ...
 FROM main_unifiedjob
-WHERE (main_unifiedjob.created >= 'since' AND main_unifiedjob.created < 'until')
-   OR (main_unifiedjob.finished >= 'since' AND main_unifiedjob.finished < 'until')
-  AND main_unifiedjob.launch_type != 'sync'
+WHERE main_unifiedjob.finished >= 'since'
+  AND main_unifiedjob.finished < 'until'
 ```
 
 **Time Range Support**:
 - ✅ **Supports `since`/`until` parameters**
-- Filters by `created` OR `finished` timestamp (OR condition)
+- Filters by `finished` timestamp
 
 **Frequency**:
 - Run per collection window (typically daily)
-- Accesses jobs that were either created or finished in the time window
+- Accesses jobs that finished in the time window
 
 ---
 
@@ -490,6 +492,21 @@ ORDER BY main_hostmetric.hostname ASC, COALESCE(main_host.id, 0) ASC
 
 ---
 
+## Other registered billing collectors
+
+The billing collector also registers the following current collectors. They use non-partitioned tables and therefore do not add a partition-pruning case to this document:
+
+| Collector | Source table(s) | Time range | Role |
+|-----------|-----------------|------------|------|
+| `controller_version_service` | `main_instance` | Snapshot | Controller version metadata |
+| `credentials_service` | `main_unifiedjob_credentials`, `main_unifiedjob`, `main_credential`, `main_credentialtype` | `since` / `until` | Managed credential usage |
+| `execution_environments` | `main_executionenvironment` | Snapshot | Execution environment metadata |
+| `table_metadata` | PostgreSQL catalog tables | Snapshot | Table row and size metadata |
+
+The library-only `feature_flags_service` reads enabled flags from `dab_feature_flags_aapflag`; it is not currently registered by the billing workflow.
+
+`task_executions_service` is a metrics-service database collector rather than a Controller database collector and is outside this partition analysis.
+
 ## Partition Pruning Strategies
 
 ### How Partition Pruning Works
@@ -557,6 +574,10 @@ All collectors leverage indexes where available:
 | `main_host` | `main_host`, `main_inventory`, `main_organization`, `main_unifiedjob` | ❌ | N/A | ❌ | Daily snapshot |
 | `main_host_daily` | `main_host`, `main_inventory`, `main_organization`, `main_unifiedjob` | ❌ | N/A | ✅ | Incremental |
 | `main_indirectmanagednodeaudit` | `main_indirectmanagednodeaudit`, `main_job`, `main_unifiedjob`, `main_inventory`, `main_organization`, `main_unifiedjobtemplate` | ❌ | N/A | ✅ | Incremental |
+| `main_hostmetric` | `main_hostmetric`, `main_host` | ❌ | N/A | ✅ | Renewal guidance / incremental |
+| `controller_version_service` | `main_instance` | ❌ | N/A | ❌ | Snapshot |
+| `credentials_service` | `main_unifiedjob_credentials`, `main_unifiedjob`, `main_credential`, `main_credentialtype` | ❌ | N/A | ✅ | Incremental |
+| `table_metadata` | PostgreSQL catalog tables | ❌ | N/A | ❌ | Snapshot |
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -10,11 +10,24 @@ METRICS_UTILITY_BUCKET_ENDPOINT
 METRICS_UTILITY_BUCKET_NAME
 METRICS_UTILITY_BUCKET_REGION
 METRICS_UTILITY_BUCKET_SECRET_KEY
+METRICS_UTILITY_CANDLEPIN_CA
+METRICS_UTILITY_CANDLEPIN_CERT_DIR
+METRICS_UTILITY_CANDLEPIN_ENABLED
+METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED
+METRICS_UTILITY_CANDLEPIN_ORG
+METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED
+METRICS_UTILITY_CANDLEPIN_RENEWAL_DAYS
+METRICS_UTILITY_CANDLEPIN_STORAGE
+METRICS_UTILITY_CANDLEPIN_URL
 METRICS_UTILITY_CLUSTER_NAME
 METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX
 METRICS_UTILITY_CRC_INGRESS_URL
 METRICS_UTILITY_CRC_SSO_URL
 METRICS_UTILITY_DB_HOST
+METRICS_UTILITY_DB_NAME
+METRICS_UTILITY_DB_PASSWORD
+METRICS_UTILITY_DB_PORT
+METRICS_UTILITY_DB_USER
 METRICS_UTILITY_DEDUPLICATOR
 METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR
 METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES
@@ -40,6 +53,8 @@ METRICS_UTILITY_REPORT_RHN_LOGIN
 METRICS_UTILITY_REPORT_SKU
 METRICS_UTILITY_REPORT_SKU_DESCRIPTION
 METRICS_UTILITY_REPORT_TYPE
+METRICS_UTILITY_RH_PASSWORD
+METRICS_UTILITY_RH_USERNAME
 METRICS_UTILITY_SERVICE_ACCOUNT_ID
 METRICS_UTILITY_SERVICE_ACCOUNT_SECRET
 METRICS_UTILITY_SHIP_PATH
@@ -59,7 +74,7 @@ container
 ### Dev:
 
 * `AWX_PATH` - used to find controller virtualenv, when *not* using `mock_awx`; defaults to `/awx_devel`; runs from `metrics_utility/__init__.py` `.prepare`/`.manage`
-* `METRICS_UTILITY_DB_HOST` - host to talk to controller db when using `mock_awx`
+* `METRICS_UTILITY_DB_HOST`, `METRICS_UTILITY_DB_NAME`, `METRICS_UTILITY_DB_PASSWORD`, `METRICS_UTILITY_DB_PORT`, `METRICS_UTILITY_DB_USER` - Controller database connection settings used by the standalone/mock-AWX development environment
 
 
 ### Stored in `config.json` - `billing_provider_params`
@@ -77,6 +92,8 @@ container
 * `METRICS_UTILITY_BUCKET_REGION` - `bucket_region`
 * `METRICS_UTILITY_BUCKET_SECRET_KEY` - `bucket_secret_key`
 
+S3 access and secret keys are optional when the runtime can resolve credentials through the default boto3 credential chain (for example, IRSA or an EC2 instance profile). If one key is set, both must be set.
+
 
 ### Used by CRC
 
@@ -87,13 +104,30 @@ container
 * `METRICS_UTILITY_SERVICE_ACCOUNT_SECRET` - secret
 
 
+### Used by Candlepin certificate registration and lifecycle
+
+* `METRICS_UTILITY_CANDLEPIN_STORAGE` - certificate store backend, either `local` (default) or `db`
+* `METRICS_UTILITY_CANDLEPIN_CERT_DIR` - local certificate directory; defaults to `/var/lib/awx/candlepin-certs`
+* `METRICS_UTILITY_CANDLEPIN_ENABLED` - enables Candlepin certificate handling during CRC gathering; defaults to `false`
+* `METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED` - enables initial consumer registration; defaults to `false`
+* `METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED` - enables check-in and proactive certificate renewal during CRC gathering
+* `METRICS_UTILITY_CANDLEPIN_RENEWAL_DAYS` - renewal threshold in days; defaults to `30`
+* `METRICS_UTILITY_CANDLEPIN_URL` - Candlepin base URL; defaults to `https://subscription.rhsm.redhat.com/subscription`
+* `METRICS_UTILITY_CANDLEPIN_CA` - optional CA certificate path; otherwise RHSM CA paths or the system CA store are used
+* `METRICS_UTILITY_CANDLEPIN_ORG` - optional explicit Candlepin owner/org key; otherwise it is discovered from the subscription account
+* `METRICS_UTILITY_RH_USERNAME` / `METRICS_UTILITY_RH_PASSWORD` - subscription credentials used for registration; CLI flags override these values
+* `METRICS_UTILITY_PROXY_URL` - HTTP/HTTPS proxy used for Candlepin calls
+
+When `METRICS_UTILITY_CANDLEPIN_STORAGE=db`, registration may fall back to the Controller `conf_setting` credentials. Certificate and private-key material is not written into gathered `config.json` payloads.
+
+
 ### Only used during gather
 
 * `METRICS_UTILITY_CLUSTER_NAME` - `total_workers_vcpu` collector payload `.cluster_name` (required when that collector is enabled)
-* `METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX` - `total_workers_vcpu` collector custom lock name
+* `METRICS_UTILITY_COLLECTOR_LOCK_SUFFIX` - optional suffix for the billing collector advisory-lock name
 * `METRICS_UTILITY_DISABLE_JOB_HOST_SUMMARY_COLLECTOR` - disable `job_host_summary` collector (use together with `METRICS_UTILITY_OPTIONAL_COLLECTORS`)
 * `METRICS_UTILITY_DISABLE_SAVE_LAST_GATHERED_ENTRIES` - skip updating last gather info from controller settings
-* `METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS` - maximum lenght of collection interval in days, default 28; `get_max_gather_period_days`
+* `METRICS_UTILITY_MAX_GATHER_PERIOD_DAYS` - maximum length of a collection interval in days, default 28; see `get_max_gather_period_days`
 * `METRICS_UTILITY_OPTIONAL_COLLECTORS` - optional collectors, comma-separated list
 * `METRICS_UTILITY_PROMETHEUS_URL` - Prometheus base url
 * `METRICS_UTILITY_USAGE_BASED_METERING_ENABLED` - `total_workers_vcpu` collector toggle - skips kubernetes when disabled (=false, default)
@@ -133,7 +167,7 @@ container
 ### Both build & gather
 
 * `METRICS_UTILITY_SHIP_PATH` - directory in local path or s3
-* `METRICS_UTILITY_SHIP_TARGET` - one of `directory`, `s3`, `controller_db` (build), `crc` (gather)
+* `METRICS_UTILITY_SHIP_TARGET` - one of `directory`, `s3`, or `crc` for gathering; `controller_db` is additionally supported when building renewal-guidance reports
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -99,7 +99,7 @@ S3 access and secret keys are optional when the runtime can resolve credentials 
 
 * `METRICS_UTILITY_CRC_INGRESS_URL` - upload url
 * `METRICS_UTILITY_CRC_SSO_URL` - login url
-* `METRICS_UTILITY_PROXY_URL` - upload proxy
+* `METRICS_UTILITY_PROXY_URL` - HTTP/HTTPS proxy for CRC uploads and Candlepin calls
 * `METRICS_UTILITY_SERVICE_ACCOUNT_ID` - account id
 * `METRICS_UTILITY_SERVICE_ACCOUNT_SECRET` - secret
 
@@ -110,13 +110,12 @@ S3 access and secret keys are optional when the runtime can resolve credentials 
 * `METRICS_UTILITY_CANDLEPIN_CERT_DIR` - local certificate directory; defaults to `/var/lib/awx/candlepin-certs`
 * `METRICS_UTILITY_CANDLEPIN_ENABLED` - enables Candlepin certificate handling during CRC gathering; defaults to `false`
 * `METRICS_UTILITY_CANDLEPIN_REGISTRATION_ENABLED` - enables initial consumer registration; defaults to `false`
-* `METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED` - enables check-in and proactive certificate renewal during CRC gathering
+* `METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED` - enables check-in and proactive certificate renewal during CRC gathering; defaults to `false`
 * `METRICS_UTILITY_CANDLEPIN_RENEWAL_DAYS` - renewal threshold in days; defaults to `30`
 * `METRICS_UTILITY_CANDLEPIN_URL` - Candlepin base URL; defaults to `https://subscription.rhsm.redhat.com/subscription`
 * `METRICS_UTILITY_CANDLEPIN_CA` - optional CA certificate path; otherwise RHSM CA paths or the system CA store are used
 * `METRICS_UTILITY_CANDLEPIN_ORG` - optional explicit Candlepin owner/org key; otherwise it is discovered from the subscription account
 * `METRICS_UTILITY_RH_USERNAME` / `METRICS_UTILITY_RH_PASSWORD` - subscription credentials used for registration; CLI flags override these values
-* `METRICS_UTILITY_PROXY_URL` - HTTP/HTTPS proxy used for Candlepin calls
 
 When `METRICS_UTILITY_CANDLEPIN_STORAGE=db`, registration may fall back to the Controller `conf_setting` credentials. Certificate and private-key material is not written into gathered `config.json` payloads.
 

--- a/docs/old-readme.md
+++ b/docs/old-readme.md
@@ -1,4 +1,6 @@
-# AAP metrics-utility
+# AAP metrics-utility (legacy)
+
+> This page contains historical pre-0.5 examples. For current installation, CLI, environment, and architecture documentation, start with the [README](../README.md), [CLI guide](cli.md), and [environment reference](environment.md). Current command flags and defaults take precedence over examples on this page.
 
 The AAP metrics utility tool is a standalone CLI utility called `metrics-utility` which is intended to be installed to
 the system containing instance of the [Automation Controller](https://www.ansible.com/products/controller).

--- a/metrics_utility/library/README.md
+++ b/metrics_utility/library/README.md
@@ -39,6 +39,8 @@ Controller collectors (in `metrics_utility.library.collectors.controller`):
 * `main_jobevent_service(db, since, until).gather() -> DataFrame`
 * `unified_jobs(db, since, until).gather() -> DataFrame`
 
+Additional library collectors are available for dashboard data, filter options, metrics-service task execution data, Controller credentials, feature flags, Controller versions, table metadata, and worker vCPU data. The billing CLI registers only the collectors listed in its own `automation_controller_billing/collectors.py` module; check each collector's module docstring for its input database and time-window contract.
+
 Other collectors (in `metrics_utility.library.collectors.others`):
 * `total_workers_vcpu(cluster_name, metering_enabled, prometheus_url, ca_cert_path, token) -> Dict`
 
@@ -74,7 +76,7 @@ Such tarball can then be passed to a Storage class, and gets cleaned up afterwar
 Storage objects serve to provide a shared interface for various storage modes. Each can be initialized with an appropriate configuration, and can retrieve or save objects from/to long-term storage.
 
 Mainly S3 and local directories are supported,
-but the Storage mechanism can also be used to push the data to cloud APIs or to save it in a local DB.
+but the Storage mechanism can also be used to push the data to cloud APIs. Database-backed report inputs use the extractor/report layers rather than a generic database Storage adapter.
 
 Common API:
 


### PR DESCRIPTION
## Summary

- Add an end-to-end architecture guide with Mermaid diagrams
- Refresh the README, CLI, environment, library, partition-analysis, and legacy documentation
- Document Candlepin registration/lifecycle settings and implicit S3 credentials
- Correct unsupported gather flags and stale collector descriptions
- Tighten environment docs: document `METRICS_UTILITY_CANDLEPIN_LIFECYCLE_ENABLED` default and consolidate `METRICS_UTILITY_PROXY_URL` description

## Validation

- Direct command help checks passed for gather, build, and Candlepin management commands
- `git diff --check` passed
- Repository-relative documentation targets verified
- `uv run` could not run because the existing `uv.lock` is malformed at line 722; direct `.venv/bin/python` checks succeeded