### PR TITLE
Add push-triggered downstream repo sync workflow

### DIFF
--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -1,0 +1,73 @@
+# Push-triggered sync from ansible/metrics-utility to ansible-automation-platform/metrics-utility.
+# Supplements the hourly scheduled sync in ansible-automation-platform/cicd-ops.
+#
+# Prerequisites (org-level):
+#   - Org secret:   ANSIBLE_CICD_BOT_ORG_RW_TOKEN_PRIVATE_KEY
+#   - Org variable: ANSIBLE_CICD_BOT_ORG_RW_TOKEN_APP_ID
+#   - GitHub App installed on ansible-automation-platform
+
+name: "Repo Sync to a foreign GitHub org"
+
+on:
+  push:
+    branches:
+      - devel
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SOURCE_ORG: "ansible"
+  TARGET_ORG: "ansible-automation-platform"
+  TARGET_REPO: ${{ github.event.repository.name }}
+
+jobs:
+  sync:
+    name: "Sync → ${{ github.event.repository.name }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.ANSIBLE_CICD_BOT_ORG_RW_TOKEN_APP_ID }}
+          private-key: ${{ secrets.ANSIBLE_CICD_BOT_ORG_RW_TOKEN_PRIVATE_KEY }}
+          owner: ${{ env.TARGET_ORG }}
+          repositories: ${{ env.TARGET_REPO }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: "Sync repository"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_REPO: ${{ github.event.repository.name }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          echo "▶ Cloning ${SOURCE_ORG}/${SOURCE_REPO} (branch: ${BRANCH})"
+          git clone --single-branch --branch "${BRANCH}" \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${SOURCE_ORG}/${SOURCE_REPO}.git"
+          cd "${SOURCE_REPO}"
+          echo "▶ Pushing ${BRANCH} to ${TARGET_ORG}/${TARGET_REPO}"
+          git push "https://x-access-token:${TARGET_GITHUB_TOKEN}@github.com/${TARGET_ORG}/${TARGET_REPO}.git" "HEAD:${BRANCH}"
+          echo "✔ Mirrored ${SOURCE_ORG}/${SOURCE_REPO}:${BRANCH} to ${TARGET_ORG}/${TARGET_REPO}:${BRANCH}"
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf "${{ github.event.repository.name }}"


### PR DESCRIPTION
## Description

- What is being changed?
  - Adds `.github/workflows/repo-sync.yaml` to sync `devel` to `ansible-automation-platform/metrics-utility` on every push.
- Why is this change needed?
  - Downstream currently relies on the hourly scheduled sync in `ansible-automation-platform/cicd-ops`. A push-triggered workflow gives immediate mirroring after merges to `devel`.
- How does this change address the issue?
  - Uses the org-standard caller template from [`ansible/ansible-cicd`](https://github.com/ansible/ansible-cicd/blob/main/.github/workflows/i-want-it-now.yaml) with the `ANSIBLE_CICD_BOT_ORG_RW_TOKEN_*` org credentials already enabled for this repo.

## Testing

### Prerequisites
- Org secret `ANSIBLE_CICD_BOT_ORG_RW_TOKEN_PRIVATE_KEY` and org variable `ANSIBLE_CICD_BOT_ORG_RW_TOKEN_APP_ID` must be available to this repo (already granted by GitHub admins).

### Steps to Test
1. Merge this PR to `devel`.
2. Open [Actions](https://github.com/ansible/metrics-utility/actions) and confirm the "Repo Sync to a foreign GitHub org" workflow runs on the merge commit.
3. Verify the workflow completes successfully.
4. Confirm `ansible-automation-platform/metrics-utility` `devel` matches the upstream commit SHA.

### Expected Results
- Workflow runs automatically on push to `devel` and fast-forward pushes to downstream `devel`.
- No schema, API, or version changes are introduced by this PR.

## Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [x] Requires infrastructure/deployment changes
  - Adds GitHub Actions workflow only; no deployment changes required.
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

## Self-Review Checklist

### Code Quality

- [x] Code is properly linted and formatted.
- [ ] All tests (existing and new) pass successfully.
- [ ] Tests are added or updated as needed.
- [x] Code includes relevant comments for complex sections.
- [ ] Changes are reviewed and approved by at least two team members.
- [ ] Documentation is updated where applicable.