### PR TITLE
update AWX schema dump (b980d60)

### DIFF
--- a/tools/docker/latest.sql
+++ b/tools/docker/latest.sql
@@ -2072,9 +2072,7 @@ CREATE TABLE public.main_host (
     variables text NOT NULL,
     created_by_id integer,
     inventory_id integer NOT NULL,
-    last_job_host_summary_id integer,
     modified_by_id integer,
-    last_job_id integer,
     ansible_facts jsonb NOT NULL,
     ansible_facts_modified timestamp with time zone
 );
@@ -7595,18 +7593,6 @@ CREATE INDEX main_host_inventory_sources_host_id_03f0dcdc ON public.main_host_in
 CREATE INDEX main_host_inventory_sources_inventorysource_id_b25d3959 ON public.main_host_inventory_sources USING btree (inventorysource_id);
 
 --
--- Name: main_host_last_job_host_summary_id_b8bd727d; Type: INDEX; Schema: public; Owner: awx
---
-
-CREATE INDEX main_host_last_job_host_summary_id_b8bd727d ON public.main_host USING btree (last_job_host_summary_id);
-
---
--- Name: main_host_last_job_id_d247075b; Type: INDEX; Schema: public; Owner: awx
---
-
-CREATE INDEX main_host_last_job_id_d247075b ON public.main_host USING btree (last_job_id);
-
---
 -- Name: main_host_modified_by_id_28b76283; Type: INDEX; Schema: public; Owner: awx
 --
 
@@ -10310,20 +10296,6 @@ ALTER TABLE ONLY public.main_host
 
 ALTER TABLE ONLY public.main_host_inventory_sources
     ADD CONSTRAINT main_host_inventory_sources_host_id_03f0dcdc_fk_main_host_id FOREIGN KEY (host_id) REFERENCES public.main_host(id) DEFERRABLE INITIALLY DEFERRED;
-
---
--- Name: main_host main_host_last_job_host_summar_b8bd727d_fk_main_jobh; Type: FK CONSTRAINT; Schema: public; Owner: awx
---
-
-ALTER TABLE ONLY public.main_host
-    ADD CONSTRAINT main_host_last_job_host_summar_b8bd727d_fk_main_jobh FOREIGN KEY (last_job_host_summary_id) REFERENCES public.main_jobhostsummary(id) DEFERRABLE INITIALLY DEFERRED;
-
---
--- Name: main_host main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id; Type: FK CONSTRAINT; Schema: public; Owner: awx
---
-
-ALTER TABLE ONLY public.main_host
-    ADD CONSTRAINT main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id FOREIGN KEY (last_job_id) REFERENCES public.main_job(unifiedjob_ptr_id) DEFERRABLE INITIALLY DEFERRED;
 
 --
 -- Name: main_host main_host_modified_by_id_28b76283_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: awx


### PR DESCRIPTION
Latest AWX schema dump .. might or may not have AAP-90281 implications.. does .. :boom: 

if so...

> AWX main_host schema change to adapt to: the last_job_id and last_job_host_summary_id columns are dropped in AWX devel/2.7 ([ansible/awx#16529](https://github.com/ansible/awx/pull/16529)), completing the earlier deprecation ([ansible/awx#16332](https://github.com/ansible/awx/pull/16332)). Any collector still reading main_host.last_job_id (e.g. for a last-automation date) will break and must switch to deriving the latest job from main_jobhostsummary (join on host_id, take the latest row, read job_id).

...fixed in #567 