### PR TITLE
AAP-90281 - fix: support AWX 0210 host schema changes

### DIFF
--- a/docs/collectors-and-partitions.md
+++ b/docs/collectors-and-partitions.md
@@ -367,7 +367,8 @@ SELECT version FROM main_instance WHERE enabled = true AND version IS NOT NULL O
 - `main_host` (READ) - Filtered by `enabled='t'`
 - `main_inventory` (READ) - LEFT JOIN
 - `main_organization` (READ) - LEFT JOIN
-- `main_unifiedjob` (READ) - LEFT JOIN for `last_job_id`
+- `main_jobhostsummary` (READ) - LEFT JOIN LATERAL for the latest summary per host
+- `main_unifiedjob` (READ) - LEFT JOIN through the latest job host summary
 
 **Partition Information**:
 - ❌ **Not partitioned** (all tables are non-partitioned)
@@ -376,6 +377,11 @@ SELECT version FROM main_instance WHERE enabled = true AND version IS NOT NULL O
 ```sql
 SELECT main_host.*, main_inventory.*, main_organization.*, ...
 FROM main_host
+LEFT JOIN LATERAL (
+  SELECT job_id FROM main_jobhostsummary
+  WHERE main_jobhostsummary.host_id = main_host.id
+  ORDER BY main_jobhostsummary.id DESC LIMIT 1
+) latest_summary ON TRUE
 WHERE enabled='t'
 ```
 
@@ -398,7 +404,8 @@ WHERE enabled='t'
 - `main_host` (READ) - Filtered by `created` OR `modified` timestamp
 - `main_inventory` (READ) - LEFT JOIN
 - `main_organization` (READ) - LEFT JOIN
-- `main_unifiedjob` (READ) - LEFT JOIN
+- `main_jobhostsummary` (READ) - LEFT JOIN LATERAL for the latest summary per host
+- `main_unifiedjob` (READ) - LEFT JOIN through the latest job host summary
 
 **Partition Information**:
 - ❌ **Not partitioned** (all tables are non-partitioned)
@@ -407,6 +414,11 @@ WHERE enabled='t'
 ```sql
 SELECT main_host.*, ...
 FROM main_host
+LEFT JOIN LATERAL (
+  SELECT job_id FROM main_jobhostsummary
+  WHERE main_jobhostsummary.host_id = main_host.id
+  ORDER BY main_jobhostsummary.id DESC LIMIT 1
+) latest_summary ON TRUE
 WHERE enabled='t'
   AND (main_host.created >= 'since' AND main_host.created < 'until'
     OR main_host.modified >= 'since' AND main_host.modified < 'until')

--- a/metrics_utility/library/collectors/controller/main_host.py
+++ b/metrics_utility/library/collectors/controller/main_host.py
@@ -90,7 +90,14 @@ def _main_host_query(where):
         FROM main_host
         LEFT JOIN main_inventory ON main_inventory.id = main_host.inventory_id
         LEFT JOIN main_organization ON main_organization.id = main_inventory.organization_id
-        LEFT JOIN main_unifiedjob ON main_unifiedjob.id = main_host.last_job_id
+        LEFT JOIN LATERAL (
+            SELECT main_jobhostsummary.job_id
+            FROM main_jobhostsummary
+            WHERE main_jobhostsummary.host_id = main_host.id
+            ORDER BY main_jobhostsummary.id DESC
+            LIMIT 1
+        ) AS latest_job_host_summary ON TRUE
+        LEFT JOIN main_unifiedjob ON main_unifiedjob.id = latest_job_host_summary.job_id
         WHERE {where}
         ORDER BY main_host.id ASC
     """

--- a/metrics_utility/test/library/test_collectors_main_host.py
+++ b/metrics_utility/test/library/test_collectors_main_host.py
@@ -1,8 +1,10 @@
+import datetime
+
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from metrics_utility.library.collectors.controller.main_host import main_host
+from metrics_utility.library.collectors.controller.main_host import main_host, main_host_daily
 
 
 def test_main_host_basic():
@@ -49,7 +51,12 @@ def test_main_host_query_structure(mock_copy_pandas):
     assert 'main_host' in query
     assert 'main_inventory' in query
     assert 'main_organization' in query
+    assert 'main_jobhostsummary' in query
     assert 'main_unifiedjob' in query
+    assert 'main_host.last_job_id' not in query
+    assert 'main_host.last_job_host_summary_id' not in query
+    assert 'ORDER BY main_jobhostsummary.id DESC' in query
+    assert 'LIMIT 1' in query
 
     # Should have canonical_facts and facts columns
     assert 'canonical_facts' in query
@@ -88,3 +95,21 @@ def test_main_host_uses_yaml_json_functions(mock_copy_pandas):
     # Should use helper functions for parsing YAML/JSON
     assert 'metrics_utility_is_valid_json' in query
     assert 'metrics_utility_parse_yaml_field' in query
+
+
+@patch('metrics_utility.library.collectors.util._copy_table_pandas')
+def test_main_host_daily_uses_latest_summary_query(mock_copy_pandas):
+    """The incremental collector uses the same post-0210-compatible lookup."""
+    mock_copy_pandas.return_value = pd.DataFrame()
+
+    main_host_daily(
+        db=MagicMock(),
+        since=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        until=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+    ).gather()
+
+    query = mock_copy_pandas.call_args[0][1]
+    assert 'main_jobhostsummary.host_id = main_host.id' in query
+    assert 'main_unifiedjob.id = latest_job_host_summary.job_id' in query
+    assert 'main_host.last_job_id' not in query
+    assert 'main_host.last_job_host_summary_id' not in query

--- a/tools/docker/latest.sql
+++ b/tools/docker/latest.sql
@@ -2072,9 +2072,7 @@ CREATE TABLE public.main_host (
     variables text NOT NULL,
     created_by_id integer,
     inventory_id integer NOT NULL,
-    last_job_host_summary_id integer,
     modified_by_id integer,
-    last_job_id integer,
     ansible_facts jsonb NOT NULL,
     ansible_facts_modified timestamp with time zone
 );
@@ -7595,18 +7593,6 @@ CREATE INDEX main_host_inventory_sources_host_id_03f0dcdc ON public.main_host_in
 CREATE INDEX main_host_inventory_sources_inventorysource_id_b25d3959 ON public.main_host_inventory_sources USING btree (inventorysource_id);
 
 --
--- Name: main_host_last_job_host_summary_id_b8bd727d; Type: INDEX; Schema: public; Owner: awx
---
-
-CREATE INDEX main_host_last_job_host_summary_id_b8bd727d ON public.main_host USING btree (last_job_host_summary_id);
-
---
--- Name: main_host_last_job_id_d247075b; Type: INDEX; Schema: public; Owner: awx
---
-
-CREATE INDEX main_host_last_job_id_d247075b ON public.main_host USING btree (last_job_id);
-
---
 -- Name: main_host_modified_by_id_28b76283; Type: INDEX; Schema: public; Owner: awx
 --
 
@@ -10310,20 +10296,6 @@ ALTER TABLE ONLY public.main_host
 
 ALTER TABLE ONLY public.main_host_inventory_sources
     ADD CONSTRAINT main_host_inventory_sources_host_id_03f0dcdc_fk_main_host_id FOREIGN KEY (host_id) REFERENCES public.main_host(id) DEFERRABLE INITIALLY DEFERRED;
-
---
--- Name: main_host main_host_last_job_host_summar_b8bd727d_fk_main_jobh; Type: FK CONSTRAINT; Schema: public; Owner: awx
---
-
-ALTER TABLE ONLY public.main_host
-    ADD CONSTRAINT main_host_last_job_host_summar_b8bd727d_fk_main_jobh FOREIGN KEY (last_job_host_summary_id) REFERENCES public.main_jobhostsummary(id) DEFERRABLE INITIALLY DEFERRED;
-
---
--- Name: main_host main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id; Type: FK CONSTRAINT; Schema: public; Owner: awx
---
-
-ALTER TABLE ONLY public.main_host
-    ADD CONSTRAINT main_host_last_job_id_d247075b_fk_main_job_unifiedjob_ptr_id FOREIGN KEY (last_job_id) REFERENCES public.main_job(unifiedjob_ptr_id) DEFERRABLE INITIALLY DEFERRED;
 
 --
 -- Name: main_host main_host_modified_by_id_28b76283_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: awx


### PR DESCRIPTION
## Description

Fixes AAP-90281. Update `main_host` and `main_host_daily` to derive `last_automation` from the latest `main_jobhostsummary` row per host, removing dependencies on deprecated `main_host.last_job_id` and `last_job_host_summary_id` columns.

## Testing

- Focused collector tests: 6 passed
- Ruff check and format: passed
- Full suite: 1,576 passed; remaining failures/errors require unavailable integration services and fixtures (PostgreSQL, SeaweedFS, Prometheus).

## Required Actions

- AWX 0210+ schema fixture updated.
- No downstream schema contract changes are expected beyond the collector query dependency update.